### PR TITLE
Increased endowment so example code runs

### DIFF
--- a/docs/api-contract/start/blueprint.md
+++ b/docs/api-contract/start/blueprint.md
@@ -27,7 +27,7 @@ We either have a `Blueprint` from a code deploy of a manual create. From here we
 
 ```javascript
 // Deploy a contract using the Blueprint
-const endowment = 12300000000n;
+const endowment = 1230000000000n;
 
 // NOTE The apps UI specifies these in Mgas
 const gasLimit = 100000n * 1000000n;


### PR DESCRIPTION
The endowment in the code example isn't large enough to successfully deploy the contract and run the subsequent example queries/transactions on it.