### PR TITLE
Change order of params to match example

### DIFF
--- a/docs/util-crypto/examples/verify-signature.md
+++ b/docs/util-crypto/examples/verify-signature.md
@@ -8,7 +8,7 @@ This function will return true if a message passed as parameter has been signed 
 const { decodeAddress, signatureVerify } = require('@polkadot/util-crypto');
 const { u8aToHex } = require('@polkadot/util');
 
-const isValidSignature = (signedMessage, address, signature) => {
+const isValidSignature = (signedMessage, signature, address) => {
   const publicKey = decodeAddress(address);
   const hexPublicKey = u8aToHex(publicKey);
 


### PR DESCRIPTION
Appears the signature and address variable were being imported out of order