### PR TITLE
Add Utterance Comments

### DIFF
--- a/src/components/comments/index.js
+++ b/src/components/comments/index.js
@@ -1,0 +1,30 @@
+import React, { useEffect } from 'react';
+import useThemeContext from '@theme/hooks/useThemeContext';
+import styles from "./styles.module.css";
+import "./styles.css";
+
+function Comments(props) {
+	const { isDarkTheme } = useThemeContext();
+	const theme = isDarkTheme ? "github-dark" : "github-light";
+
+	useEffect(() => {
+		const script = document.createElement('script');
+
+		script.src = "https://utteranc.es/client.js";
+		script.setAttribute('repo', "polkadot-js/docs");
+		script.setAttribute('issue-term', "pathname");
+		script.setAttribute('label', "comment");
+		script.setAttribute('theme', theme);
+		script.crossOrigin = "anonymous";
+		script.async = true;
+
+		document.getElementById("comment-container").appendChild(script);
+	}, []);
+
+
+	return (
+		<div id="comment-container" className={'container ' + styles.commentWrapper}></div>
+	);
+}
+
+export default Comments;

--- a/src/components/comments/styles.css
+++ b/src/components/comments/styles.css
@@ -1,0 +1,16 @@
+.utterances {
+	margin: 0;
+}
+
+@media only screen and (min-width: 997px) {
+  .utterances {
+    max-width: 75% !important;
+  }
+}
+
+@media only screen and (max-width: 996px) {
+  .utterances {
+	margin-left: auto;
+	margin-right: auto;
+  }
+}

--- a/src/components/comments/styles.module.css
+++ b/src/components/comments/styles.module.css
@@ -1,0 +1,7 @@
+@media (min-width: 997px) and (max-width: 1320px) {
+  .commentWrapper {
+    max-width: calc(
+      var(--ifm-container-width) - 300px - var(--ifm-spacing-horizontal) * 2
+    );
+  }
+}

--- a/src/theme/DocItem/index.js
+++ b/src/theme/DocItem/index.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import OriginalDocItem from "@theme-original/DocItem";
-import Comment from "../../components/Comments"
+import Comment from "../../components/comments"
 
 export default function CustomDocItem(props) {
 	return (

--- a/src/theme/DocItem/index.js
+++ b/src/theme/DocItem/index.js
@@ -1,0 +1,14 @@
+// Add utterances comments at the bottom of custom `DocItem` theme.
+
+import React from 'react';
+import OriginalDocItem from "@theme-original/DocItem";
+import Comment from "../../components/Comments"
+
+export default function CustomDocItem(props) {
+	return (
+		<>
+			<OriginalDocItem {...props} />
+			<Comment {...props} />
+		</>
+	);
+}


### PR DESCRIPTION
@jacogr you might hate this, you might love this, but this is something I have set up for some of my Docusaurus 2 projects.

https://utteranc.es/

Basically this PR integrates Utterances into your documentation so every page has its own comment section. New comments are placed into a github issue with the appropriate title which identifies which page it is for. As users post on github or in your comments, they will be shared on both sides.

Looks like this:

<img width="1669" alt="image" src="https://user-images.githubusercontent.com/1860335/100562654-2f3aad80-3271-11eb-82fc-f09cb12f521c.png">

<img width="1545" alt="image" src="https://user-images.githubusercontent.com/1860335/100562691-47aac800-3271-11eb-8482-6c950854fe56.png">

<img width="603" alt="image" src="https://user-images.githubusercontent.com/1860335/100562679-4083ba00-3271-11eb-8b6e-86d5fd3c258d.png">

