### PR TITLE
Improve rpc docs

### DIFF
--- a/docs/api/start/rpc.custom.md
+++ b/docs/api/start/rpc.custom.md
@@ -1,13 +1,12 @@
----
+
 title: Custom RPC
 ---
 
-In previous sections we looked at the injection of types, as in use and defined in modules from the node. Another area that can be customized is RPC definitions, and like with the types, the API provides the capability to add user-defined RPCs (in addition to the Polkadot/Substrate base) to allow use of these RPCs via the API.
-
+In the previous section we looked at how to override the types the node uses and how to define extra custom types. You can also define custom RPC methods and we will cover that here.
 
 ## Custom definitions
 
-RPCs are exposed as a method on a specific module, this means that once available you can call any rpc via the `api.rpc.<module>.<method>(...params[])` endpoints. As an example, you can define a `firstModule_testMethod` on the Rust node and once injected it will be callable via `api.rpc.firstModule.testMethod(...`). To extend with user-defined RPCs, the injection can happen at the time of API creation with the addition of the `rpc` key (in addition to any other params, such as `types` or `provider`) -
+RPCs are exposed as a method on a specific module. This means that once available: you can call any rpc via `api.rpc.<module>.<method>(...params[])`. For example, you can define a `firstModule_testMethod` on the Rust node and if correctly defined it will be callable via `api.rpc.firstModule.testMethod(...`). To supply custom RPC methods, you provide an `rpc` object on the options to the API.
 
 ```js
 ...
@@ -39,14 +38,14 @@ const api = await ApiPromise.create({
 });
 ```
 
-In the above example we have defined a new method, which is now available on the RPCs as `api.rpc.firstModule.testMethod(index: u64, at?: Hash) => Promise<Balance>`. In the case of optional params, we have added the `isOptional: true` flag alongside the `name` & `type` in the param definition.
+In the above example we have defined a new method, which is now available on the API as `api.rpc.firstModule.testMethod(index: u64, at?: Hash) => Promise<Balance>`. For the optional parameters, we added `isOptional: true` alongside the `name` & `type` in the parameter definition.
 
-Be aware that while defined, the method will only appear on the API if it is in the list as returned by `api.rpc.rpc.methods()`, which is the list of known RPCs the node exposes. When making changes to the node, always ensure that it does expose the RPC method correctly, otherwise it will not be decorated. Additionally ensure that any method, as defined on the Rust side, consists of a `<module>` and `<method>` part, so `foo_bar` would be valid as a name (and can be defined above), while a standalone `bar` would not be, won't be detecte and cannot be decorated. When unsure, always follow the same approach as done in Substrate master.
+Even if you define the method it will only appear on the API if it appears in the list returned by `api.rpc.rpc.methods()`, which is the list of known RPCs the node exposes. So when making changes to the node you should double-check that it does announce the RPC method and that it conforms to the format `<module>_<method>`.  For example `foo_bar` is a valid name whereas `bar` is not. I.E. Methods which do not contain both a `module` and `method` component won't be detected and cannot be decorated. If in doubt, follow the conventions in Substrate master.
 
 
-## Definition breakdown
+## RPC options in detail
 
-While the above example should be self-explanatory, it is important to understand the structure. The `rpc: { ... }` definitions are keyed first and foremost by the name of the module exposing the RPC. This means that when we have 2 modules `firstModule` & `testModule`, the first-level structure would follow the following pattern,
+While the above example should be self-explanatory, let's quickly walk through the structure. Under the `rpc: { ... }` key in the options, keys are the name of the module exposing the RPC. So given 2 modules `firstModule` & `testModule`, and the top-level structure would be as follows:
 
 ```js
 ...
@@ -58,9 +57,9 @@ const api = await ApiPromise.create({
 });
 ```
 
-Inside the specific module definitions, the key is the actual expose RPC method. As we have seen in the first example, we expose a `testMethod` on `firstModule`. For the method definitions, apart from the description, we have definitions for the params and return a single result `type`.
+Inside each module definition, the key is the name of the RPC method. In the example, we defined a `testMethod` on `firstModule`. A method definition should provide a `description` of the method, an array of type definitions for the parameters named `params`, and define the `type` of the result of the RPC call.
 
-Params itself, as an array, contains fields for `name`, `type` and an optional flag `isOptional` that indicates that the field is not required when making the call. (And example of this use would be in cases such as `state.getStorage(key, blockHash?)` where the last param is optional)
+`params` is an array of type definitions. In the example, contains fields for `name`, `type` and an optional flag `isOptional` that indicates that the field is not required when making the call. (And example of this use would be in cases such as `state.getStorage(key, blockHash?)` where the last param is optional)
 
 
 ## Type creation


### PR DESCRIPTION
Use more natural English and remove redundant repetition in the RPC docs.