### PR TITLE
Adding specifics to the Intro API

### DIFF
--- a/docs/api/start/intro.md
+++ b/docs/api/start/intro.md
@@ -24,7 +24,7 @@ const { ApiPromise, WsProvider } = require('@polkadot/api');
 ...
 ```
 
-While Node.js as of later versions supports the `import` syntax, we are only exporting CommonJS modules, hence the need for require.
+While Node.js versions `>=12` support the `import` syntax, we are only exporting CommonJS modules, hence the need for require.
 
 
 ## What this is not


### PR DESCRIPTION
Adding in the specific version of Node.js that starts supporting `import` statements to further clarify.  On v10.x, Node programs throw an error due to the module using `import` statements.

```
$ nvm use v10.24.0
Now using node v10.24.0 (npm v6.14.11)

asavage@antonios-MacBook-Pro:~/tony/web3sandbox/polkadot (master) [kube <> ]
$ node main.js
/Users/tony/web3sandbox/node_modules/@polkadot/api/index.js:3
import "./detectPackage.js";
       ^^^^^^^^^^^^^^^^^^^^
```