### PR TITLE
Add a note regarding fees for batch transactions.

### DIFF
--- a/docs/api/cookbook/tx.md
+++ b/docs/api/cookbook/tx.md
@@ -162,7 +162,7 @@ api.tx.utility
   });
 ```
 
-The fee for a batch transaction can be estimated similar to the fee for a single transaction using the exposed `.paymentInfo` helper method that is described earlier, and it is usually less than the sum of the fees for each included transaction, if they would run individually.
+The fee for a batch transaction can be estimated similar to the fee for a single transaction using the exposed `.paymentInfo` helper method that was described earlier, and it is usually less than the sum of the fees for each individual transaction.
 
 ## How do I take the pending tx pool into account in my nonce?
 

--- a/docs/api/cookbook/tx.md
+++ b/docs/api/cookbook/tx.md
@@ -162,6 +162,7 @@ api.tx.utility
   });
 ```
 
+The fee for a batch transaction can be estimated similar to the fee for a single transaction using the exposed `.paymentInfo` helper method that is described earlier, and it is usually less than the sum of the fees for each included transaction, if they would run individually.
 
 ## How do I take the pending tx pool into account in my nonce?
 


### PR DESCRIPTION
I needed to estimate the transaction fees for a batch transaction and initially somehow thought I need to estimate the fee as the sum of the fees for each separate tx. Later I noticed the paymentInfo is also supported on utility.batch, and in fact the fee for a batch is less than the sum of the individual fees:)
Not sure if it is only me or it might happen to others as well, so just adding a note to mention it in the docs in case it is helpful. Feel free to rephrase or ignore if it is not relevant.