### PR TITLE
Update verify-signature.md

### DIFF
--- a/docs/util-crypto/examples/verify-signature.md
+++ b/docs/util-crypto/examples/verify-signature.md
@@ -6,13 +6,13 @@ This function will return true if a message passed as parameter has been signed 
 
 ```javascript
 const { cryptoWaitReady, decodeAddress, signatureVerify } = require('@polkadot/util-crypto');
-const { u8aToHex, u8aWrapBytes } = require('@polkadot/util');
+const { u8aToHex } = require('@polkadot/util');
 
 const isValidSignature = (signedMessage, signature, address) => {
   const publicKey = decodeAddress(address);
   const hexPublicKey = u8aToHex(publicKey);
 
-  return signatureVerify(u8aWrapBytes(signedMessage), signature, hexPublicKey).isValid;
+  return signatureVerify(signedMessage, signature, hexPublicKey).isValid;
 };
 
 const main = async () => {

--- a/docs/util-crypto/examples/verify-signature.md
+++ b/docs/util-crypto/examples/verify-signature.md
@@ -5,22 +5,27 @@ title: Verify Signature
 This function will return true if a message passed as parameter has been signed by the passed address 
 
 ```javascript
-const { decodeAddress, signatureVerify } = require('@polkadot/util-crypto');
-const { u8aToHex } = require('@polkadot/util');
+const { cryptoWaitReady, decodeAddress, signatureVerify } = require('@polkadot/util-crypto');
+const { u8aToHex, u8aWrapBytes } = require('@polkadot/util');
 
 const isValidSignature = (signedMessage, signature, address) => {
   const publicKey = decodeAddress(address);
   const hexPublicKey = u8aToHex(publicKey);
 
-  return signatureVerify(signedMessage, signature, hexPublicKey).isValid;
+  return signatureVerify(u8aWrapBytes(signedMessage), signature, hexPublicKey).isValid;
 };
 
-const isValid = isValidSignature(
-  'This is a text message',
-  '0x2aeaa98e26062cf65161c68c5cb7aa31ca050cb5bdd07abc80a475d2a2eebc7b7a9c9546fbdff971b29419ddd9982bf4148c81a49df550154e1674a6b58bac84',
-  '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty'
-);
+const main = async () => {
+  //Some interfaces, such as using sr25519 however are only available via WASM
+  await cryptoWaitReady();
+  const isValid = isValidSignature(
+    'This is a text message',
+    '0x2aeaa98e26062cf65161c68c5cb7aa31ca050cb5bdd07abc80a475d2a2eebc7b7a9c9546fbdff971b29419ddd9982bf4148c81a49df550154e1674a6b58bac84',
+    '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty'
+  );
+  console.log(isValid)
+  // true
+}
 
-console.log(isValid)
-// true
+main();
 ```


### PR DESCRIPTION
Hi,

The origin example always returns false.
It should wait until the WASM has been initialized because the type of address is sr25519.
And the `signedMessage` should be wrapped by <Bytes></Bytes>