### PR TITLE
fix typo from brick to break

### DIFF
--- a/docs/api/examples/promise/upgrade-chain.md
+++ b/docs/api/examples/promise/upgrade-chain.md
@@ -2,7 +2,7 @@
 title: Chain upgrade
 ---
 
-Performs a chain upgrade using the `sudo` module. This may brick your chain, so use it as an educational sample. (use `substrate purge-chain --dev` to remove DB and recover).
+Performs a chain upgrade using the `sudo` module. This may break your chain, so use it as an educational sample. (use `substrate purge-chain --dev` to remove DB and recover).
 
 ```javascript
 // Import the API & Provider and some utility functions


### PR DESCRIPTION
I do not think you intended to use the word brick, and think that break was intended instead