### PR TITLE
Grammatical error in extrinsics.md

### DIFF
--- a/docs/substrate/extrinsics.md
+++ b/docs/substrate/extrinsics.md
@@ -2,7 +2,7 @@
 title: Extrinsics
 ---
 
-The following sections contain Extrinsics methods are part of the default Substrate runtime. On the api, these are exposed via `api.tx.<module>.<method>`. 
+The following sections contain Extrinsics methods that are part of the default Substrate runtime. On the api, these are exposed via `api.tx.<module>.<method>`. 
 
 (NOTE: These were generated from a static/snapshot view of a recent Substrate master node. Some items may not be available in older nodes, or in any customized implementations.)
 


### PR DESCRIPTION
Added a missing "that" in the first sentence.