### PR TITLE
Fix the metadata at custom RPC docs

### DIFF
--- a/docs/api/start/rpc.custom.md
+++ b/docs/api/start/rpc.custom.md
@@ -1,4 +1,4 @@
-
+---
 title: Custom RPC
 ---
 


### PR DESCRIPTION
Fixes this:

![image](https://user-images.githubusercontent.com/265507/149615993-380df538-c903-43e0-b5e3-a6d575080f12.png)
