### PR TITLE
Minor typo fixes

### DIFF
--- a/docs/api/start/api.tx.subs.md
+++ b/docs/api/start/api.tx.subs.md
@@ -30,7 +30,7 @@ const unsub = await api.tx.balances
   });
 ```
 
-As per all previous subscriptions, the transaction subscription returns in `unsub()` and the actual method has a subscription callback. The `result` object has 2 parts, `events` (to to covered in the next section) and the `status` enum.
+As per all previous subscriptions, the transaction subscription returns in `unsub()` and the actual method has a subscription callback. The `result` object has 2 parts, `events` (to be covered in the next section) and the `status` enum.
 
 When the `status` enum is in `Finalized` state (checked via `isFinalized`), the underlying value contains the block hash of the block where the transaction has been finalized. `Finalized` will follow `InBlock`, which is the block where the transaction has been included. `InBlock` does not mean the block is finalized, but rather applies to the transaction state, where `Finalized` means that the transaction cannot be forked off the chain.
 

--- a/docs/api/start/keyring.md
+++ b/docs/api/start/keyring.md
@@ -2,7 +2,7 @@
 title: Keyring
 ---
 
-This section will give a quick introduction into the Keyring, including the addition of accounts, retrieving pairs and the signing of any data. Unlike the rest of the API, only the core concepts will be covered with the most-used-functions. However, what is covered is enough for 99.9 of the use-cases ... or rather, that is the aim.
+This section will give a quick introduction into the Keyring, including the addition of accounts, retrieving pairs and the signing of any data. Unlike the rest of the API, only the core concepts will be covered with the most-used-functions. However, what is covered is enough for 99.9% of the use-cases ... or rather, that is the aim.
 
 
 ## Installation


### PR DESCRIPTION
- changing "99.9 of the use cases" to "99.9% of the use-cases" in keyring.md
- changing "to to" to "to be" in api.tx.subs.md 