### PR TITLE
Fix URL typo

### DIFF
--- a/docs/ui-keyring/start/install.md
+++ b/docs/ui-keyring/start/install.md
@@ -4,7 +4,7 @@ title: Installation
 
 If you already use the [@polkadot/api](https://www.npmjs.com/package/@polkadot/api) in your project (which is true in most cases), you don't need anything more than `yarn add @polkadot/ui-keyring @polkadot/ui-settings`. In this case the `ui-settings` is a peer dependency, so should be installed alongside.
 
-If however you use the `ui-keyring` independently (i.e. in an address generator, like the [examples](https://github.com/polkdot-js/ui) you would need the `keyring` dependency as well, `yarn add @polkadot/keyring @polkadot/ui-keyring`. (In the first case the `@polkadot/api` already comes bundled with the base keyring, so no additional dependencies are needed).
+If however you use the `ui-keyring` independently (i.e. in an address generator, like the [examples](https://github.com/polkadot-js/ui) you would need the `keyring` dependency as well, `yarn add @polkadot/keyring @polkadot/ui-keyring`. (In the first case the `@polkadot/api` already comes bundled with the base keyring, so no additional dependencies are needed).
 
 
 ## Initialization


### PR DESCRIPTION
Fixes typo on the "example" hyperlink on [this](https://polkadot.js.org/docs/ui-keyring/start/install) page.