### PR TITLE
formats 'Get chain information' example in-line with others

### DIFF
--- a/docs/api/examples/promise/chain-info.md
+++ b/docs/api/examples/promise/chain-info.md
@@ -6,11 +6,13 @@ This example shows how to connect to the api and retrieve the chain information 
 
 ```javascript
 // Import the API
-const { ApiPromise } = require('@polkadot/api');
+import { ApiPromise, WsProvider } from '@polkadot/api';
 
 async function main () {
+  // Create connection to websocket
+  const wsProvider = new WsProvider('wss://rpc.polkadot.io');
   // Create a new instance of the api
-  const api = await ApiPromise.create();
+  const api = await ApiPromise.create({ provider: wsProvider });
   // get the chain information
   const chainInfo = await api.registry.getChainProperties()
 


### PR DESCRIPTION
Updates example in the API documentation so that it:

(1) works
(2) is the same formatting as others in the documentation.