### PR TITLE
isReady field no longer present or necessary

### DIFF
--- a/docs/api/start/create.md
+++ b/docs/api/start/create.md
@@ -35,7 +35,7 @@ The API creation is done via the `ApiPromise.create` interface which is a shortc
 
 ```js
 ApiPromise
-  .create({ provider: wsProvider }).isReady
+  .create({ provider: wsProvider })
   .then((api) =>
     console.log(api.genesisHash.toHex())
   );


### PR DESCRIPTION
The isReady field is undefined in the latest version of the library. According to API documentation at https://polkadot-java.github.io/org/polkadot/api/promise/ApiPromise.html, the isReady field is no longer necessary. I verified this locally on my end as well.