### PR TITLE
Add tx hash to transaction subscriptions

### DIFF
--- a/docs/api/start/api.tx.subs.md
+++ b/docs/api/start/api.tx.subs.md
@@ -48,11 +48,12 @@ To display or act on these events, we can do the following -
 // Make a transfer from Alice to BOB, waiting for inclusion
 const unsub = await api.tx.balances
   .transfer(BOB, 12345)
-  .signAndSend(alice, ({ events = [], status }) => {
+  .signAndSend(alice, ({ events = [], status, txHash }) => {
     console.log(`Current status is ${status.type}`);
 
     if (status.isFinalized) {
       console.log(`Transaction included at blockHash ${status.asFinalized}`);
+      console.log(`Transaction hash ${txHash.toHex()}`);
 
       // Loop through Vec<EventRecord> to display all events
       events.forEach(({ phase, event: { data, method, section } }) => {


### PR DESCRIPTION
Basic transaction returns tx hash, while transaction subscription returns an unsub function.
I think it is helpful to explicitly show how to get txHash in subscription too.
For example to generate a subscan.io link, or just to check it yourself.