### PR TITLE
Small typo fix

### DIFF
--- a/docs/api/start/basics.md
+++ b/docs/api/start/basics.md
@@ -22,7 +22,7 @@ None of the information contained within the `api.{consts, query, tx}.<module>.<
 
 ## Types
 
-The metadata defines the calls with all the type names used in the various interfaces. At the moment (this is undergoing investigations and could improve in future versions of metadata), this also means that the types between the API and the node need to be aligned. For instance, by default Substrate defines a `BlockNumber` type as a `u32` and the API follows the Substrate defaults - if a chain has a different definitions, the API needs to be aware of this so it can actually decode (and encode) the type.
+The metadata defines the calls with all the type names used in the various interfaces. At the moment (this is undergoing investigations and could improve in future versions of metadata), this also means that the types between the API and the node need to be aligned. For instance, by default Substrate defines a `BlockNumber` type as a `u32` and the API follows the Substrate defaults - if a chain has a different definition, the API needs to be aware of this so it can actually decode (and encode) the type.
 
 At this point just be aware of it, we will touch on types, custom chains and their impacts in a later section.
 


### PR DESCRIPTION
Small typo fix - Removed an extra unnecessary 's'