### PR TITLE
Corrected message for DuplicateContract

### DIFF
--- a/docs/substrate/errors.md
+++ b/docs/substrate/errors.md
@@ -507,7 +507,7 @@ ___
  
 ### DuplicateContract
 - **interface**: `api.errors.contracts.DuplicateContract.is`
-- **summary**:    A contract with the same AccountId already exists. 
+- **summary**:    A contract with the same CodeHash already exists. 
  
 ### Indeterministic
 - **interface**: `api.errors.contracts.Indeterministic.is`


### PR DESCRIPTION
The current message for this error is incorrect. This error occurs when the contract was previously uploaded and the CodeHash is already in use. It does not consist of a duplicate AccountId for the contract. 