### PR TITLE
chore: update `Sudid` destructure docs

### DIFF
--- a/docs/api/cookbook/tx.md
+++ b/docs/api/cookbook/tx.md
@@ -88,20 +88,21 @@ The section above shows you how to listen for the result of a regular extrinsic.
 To properly parse this information, we will follow the steps above, but then specifically peek into the event data to find the final result:
 
 ```js
-const unsub = await api.tx.sudo
+const unsubscribe = await api.tx.sudo
   .sudo(
     api.tx.balances.forceTransfer(user1, user2, amount)
   )
   .signAndSend(sudoPair, ({ status, events }) => {
     if (status.isInBlock || status.isFinalized) {
       events
-        // We know this tx should result in `Sudid` event.
-        .filter(({ event }) =>
-          api.events.sudo.Sudid.is(event)
-        )
-        // We know that `Sudid` returns just a `Result`
-        .forEach(({ event : { data: [result] } }) => {
-          // Now we look to see if the extrinsic was actually successful or not...
+        .forEach(({ event }) => {
+          // We know this tx should result in `Sudid` event, ignore all others.
+          if(!api.events.sudo.Sudid.is(event)) continue;
+
+          // `event` is now typed as Sudid, which has a payload called `sudoResult`
+          const result = event.data.sudoResult
+                // ^? `Result<Null, SpRuntimeDispatchError>`
+
           if (result.isError) {
             let error = result.asError;
             if (error.isModule) {


### PR DESCRIPTION
The docs destructure an array element form the `Sudid` event. This is no longer available. It is now a named field called `sudo_result`.

Came up in this substack question:
https://substrate.stackexchange.com/questions/10981/property-iserror-does-not-exist-on-type-codec-when-showing-sudo-events

And here is the actual Event defintion:
https://github.com/paritytech/polkadot-sdk/blob/e2caa813bfd2973e7a7a74aa5292433397dbc787/substrate/frame/sudo/src/lib.rs#L302-L306