### PR TITLE
Update typegen and generated latest docs

### DIFF
--- a/docs/asset-hub-kusama/constants.md
+++ b/docs/asset-hub-kusama/constants.md
@@ -14,17 +14,37 @@ The following sections contain the module constants, also known as parameter typ
 
 - **[balances](#balances)**
 
+- **[bounties](#bounties)**
+
+- **[childBounties](#childbounties)**
+
+- **[claims](#claims)**
+
 - **[collatorSelection](#collatorselection)**
+
+- **[convictionVoting](#convictionvoting)**
+
+- **[delegatedStaking](#delegatedstaking)**
 
 - **[foreignAssets](#foreignassets)**
 
+- **[indices](#indices)**
+
 - **[messageQueue](#messagequeue)**
+
+- **[multiBlockElection](#multiblockelection)**
+
+- **[multiBlockElectionVerifier](#multiblockelectionverifier)**
+
+- **[multiBlockMigrations](#multiblockmigrations)**
 
 - **[multisig](#multisig)**
 
 - **[nftFractionalization](#nftfractionalization)**
 
 - **[nfts](#nfts)**
+
+- **[nominationPools](#nominationpools)**
 
 - **[parachainSystem](#parachainsystem)**
 
@@ -34,7 +54,19 @@ The following sections contain the module constants, also known as parameter typ
 
 - **[proxy](#proxy)**
 
+- **[recovery](#recovery)**
+
+- **[referenda](#referenda)**
+
 - **[revive](#revive)**
+
+- **[scheduler](#scheduler)**
+
+- **[session](#session)**
+
+- **[society](#society)**
+
+- **[staking](#staking)**
 
 - **[stateTrieMigration](#statetriemigration)**
 
@@ -44,11 +76,15 @@ The following sections contain the module constants, also known as parameter typ
 
 - **[transactionPayment](#transactionpayment)**
 
+- **[treasury](#treasury)**
+
 - **[uniques](#uniques)**
 
 - **[utility](#utility)**
 
 - **[vesting](#vesting)**
+
+- **[voterList](#voterlist)**
 
 - **[xcmpQueue](#xcmpqueue)**
 
@@ -82,7 +118,7 @@ ___
 - **interface**: `api.consts.assetConversion.poolSetupFee`
 - **summary**:    A one-time fee to setup the pool. 
  
-### poolSetupFeeAsset: `StagingXcmV4Location`
+### poolSetupFeeAsset: `StagingXcmV5Location`
 - **interface**: `api.consts.assetConversion.poolSetupFeeAsset`
 - **summary**:    Asset class from [`Config::Assets`] used to pay the [`Config::PoolSetupFee`]. 
 
@@ -164,6 +200,74 @@ ___
 ___
 
 
+## bounties
+ 
+### bountyDepositBase: `u128`
+- **interface**: `api.consts.bounties.bountyDepositBase`
+- **summary**:    The amount held on deposit for placing a bounty proposal. 
+ 
+### bountyDepositPayoutDelay: `u32`
+- **interface**: `api.consts.bounties.bountyDepositPayoutDelay`
+- **summary**:    The delay period for which a bounty beneficiary need to wait before claim the payout. 
+ 
+### bountyUpdatePeriod: `u32`
+- **interface**: `api.consts.bounties.bountyUpdatePeriod`
+- **summary**:    The time limit for a curator to act before a bounty expires. 
+
+   The period that starts when a curator is approved, during which they must execute or  update the bounty via `extend_bounty_expiry`. If missed, the bounty expires, and the  curator may be slashed. If `BlockNumberFor::MAX`, bounties stay active indefinitely,  removing the need for `extend_bounty_expiry`. 
+ 
+### bountyValueMinimum: `u128`
+- **interface**: `api.consts.bounties.bountyValueMinimum`
+- **summary**:    Minimum value for a bounty. 
+ 
+### curatorDepositMax: `Option<u128>`
+- **interface**: `api.consts.bounties.curatorDepositMax`
+- **summary**:    Maximum amount of funds that should be placed in a deposit for making a proposal. 
+ 
+### curatorDepositMin: `Option<u128>`
+- **interface**: `api.consts.bounties.curatorDepositMin`
+- **summary**:    Minimum amount of funds that should be placed in a deposit for making a proposal. 
+ 
+### curatorDepositMultiplier: `Permill`
+- **interface**: `api.consts.bounties.curatorDepositMultiplier`
+- **summary**:    The curator deposit is calculated as a percentage of the curator fee. 
+
+   This deposit has optional upper and lower bounds with `CuratorDepositMax` and  `CuratorDepositMin`. 
+ 
+### dataDepositPerByte: `u128`
+- **interface**: `api.consts.bounties.dataDepositPerByte`
+- **summary**:    The amount held on deposit per byte within the tip report reason or bounty description. 
+ 
+### maximumReasonLength: `u32`
+- **interface**: `api.consts.bounties.maximumReasonLength`
+- **summary**:    Maximum acceptable reason length. 
+
+   Benchmarks depend on this value, be sure to update weights file when changing this value 
+
+___
+
+
+## childBounties
+ 
+### childBountyValueMinimum: `u128`
+- **interface**: `api.consts.childBounties.childBountyValueMinimum`
+- **summary**:    Minimum value for a child-bounty. 
+ 
+### maxActiveChildBountyCount: `u32`
+- **interface**: `api.consts.childBounties.maxActiveChildBountyCount`
+- **summary**:    Maximum number of child bounties that can be added to a parent bounty. 
+
+___
+
+
+## claims
+ 
+### prefix: `Bytes`
+- **interface**: `api.consts.claims.prefix`
+
+___
+
+
 ## collatorSelection
  
 ### kickThreshold: `u32`
@@ -190,6 +294,36 @@ ___
 ### potId: `FrameSupportPalletId`
 - **interface**: `api.consts.collatorSelection.potId`
 - **summary**:    Account Identifier from which the internal Pot is generated. 
+
+___
+
+
+## convictionVoting
+ 
+### maxVotes: `u32`
+- **interface**: `api.consts.convictionVoting.maxVotes`
+- **summary**:    The maximum number of concurrent votes an account may have. 
+
+   Also used to compute weight, an overly large value can lead to extrinsics with large  weight estimation: see `delegate` for instance. 
+ 
+### voteLockingPeriod: `u32`
+- **interface**: `api.consts.convictionVoting.voteLockingPeriod`
+- **summary**:    The minimum period of vote locking. 
+
+   It should be no shorter than enactment period to ensure that in the case of an approval,  those successful voters are locked into the consequences that their votes entail. 
+
+___
+
+
+## delegatedStaking
+ 
+### palletId: `FrameSupportPalletId`
+- **interface**: `api.consts.delegatedStaking.palletId`
+- **summary**:    Injected identifier for the pallet. 
+ 
+### slashRewardFraction: `Perbill`
+- **interface**: `api.consts.delegatedStaking.slashRewardFraction`
+- **summary**:    Fraction of the slash that is rewarded to the caller of pending slash to the agent. 
 
 ___
 
@@ -229,6 +363,15 @@ ___
 ___
 
 
+## indices
+ 
+### deposit: `u128`
+- **interface**: `api.consts.indices.deposit`
+- **summary**:    The deposit needed for reserving an index. 
+
+___
+
+
 ## messageQueue
  
 ### heapSize: `u32`
@@ -252,6 +395,83 @@ ___
 - **summary**:    The amount of weight (if any) which should be provided to the message queue for  servicing enqueued items `on_initialize`. 
 
    This may be legitimately `None` in the case that you will call  `ServiceQueues::service_queues` manually or set [`Self::IdleMaxServiceWeight`] to have  it run in `on_idle`. 
+
+___
+
+
+## multiBlockElection
+ 
+### pages: `u32`
+- **interface**: `api.consts.multiBlockElection.pages`
+- **summary**:    The number of pages. 
+
+   The snapshot is created with this many keys in the storage map. 
+
+   The solutions may contain at MOST this many pages, but less pages are acceptable as  well. 
+ 
+### signedPhase: `u32`
+- **interface**: `api.consts.multiBlockElection.signedPhase`
+- **summary**:    Duration of the signed phase. 
+ 
+### signedValidationPhase: `u32`
+- **interface**: `api.consts.multiBlockElection.signedValidationPhase`
+- **summary**:    Duration of the singed validation phase. 
+
+   The duration of this should not be less than `T::Pages`, and there is no point in it  being more than `SignedPhase::MaxSubmission::get() * T::Pages`. TODO: integrity test for  it. 
+ 
+### targetSnapshotPerBlock: `u32`
+- **interface**: `api.consts.multiBlockElection.targetSnapshotPerBlock`
+- **summary**:    The number of snapshot targets to fetch per block. 
+ 
+### unsignedPhase: `u32`
+- **interface**: `api.consts.multiBlockElection.unsignedPhase`
+- **summary**:    Duration of the unsigned phase. 
+ 
+### voterSnapshotPerBlock: `u32`
+- **interface**: `api.consts.multiBlockElection.voterSnapshotPerBlock`
+- **summary**:    The number of snapshot voters to fetch per block. 
+
+___
+
+
+## multiBlockElectionVerifier
+ 
+### maxBackersPerWinner: `u32`
+- **interface**: `api.consts.multiBlockElectionVerifier.maxBackersPerWinner`
+- **summary**:    Maximum number of backers, per winner, per page. 
+ 
+### maxBackersPerWinnerFinal: `u32`
+- **interface**: `api.consts.multiBlockElectionVerifier.maxBackersPerWinnerFinal`
+- **summary**:    Maximum number of backers, per winner, among all pages of an election. 
+
+   This can only be checked at the very final step of verification. 
+
+   NOTE: at the moment, we don't check this, and it is in place for future compatibility. 
+ 
+### maxWinnersPerPage: `u32`
+- **interface**: `api.consts.multiBlockElectionVerifier.maxWinnersPerPage`
+- **summary**:    Maximum number of supports (aka. winners/validators/targets) that can be represented in  a page of results. 
+ 
+### solutionImprovementThreshold: `Perbill`
+- **interface**: `api.consts.multiBlockElectionVerifier.solutionImprovementThreshold`
+- **summary**:    The minimum amount of improvement to the solution score that defines a solution as  "better". 
+
+___
+
+
+## multiBlockMigrations
+ 
+### cursorMaxLen: `u32`
+- **interface**: `api.consts.multiBlockMigrations.cursorMaxLen`
+- **summary**:    The maximal length of an encoded cursor. 
+
+   A good default needs to selected such that no migration will ever have a cursor with MEL  above this limit. This is statically checked in `integrity_test`. 
+ 
+### identifierMaxLen: `u32`
+- **interface**: `api.consts.multiBlockMigrations.identifierMaxLen`
+- **summary**:    The maximal length of an encoded identifier. 
+
+   A good default needs to selected such that no migration will ever have an identifier  with MEL above this limit. This is statically checked in `integrity_test`. 
 
 ___
 
@@ -363,6 +583,29 @@ ___
 ___
 
 
+## nominationPools
+ 
+### maxPointsToBalance: `u8`
+- **interface**: `api.consts.nominationPools.maxPointsToBalance`
+- **summary**:    The maximum pool points-to-balance ratio that an `open` pool can have. 
+
+   This is important in the event slashing takes place and the pool's points-to-balance  ratio becomes disproportional. 
+
+   Moreover, this relates to the `RewardCounter` type as well, as the arithmetic operations  are a function of number of points, and by setting this value to e.g. 10, you ensure  that the total number of points in the system are at most 10 times the total_issuance of  the chain, in the absolute worse case. 
+
+   For a value of 10, the threshold would be a pool points-to-balance ratio of 10:1.  Such a scenario would also be the equivalent of the pool being 90% slashed. 
+ 
+### maxUnbonding: `u32`
+- **interface**: `api.consts.nominationPools.maxUnbonding`
+- **summary**:    The maximum number of simultaneous unbonding chunks that can exist per member. 
+ 
+### palletId: `FrameSupportPalletId`
+- **interface**: `api.consts.nominationPools.palletId`
+- **summary**:    The nomination pool's pallet id. 
+
+___
+
+
 ## parachainSystem
  
 ### selfParaId: `u32`
@@ -377,6 +620,18 @@ ___
 ### advertisedXcmVersion: `u32`
 - **interface**: `api.consts.polkadotXcm.advertisedXcmVersion`
 - **summary**:    The latest supported version that we advertise. Generally just set it to  `pallet_xcm::CurrentXcmVersion`. 
+ 
+### maxLockers: `u32`
+- **interface**: `api.consts.polkadotXcm.maxLockers`
+- **summary**:    The maximum number of local XCM locks that a single account may have. 
+ 
+### maxRemoteLockConsumers: `u32`
+- **interface**: `api.consts.polkadotXcm.maxRemoteLockConsumers`
+- **summary**:    The maximum number of consumers a single remote lock may have. 
+ 
+### universalLocation: `StagingXcmV5Junctions`
+- **interface**: `api.consts.polkadotXcm.universalLocation`
+- **summary**:    This chain's Universal Location. 
 
 ___
 
@@ -453,6 +708,62 @@ ___
 ___
 
 
+## recovery
+ 
+### configDepositBase: `u128`
+- **interface**: `api.consts.recovery.configDepositBase`
+- **summary**:    The base amount of currency needed to reserve for creating a recovery configuration. 
+
+   This is held for an additional storage item whose value size is  `2 + sizeof(BlockNumber, Balance)` bytes. 
+ 
+### friendDepositFactor: `u128`
+- **interface**: `api.consts.recovery.friendDepositFactor`
+- **summary**:    The amount of currency needed per additional user when creating a recovery  configuration. 
+
+   This is held for adding `sizeof(AccountId)` bytes more into a pre-existing storage  value. 
+ 
+### maxFriends: `u32`
+- **interface**: `api.consts.recovery.maxFriends`
+- **summary**:    The maximum amount of friends allowed in a recovery configuration. 
+
+   NOTE: The threshold programmed in this Pallet uses u16, so it does  not really make sense to have a limit here greater than u16::MAX.  But also, that is a lot more than you should probably set this value  to anyway... 
+ 
+### recoveryDeposit: `u128`
+- **interface**: `api.consts.recovery.recoveryDeposit`
+- **summary**:    The base amount of currency needed to reserve for starting a recovery. 
+
+   This is primarily held for deterring malicious recovery attempts, and should  have a value large enough that a bad actor would choose not to place this  deposit. It also acts to fund additional storage item whose value size is  `sizeof(BlockNumber, Balance + T * AccountId)` bytes. Where T is a configurable  threshold. 
+
+___
+
+
+## referenda
+ 
+### alarmInterval: `u32`
+- **interface**: `api.consts.referenda.alarmInterval`
+- **summary**:    Quantization level for the referendum wakeup scheduler. A higher number will result in  fewer storage reads/writes needed for smaller voters, but also result in delays to the  automatic referendum status changes. Explicit servicing instructions are unaffected. 
+ 
+### maxQueued: `u32`
+- **interface**: `api.consts.referenda.maxQueued`
+- **summary**:    Maximum size of the referendum queue for a single track. 
+ 
+### submissionDeposit: `u128`
+- **interface**: `api.consts.referenda.submissionDeposit`
+- **summary**:    The minimum amount to be used as a deposit for a public referendum proposal. 
+ 
+### tracks: `Vec<(u16,PalletReferendaTrackDetails)>`
+- **interface**: `api.consts.referenda.tracks`
+- **summary**:    A list of tracks. 
+
+   Note: if the tracks are dynamic, the value in the static metadata might be inaccurate. 
+ 
+### undecidingTimeout: `u32`
+- **interface**: `api.consts.referenda.undecidingTimeout`
+- **summary**:    The number of blocks after submission that a referendum must begin being decided by.  Once this passes, then anyone may cancel the referendum. 
+
+___
+
+
 ## revive
  
 ### chainId: `u64`
@@ -494,6 +805,154 @@ ___
    #### Warning 
 
    Do **not** set to `true` on productions chains. 
+
+___
+
+
+## scheduler
+ 
+### maximumWeight: `SpWeightsWeightV2Weight`
+- **interface**: `api.consts.scheduler.maximumWeight`
+- **summary**:    The maximum weight that may be scheduled per block for any dispatchables. 
+ 
+### maxScheduledPerBlock: `u32`
+- **interface**: `api.consts.scheduler.maxScheduledPerBlock`
+- **summary**:    The maximum number of scheduled calls in the queue for a single block. 
+
+   NOTE:  + Dependent pallets' benchmarks might require a higher limit for the setting. Set a  higher limit under `runtime-benchmarks` feature. 
+
+___
+
+
+## session
+ 
+### keyDeposit: `u128`
+- **interface**: `api.consts.session.keyDeposit`
+- **summary**:    The amount to be held when setting keys. 
+
+___
+
+
+## society
+ 
+### challengePeriod: `u32`
+- **interface**: `api.consts.society.challengePeriod`
+- **summary**:    The number of [Config::BlockNumberProvider] blocks between membership challenges. 
+ 
+### claimPeriod: `u32`
+- **interface**: `api.consts.society.claimPeriod`
+- **summary**:    The number of [Config::BlockNumberProvider] blocks on which new candidates can claim  their membership and be the named head. 
+ 
+### graceStrikes: `u32`
+- **interface**: `api.consts.society.graceStrikes`
+- **summary**:    The maximum number of strikes before a member gets funds slashed. 
+ 
+### maxBids: `u32`
+- **interface**: `api.consts.society.maxBids`
+- **summary**:    The maximum number of bids at once. 
+ 
+### maxLockDuration: `u32`
+- **interface**: `api.consts.society.maxLockDuration`
+- **summary**:    The maximum duration of the payout lock. 
+ 
+### maxPayouts: `u32`
+- **interface**: `api.consts.society.maxPayouts`
+- **summary**:    The maximum number of payouts a member may have waiting unclaimed. 
+ 
+### palletId: `FrameSupportPalletId`
+- **interface**: `api.consts.society.palletId`
+- **summary**:    The societies's pallet id 
+ 
+### periodSpend: `u128`
+- **interface**: `api.consts.society.periodSpend`
+- **summary**:    The amount of incentive paid within each period. Doesn't include VoterTip. 
+ 
+### votingPeriod: `u32`
+- **interface**: `api.consts.society.votingPeriod`
+- **summary**:    The number of [Config::BlockNumberProvider] blocks on which new candidates should be  voted on. Together with  `ClaimPeriod`, this sums to the number of blocks between candidate intake periods. 
+
+___
+
+
+## staking
+ 
+### bondingDuration: `u32`
+- **interface**: `api.consts.staking.bondingDuration`
+- **summary**:    Number of eras that staked funds must remain bonded for. 
+ 
+### historyDepth: `u32`
+- **interface**: `api.consts.staking.historyDepth`
+- **summary**:    Number of eras to keep in history. 
+
+   Following information is kept for eras in `[current_era -  HistoryDepth, current_era]`: `ErasValidatorPrefs`, `ErasValidatorReward`,  `ErasRewardPoints`, `ErasTotalStake`, `ClaimedRewards`,  `ErasStakersPaged`, `ErasStakersOverview`. 
+
+   Must be more than the number of eras delayed by session.  I.e. active era must always be in history. I.e. `active_era >  current_era - history_depth` must be guaranteed. 
+
+   If migrating an existing pallet from storage value to config value,  this should be set to same value or greater as in storage. 
+ 
+### maxEraDuration: `u64`
+- **interface**: `api.consts.staking.maxEraDuration`
+- **summary**:    Maximum allowed era duration in milliseconds. 
+
+   This provides a defensive upper bound to cap the effective era duration, preventing  excessively long eras from causing runaway inflation (e.g., due to bugs). If the actual  era duration exceeds this value, it will be clamped to this maximum. 
+
+   Example: For an ideal era duration of 24 hours (86,400,000 ms),  this can be set to 604,800,000 ms (7 days). 
+ 
+### maxExposurePageSize: `u32`
+- **interface**: `api.consts.staking.maxExposurePageSize`
+- **summary**:    The maximum size of each `T::ExposurePage`. 
+
+   An `ExposurePage` is weakly bounded to a maximum of `MaxExposurePageSize`  nominators. 
+
+   For older non-paged exposure, a reward payout was restricted to the top  `MaxExposurePageSize` nominators. This is to limit the i/o cost for the  nominator payout. 
+
+   Note: `MaxExposurePageSize` is used to bound `ClaimedRewards` and is unsafe to  reduce without handling it in a migration. 
+ 
+### maxInvulnerables: `u32`
+- **interface**: `api.consts.staking.maxInvulnerables`
+- **summary**:    Maximum number of invulnerable validators. 
+ 
+### maxPruningItems: `u32`
+- **interface**: `api.consts.staking.maxPruningItems`
+- **summary**:    Maximum number of storage items that can be pruned in a single call. 
+
+   This controls how many storage items can be deleted in each call to `prune_era_step`.  This should be set to a conservative value (e.g., 100-500 items) to ensure pruning  doesn't consume too much block space. The actual weight is determined by benchmarks. 
+ 
+### maxUnlockingChunks: `u32`
+- **interface**: `api.consts.staking.maxUnlockingChunks`
+- **summary**:    The maximum number of `unlocking` chunks a [`StakingLedger`] can  have. Effectively determines how many unique eras a staker may be  unbonding in. 
+
+   Note: `MaxUnlockingChunks` is used as the upper bound for the  `BoundedVec` item `StakingLedger.unlocking`. Setting this value  lower than the existing value can lead to inconsistencies in the  `StakingLedger` and will need to be handled properly in a runtime  migration. The test `reducing_max_unlocking_chunks_abrupt` shows  this effect. 
+ 
+### maxValidatorSet: `u32`
+- **interface**: `api.consts.staking.maxValidatorSet`
+- **summary**:    The absolute maximum of winner validators this pallet should return. 
+
+   As this pallet supports multi-block election, the set of winner validators *per  election* is bounded by this type. 
+ 
+### planningEraOffset: `u32`
+- **interface**: `api.consts.staking.planningEraOffset`
+- **summary**:    Number of sessions before the end of an era when the election for the next era will  start. 
+
+   - This determines how many sessions **before** the last session of the era the staking  election process should begin. 
+
+  - The value is bounded between **1** (election starts at the beginning of the last session) and `SessionsPerEra` (election starts at the beginning of the first session  of the era). 
+
+   #### Example: 
+
+  - If `SessionsPerEra = 6` and `PlanningEraOffset = 1`, the election starts at the beginning of session `6 - 1 = 5`. 
+
+  - If `PlanningEraOffset = 6`, the election starts at the beginning of session `6 - 6 = 0`, meaning it starts at the very beginning of the era. 
+ 
+### sessionsPerEra: `u32`
+- **interface**: `api.consts.staking.sessionsPerEra`
+- **summary**:    Number of sessions per era, as per the preferences of the **relay chain**. 
+ 
+### slashDeferDuration: `u32`
+- **interface**: `api.consts.staking.slashDeferDuration`
+- **summary**:    Number of eras that slashes are deferred by, after computation. 
+
+   This should be less than the bonding duration. Set to 0 if slashes  should be applied immediately, without opportunity for intervention. 
 
 ___
 
@@ -582,6 +1041,39 @@ ___
 ___
 
 
+## treasury
+ 
+### burn: `Permill`
+- **interface**: `api.consts.treasury.burn`
+- **summary**:    Percentage of spare funds (if any) that are burnt per spend period. 
+ 
+### maxApprovals: `u32`
+- **interface**: `api.consts.treasury.maxApprovals`
+- **summary**:    DEPRECATED: associated with `spend_local` call and will be removed in May 2025.  Refer to <https://github.com/paritytech/polkadot-sdk/pull/5961> for migration to `spend`. 
+
+   The maximum number of approvals that can wait in the spending queue. 
+
+   NOTE: This parameter is also used within the Bounties Pallet extension if enabled. 
+ 
+### palletId: `FrameSupportPalletId`
+- **interface**: `api.consts.treasury.palletId`
+- **summary**:    The treasury's pallet id, used for deriving its sovereign account ID. 
+ 
+### payoutPeriod: `u32`
+- **interface**: `api.consts.treasury.payoutPeriod`
+- **summary**:    The period during which an approved treasury spend has to be claimed. 
+ 
+### potAccount: `AccountId32`
+- **interface**: `api.consts.treasury.potAccount`
+- **summary**:    Gets this pallet's derived pot account. 
+ 
+### spendPeriod: `u32`
+- **interface**: `api.consts.treasury.spendPeriod`
+- **summary**:    Period between successive spends. 
+
+___
+
+
 ## uniques
  
 ### attributeDepositBase: `u128`
@@ -636,6 +1128,51 @@ ___
 ### minVestedTransfer: `u128`
 - **interface**: `api.consts.vesting.minVestedTransfer`
 - **summary**:    The minimum amount transferred to call `vested_transfer`. 
+
+___
+
+
+## voterList
+ 
+### bagThresholds: `Vec<u64>`
+- **interface**: `api.consts.voterList.bagThresholds`
+- **summary**:    The list of thresholds separating the various bags. 
+
+   Ids are separated into unsorted bags according to their score. This specifies the  thresholds separating the bags. An id's bag is the largest bag for which the id's score  is less than or equal to its upper threshold. 
+
+   When ids are iterated, higher bags are iterated completely before lower bags. This means  that iteration is _semi-sorted_: ids of higher score tend to come before ids of lower  score, but peer ids within a particular bag are sorted in insertion order. 
+
+   #### Expressing the constant 
+
+   This constant must be sorted in strictly increasing order. Duplicate items are not  permitted. 
+
+   There is an implied upper limit of `Score::MAX`; that value does not need to be  specified within the bag. For any two threshold lists, if one ends with  `Score::MAX`, the other one does not, and they are otherwise equal, the two  lists will behave identically. 
+
+   #### Calculation 
+
+   It is recommended to generate the set of thresholds in a geometric series, such that  there exists some constant ratio such that `threshold[k + 1] == (threshold[k] *  constant_ratio).max(threshold[k] + 1)` for all `k`. 
+
+   The helpers in the `/utils/frame/generate-bags` module can simplify this calculation. 
+
+   #### Examples 
+
+   - If `BagThresholds::get().is_empty()`, then all ids are put into the same bag, and  iteration is strictly in insertion order. 
+
+  - If `BagThresholds::get().len() == 64`, and the thresholds are determined according to the procedure given above, then the constant ratio is equal to 2. 
+
+  - If `BagThresholds::get().len() == 200`, and the thresholds are determined according to the procedure given above, then the constant ratio is approximately equal to 1.248. 
+
+  - If the threshold list begins `[1, 2, 3, ...]`, then an id with score 0 or 1 will fall into bag 0, an id with score 2 will fall into bag 1, etc. 
+
+   #### Migration 
+
+   In the event that this list ever changes, a copy of the old bags list must be retained.  With that `List::migrate` can be called, which will perform the appropriate migration. 
+ 
+### maxAutoRebagPerBlock: `u32`
+- **interface**: `api.consts.voterList.maxAutoRebagPerBlock`
+- **summary**:    Maximum number of accounts that may be re-bagged automatically in `on_idle`. 
+
+   A value of `0` (obtained by configuring `type MaxAutoRebagPerBlock = ();`) disables  the feature. 
 
 ___
 

--- a/docs/asset-hub-kusama/errors.md
+++ b/docs/asset-hub-kusama/errors.md
@@ -6,17 +6,41 @@ This page lists the errors that can be encountered in the different modules.
 
 (NOTE: These were generated from a static/snapshot view of a recent default asset-hub-kusama runtime. Some items may not be available in older nodes, or in any customized implementations.)
 
+- **[ahMigrator](#ahmigrator)**
+
+- **[ahOps](#ahops)**
+
 - **[assetConversion](#assetconversion)**
+
+- **[assetRate](#assetrate)**
 
 - **[assets](#assets)**
 
 - **[balances](#balances)**
 
+- **[bounties](#bounties)**
+
+- **[childBounties](#childbounties)**
+
+- **[claims](#claims)**
+
 - **[collatorSelection](#collatorselection)**
+
+- **[convictionVoting](#convictionvoting)**
+
+- **[delegatedStaking](#delegatedstaking)**
 
 - **[foreignAssets](#foreignassets)**
 
+- **[indices](#indices)**
+
 - **[messageQueue](#messagequeue)**
+
+- **[multiBlockElection](#multiblockelection)**
+
+- **[multiBlockElectionSigned](#multiblockelectionsigned)**
+
+- **[multiBlockMigrations](#multiblockmigrations)**
 
 - **[multisig](#multisig)**
 
@@ -24,23 +48,39 @@ This page lists the errors that can be encountered in the different modules.
 
 - **[nfts](#nfts)**
 
+- **[nominationPools](#nominationpools)**
+
 - **[parachainSystem](#parachainsystem)**
 
 - **[polkadotXcm](#polkadotxcm)**
 
 - **[poolAssets](#poolassets)**
 
+- **[preimage](#preimage)**
+
 - **[proxy](#proxy)**
+
+- **[recovery](#recovery)**
+
+- **[referenda](#referenda)**
 
 - **[remoteProxyRelayChain](#remoteproxyrelaychain)**
 
 - **[revive](#revive)**
 
+- **[scheduler](#scheduler)**
+
 - **[session](#session)**
+
+- **[society](#society)**
+
+- **[staking](#staking)**
 
 - **[stateTrieMigration](#statetriemigration)**
 
 - **[system](#system)**
+
+- **[treasury](#treasury)**
 
 - **[uniques](#uniques)**
 
@@ -48,8 +88,142 @@ This page lists the errors that can be encountered in the different modules.
 
 - **[vesting](#vesting)**
 
+- **[voterList](#voterlist)**
+
+- **[whitelist](#whitelist)**
+
 - **[xcmpQueue](#xcmpqueue)**
 
+
+___
+
+
+## ahMigrator
+ 
+### BadXcmVersion
+- **interface**: `api.errors.ahMigrator.BadXcmVersion.is`
+- **summary**:    The XCM version is invalid. 
+ 
+### DmpQueuePriorityAlreadySet
+- **interface**: `api.errors.ahMigrator.DmpQueuePriorityAlreadySet.is`
+- **summary**:    The DMP queue priority is already set to the same value. 
+ 
+### FailedToBoundCall
+- **interface**: `api.errors.ahMigrator.FailedToBoundCall.is`
+- **summary**:    Failed to bound a call. 
+ 
+### FailedToBoundVector
+- **interface**: `api.errors.ahMigrator.FailedToBoundVector.is`
+- **summary**:    Vector did not fit into its compile-time bound. 
+ 
+### FailedToCalculateCheckingAccount
+- **interface**: `api.errors.ahMigrator.FailedToCalculateCheckingAccount.is`
+- **summary**:    Checking account overflow or underflow. 
+ 
+### FailedToConvertCall
+- **interface**: `api.errors.ahMigrator.FailedToConvertCall.is`
+- **summary**:    Failed to convert RC call to AH call. 
+ 
+### FailedToConvertType
+- **interface**: `api.errors.ahMigrator.FailedToConvertType.is`
+- **summary**:    Failed to convert RC type to AH type. 
+ 
+### FailedToIntegrateVestingSchedule
+- **interface**: `api.errors.ahMigrator.FailedToIntegrateVestingSchedule.is`
+- **summary**:    Failed to integrate a vesting schedule. 
+ 
+### FailedToProcessAccount
+- **interface**: `api.errors.ahMigrator.FailedToProcessAccount.is`
+- **summary**:    Failed to process an account data from RC. 
+ 
+### FailedToUnreserveDeposit
+- **interface**: `api.errors.ahMigrator.FailedToUnreserveDeposit.is`
+- **summary**:    Failed to unreserve deposit. 
+ 
+### InsertConflict
+- **interface**: `api.errors.ahMigrator.InsertConflict.is`
+- **summary**:    Some item could not be inserted because it already exists. 
+ 
+### InvalidOrigin
+- **interface**: `api.errors.ahMigrator.InvalidOrigin.is`
+- **summary**:    The origin is invalid. 
+ 
+### InvalidParameter
+- **interface**: `api.errors.ahMigrator.InvalidParameter.is`
+- **summary**:    Invalid parameter. 
+ 
+### PreimageChunkMissing
+- **interface**: `api.errors.ahMigrator.PreimageChunkMissing.is`
+- **summary**:    Preimage chunk missing. 
+ 
+### PreimageMissing
+- **interface**: `api.errors.ahMigrator.PreimageMissing.is`
+- **summary**:    Preimage missing. 
+ 
+### PreimageNotFound
+- **interface**: `api.errors.ahMigrator.PreimageNotFound.is`
+- **summary**:    Failed to fetch preimage. 
+ 
+### PreimageStatusInvalid
+- **interface**: `api.errors.ahMigrator.PreimageStatusInvalid.is`
+- **summary**:    Preimage status invalid. 
+ 
+### PreimageTooBig
+- **interface**: `api.errors.ahMigrator.PreimageTooBig.is`
+- **summary**:    Preimage too big. 
+ 
+### XcmError
+- **interface**: `api.errors.ahMigrator.XcmError.is`
+- **summary**:    Failed to send XCM message. 
+
+___
+
+
+## ahOps
+ 
+### ContributionsRemaining
+- **interface**: `api.errors.ahOps.ContributionsRemaining.is`
+- **summary**:    Not all contributions are withdrawn. 
+ 
+### FailedToWithdrawCrowdloanContribution
+- **interface**: `api.errors.ahOps.FailedToWithdrawCrowdloanContribution.is`
+- **summary**:    Failed to withdraw crowdloan contribution. 
+ 
+### InternalError
+- **interface**: `api.errors.ahOps.InternalError.is`
+- **summary**:    Internal error, please bug report. 
+ 
+### MigrationNotCompleted
+- **interface**: `api.errors.ahOps.MigrationNotCompleted.is`
+- **summary**:    The Asset Hub migration is not completed. 
+ 
+### NoCrowdloanContribution
+- **interface**: `api.errors.ahOps.NoCrowdloanContribution.is`
+- **summary**:    Either no crowdloan contribution or already withdrawn. 
+ 
+### NoCrowdloanReserve
+- **interface**: `api.errors.ahOps.NoCrowdloanReserve.is`
+- **summary**:    Either no crowdloan reserve or already unreserved. 
+ 
+### NoLeaseReserve
+- **interface**: `api.errors.ahOps.NoLeaseReserve.is`
+- **summary**:    Either no lease deposit or already unreserved. 
+ 
+### NotSovereign
+- **interface**: `api.errors.ahOps.NotSovereign.is`
+- **summary**:    Account cannot be migrated since it is not a sovereign parachain account. 
+ 
+### NotYet
+- **interface**: `api.errors.ahOps.NotYet.is`
+- **summary**:    Block number is not yet reached. 
+ 
+### WrongDerivedTranslation
+- **interface**: `api.errors.ahOps.WrongDerivedTranslation.is`
+- **summary**:    The account is not a derived account. 
+ 
+### ZeroBalance
+- **interface**: `api.errors.ahOps.ZeroBalance.is`
+- **summary**:    The balance is zero. 
 
 ___
 
@@ -147,6 +321,23 @@ ___
 ### ZeroLiquidity
 - **interface**: `api.errors.assetConversion.ZeroLiquidity.is`
 - **summary**:    Requested liquidity can't be zero. 
+
+___
+
+
+## assetRate
+ 
+### AlreadyExists
+- **interface**: `api.errors.assetRate.AlreadyExists.is`
+- **summary**:    The given asset ID already has an assigned conversion rate and cannot be re-created. 
+ 
+### Overflow
+- **interface**: `api.errors.assetRate.Overflow.is`
+- **summary**:    Overflow ocurred when calculating the inverse rate. 
+ 
+### UnknownAssetKind
+- **interface**: `api.errors.assetRate.UnknownAssetKind.is`
+- **summary**:    The given asset ID is unknown. 
 
 ___
 
@@ -301,6 +492,105 @@ ___
 ___
 
 
+## bounties
+ 
+### HasActiveChildBounty
+- **interface**: `api.errors.bounties.HasActiveChildBounty.is`
+- **summary**:    The bounty cannot be closed because it has active child bounties. 
+ 
+### InsufficientProposersBalance
+- **interface**: `api.errors.bounties.InsufficientProposersBalance.is`
+- **summary**:    Proposer's balance is too low. 
+ 
+### InvalidFee
+- **interface**: `api.errors.bounties.InvalidFee.is`
+- **summary**:    Invalid bounty fee. 
+ 
+### InvalidIndex
+- **interface**: `api.errors.bounties.InvalidIndex.is`
+- **summary**:    No proposal or bounty at that index. 
+ 
+### InvalidValue
+- **interface**: `api.errors.bounties.InvalidValue.is`
+- **summary**:    Invalid bounty value. 
+ 
+### NotProposer
+- **interface**: `api.errors.bounties.NotProposer.is`
+- **summary**:    User is not the proposer of the bounty. 
+ 
+### PendingPayout
+- **interface**: `api.errors.bounties.PendingPayout.is`
+- **summary**:    A bounty payout is pending.  To cancel the bounty, you must unassign and slash the curator. 
+ 
+### Premature
+- **interface**: `api.errors.bounties.Premature.is`
+- **summary**:    The bounties cannot be claimed/closed because it's still in the countdown period. 
+ 
+### ReasonTooBig
+- **interface**: `api.errors.bounties.ReasonTooBig.is`
+- **summary**:    The reason given is just too big. 
+ 
+### RequireCurator
+- **interface**: `api.errors.bounties.RequireCurator.is`
+- **summary**:    Require bounty curator. 
+ 
+### TooManyQueued
+- **interface**: `api.errors.bounties.TooManyQueued.is`
+- **summary**:    Too many approvals are already queued. 
+ 
+### UnexpectedStatus
+- **interface**: `api.errors.bounties.UnexpectedStatus.is`
+- **summary**:    The bounty status is unexpected. 
+
+___
+
+
+## childBounties
+ 
+### InsufficientBountyBalance
+- **interface**: `api.errors.childBounties.InsufficientBountyBalance.is`
+- **summary**:    The bounty balance is not enough to add new child-bounty. 
+ 
+### ParentBountyNotActive
+- **interface**: `api.errors.childBounties.ParentBountyNotActive.is`
+- **summary**:    The parent bounty is not in active state. 
+ 
+### TooManyChildBounties
+- **interface**: `api.errors.childBounties.TooManyChildBounties.is`
+- **summary**:    Number of child bounties exceeds limit `MaxActiveChildBountyCount`. 
+
+___
+
+
+## claims
+ 
+### InvalidEthereumSignature
+- **interface**: `api.errors.claims.InvalidEthereumSignature.is`
+- **summary**:    Invalid Ethereum signature. 
+ 
+### InvalidStatement
+- **interface**: `api.errors.claims.InvalidStatement.is`
+- **summary**:    A needed statement was not included. 
+ 
+### PotUnderflow
+- **interface**: `api.errors.claims.PotUnderflow.is`
+- **summary**:    There's not enough in the pot to pay out some unvested amount. Generally implies a  logic error. 
+ 
+### SenderHasNoClaim
+- **interface**: `api.errors.claims.SenderHasNoClaim.is`
+- **summary**:    Account ID sending transaction has no claim. 
+ 
+### SignerHasNoClaim
+- **interface**: `api.errors.claims.SignerHasNoClaim.is`
+- **summary**:    Ethereum address has no claim. 
+ 
+### VestedBalanceExists
+- **interface**: `api.errors.claims.VestedBalanceExists.is`
+- **summary**:    The account already has a vested balance. 
+
+___
+
+
 ## collatorSelection
  
 ### AlreadyCandidate
@@ -370,6 +660,114 @@ ___
 ### ValidatorNotRegistered
 - **interface**: `api.errors.collatorSelection.ValidatorNotRegistered.is`
 - **summary**:    Validator ID is not yet registered. 
+
+___
+
+
+## convictionVoting
+ 
+### AlreadyDelegating
+- **interface**: `api.errors.convictionVoting.AlreadyDelegating.is`
+- **summary**:    The account is already delegating. 
+ 
+### AlreadyVoting
+- **interface**: `api.errors.convictionVoting.AlreadyVoting.is`
+- **summary**:    The account currently has votes attached to it and the operation cannot succeed until  these are removed through `remove_vote`. 
+ 
+### BadClass
+- **interface**: `api.errors.convictionVoting.BadClass.is`
+- **summary**:    The class ID supplied is invalid. 
+ 
+### ClassNeeded
+- **interface**: `api.errors.convictionVoting.ClassNeeded.is`
+- **summary**:    The class must be supplied since it is not easily determinable from the state. 
+ 
+### InsufficientFunds
+- **interface**: `api.errors.convictionVoting.InsufficientFunds.is`
+- **summary**:    Too high a balance was provided that the account cannot afford. 
+ 
+### MaxVotesReached
+- **interface**: `api.errors.convictionVoting.MaxVotesReached.is`
+- **summary**:    Maximum number of votes reached. 
+ 
+### Nonsense
+- **interface**: `api.errors.convictionVoting.Nonsense.is`
+- **summary**:    Delegation to oneself makes no sense. 
+ 
+### NoPermission
+- **interface**: `api.errors.convictionVoting.NoPermission.is`
+- **summary**:    The actor has no permission to conduct the action. 
+ 
+### NoPermissionYet
+- **interface**: `api.errors.convictionVoting.NoPermissionYet.is`
+- **summary**:    The actor has no permission to conduct the action right now but will do in the future. 
+ 
+### NotDelegating
+- **interface**: `api.errors.convictionVoting.NotDelegating.is`
+- **summary**:    The account is not currently delegating. 
+ 
+### NotOngoing
+- **interface**: `api.errors.convictionVoting.NotOngoing.is`
+- **summary**:    Poll is not ongoing. 
+ 
+### NotVoter
+- **interface**: `api.errors.convictionVoting.NotVoter.is`
+- **summary**:    The given account did not vote on the poll. 
+
+___
+
+
+## delegatedStaking
+ 
+### AlreadyStaking
+- **interface**: `api.errors.delegatedStaking.AlreadyStaking.is`
+- **summary**:    An existing staker cannot perform this action. 
+ 
+### BadState
+- **interface**: `api.errors.delegatedStaking.BadState.is`
+- **summary**:    Some corruption in internal state. 
+ 
+### InvalidDelegation
+- **interface**: `api.errors.delegatedStaking.InvalidDelegation.is`
+- **summary**:    Delegation conditions are not met. 
+
+   Possible issues are  1) Cannot delegate to self,  2) Cannot delegate to multiple delegates. 
+ 
+### InvalidRewardDestination
+- **interface**: `api.errors.delegatedStaking.InvalidRewardDestination.is`
+- **summary**:    Reward Destination cannot be same as `Agent` account. 
+ 
+### NotAgent
+- **interface**: `api.errors.delegatedStaking.NotAgent.is`
+- **summary**:    Not an existing `Agent` account. 
+ 
+### NotAllowed
+- **interface**: `api.errors.delegatedStaking.NotAllowed.is`
+- **summary**:    The account cannot perform this operation. 
+ 
+### NotDelegator
+- **interface**: `api.errors.delegatedStaking.NotDelegator.is`
+- **summary**:    Not a Delegator account. 
+ 
+### NotEnoughFunds
+- **interface**: `api.errors.delegatedStaking.NotEnoughFunds.is`
+- **summary**:    The account does not have enough funds to perform the operation. 
+ 
+### NothingToSlash
+- **interface**: `api.errors.delegatedStaking.NothingToSlash.is`
+- **summary**:    `Agent` has no pending slash to be applied. 
+ 
+### NotSupported
+- **interface**: `api.errors.delegatedStaking.NotSupported.is`
+- **summary**:    Operation not supported by this pallet. 
+ 
+### UnappliedSlash
+- **interface**: `api.errors.delegatedStaking.UnappliedSlash.is`
+- **summary**:    Unapplied pending slash restricts operation on `Agent`. 
+ 
+### WithdrawFailed
+- **interface**: `api.errors.delegatedStaking.WithdrawFailed.is`
+- **summary**:    Failed to withdraw amount from Core Staking. 
 
 ___
 
@@ -471,6 +869,31 @@ ___
 ___
 
 
+## indices
+ 
+### InUse
+- **interface**: `api.errors.indices.InUse.is`
+- **summary**:    The index was not available. 
+ 
+### NotAssigned
+- **interface**: `api.errors.indices.NotAssigned.is`
+- **summary**:    The index was not already assigned. 
+ 
+### NotOwner
+- **interface**: `api.errors.indices.NotOwner.is`
+- **summary**:    The index is assigned to another account. 
+ 
+### NotTransfer
+- **interface**: `api.errors.indices.NotTransfer.is`
+- **summary**:    The source and destination accounts are identical. 
+ 
+### Permanent
+- **interface**: `api.errors.indices.Permanent.is`
+- **summary**:    The index is permanent and may not be freed/changed. 
+
+___
+
+
 ## messageQueue
  
 ### AlreadyProcessed
@@ -512,6 +935,73 @@ ___
 - **summary**:    This message is temporarily unprocessable. 
 
    Such errors are expected, but not guaranteed, to resolve themselves eventually through  retrying. 
+
+___
+
+
+## multiBlockElection
+ 
+### Fallback
+- **interface**: `api.errors.multiBlockElection.Fallback.is`
+- **summary**:    Triggering the `Fallback` failed. 
+ 
+### Snapshot
+- **interface**: `api.errors.multiBlockElection.Snapshot.is`
+- **summary**:    Snapshot was unavailable. 
+ 
+### UnexpectedPhase
+- **interface**: `api.errors.multiBlockElection.UnexpectedPhase.is`
+- **summary**:    Unexpected phase 
+
+___
+
+
+## multiBlockElectionSigned
+ 
+### BadPageIndex
+- **interface**: `api.errors.multiBlockElectionSigned.BadPageIndex.is`
+- **summary**:    The page index is out of bounds. 
+ 
+### BadWitnessData
+- **interface**: `api.errors.multiBlockElectionSigned.BadWitnessData.is`
+- **summary**:    Bad witness data provided. 
+ 
+### Duplicate
+- **interface**: `api.errors.multiBlockElectionSigned.Duplicate.is`
+- **summary**:    The submission is a duplicate. 
+ 
+### NoSubmission
+- **interface**: `api.errors.multiBlockElectionSigned.NoSubmission.is`
+- **summary**:    No submission found. 
+ 
+### NotRegistered
+- **interface**: `api.errors.multiBlockElectionSigned.NotRegistered.is`
+- **summary**:    The account is not registered. 
+ 
+### PhaseNotSigned
+- **interface**: `api.errors.multiBlockElectionSigned.PhaseNotSigned.is`
+- **summary**:    The phase is not signed. 
+ 
+### QueueFull
+- **interface**: `api.errors.multiBlockElectionSigned.QueueFull.is`
+- **summary**:    The queue is full. 
+ 
+### RoundNotOver
+- **interface**: `api.errors.multiBlockElectionSigned.RoundNotOver.is`
+- **summary**:    Round is not yet over. 
+ 
+### TooManyInvulnerables
+- **interface**: `api.errors.multiBlockElectionSigned.TooManyInvulnerables.is`
+- **summary**:    Too many invulnerable accounts are provided, 
+
+___
+
+
+## multiBlockMigrations
+ 
+### Ongoing
+- **interface**: `api.errors.multiBlockMigrations.Ongoing.is`
+- **summary**:    The operation cannot complete since some MBMs are ongoing. 
 
 ___
 
@@ -783,6 +1273,165 @@ ___
 ___
 
 
+## nominationPools
+ 
+### AccountBelongsToOtherPool
+- **interface**: `api.errors.nominationPools.AccountBelongsToOtherPool.is`
+- **summary**:    An account is already delegating in another pool. An account may only belong to one  pool at a time. 
+ 
+### AlreadyMigrated
+- **interface**: `api.errors.nominationPools.AlreadyMigrated.is`
+- **summary**:    The pool or member delegation has already migrated to delegate stake. 
+ 
+### BondExtraRestricted
+- **interface**: `api.errors.nominationPools.BondExtraRestricted.is`
+- **summary**:    Bonding extra is restricted to the exact pending reward amount. 
+ 
+### CanNotChangeState
+- **interface**: `api.errors.nominationPools.CanNotChangeState.is`
+- **summary**:    The pools state cannot be changed. 
+ 
+### CannotWithdrawAny
+- **interface**: `api.errors.nominationPools.CannotWithdrawAny.is`
+- **summary**:    None of the funds can be withdrawn yet because the bonding duration has not passed. 
+ 
+### CommissionChangeRateNotAllowed
+- **interface**: `api.errors.nominationPools.CommissionChangeRateNotAllowed.is`
+- **summary**:    The submitted changes to commission change rate are not allowed. 
+ 
+### CommissionChangeThrottled
+- **interface**: `api.errors.nominationPools.CommissionChangeThrottled.is`
+- **summary**:    Not enough blocks have surpassed since the last commission update. 
+ 
+### CommissionExceedsGlobalMaximum
+- **interface**: `api.errors.nominationPools.CommissionExceedsGlobalMaximum.is`
+- **summary**:    The supplied commission exceeds global maximum commission. 
+ 
+### CommissionExceedsMaximum
+- **interface**: `api.errors.nominationPools.CommissionExceedsMaximum.is`
+- **summary**:    The supplied commission exceeds the max allowed commission. 
+ 
+### Defensive
+- **interface**: `api.errors.nominationPools.Defensive.is`
+- **summary**:    Some error occurred that should never happen. This should be reported to the  maintainers. 
+ 
+### DoesNotHavePermission
+- **interface**: `api.errors.nominationPools.DoesNotHavePermission.is`
+- **summary**:    The caller does not have adequate permissions. 
+ 
+### FullyUnbonding
+- **interface**: `api.errors.nominationPools.FullyUnbonding.is`
+- **summary**:    The member is fully unbonded (and thus cannot access the bonded and reward pool  anymore to, for example, collect rewards). 
+ 
+### InvalidPoolId
+- **interface**: `api.errors.nominationPools.InvalidPoolId.is`
+- **summary**:    Pool id provided is not correct/usable. 
+ 
+### MaxCommissionRestricted
+- **interface**: `api.errors.nominationPools.MaxCommissionRestricted.is`
+- **summary**:    The pool's max commission cannot be set higher than the existing value. 
+ 
+### MaxPoolMembers
+- **interface**: `api.errors.nominationPools.MaxPoolMembers.is`
+- **summary**:    Too many members in the pool or system. 
+ 
+### MaxPools
+- **interface**: `api.errors.nominationPools.MaxPools.is`
+- **summary**:    The system is maxed out on pools. 
+ 
+### MaxUnbondingLimit
+- **interface**: `api.errors.nominationPools.MaxUnbondingLimit.is`
+- **summary**:    The member cannot unbond further chunks due to reaching the limit. 
+ 
+### MetadataExceedsMaxLen
+- **interface**: `api.errors.nominationPools.MetadataExceedsMaxLen.is`
+- **summary**:    Metadata exceeds [`Config::MaxMetadataLen`] 
+ 
+### MinimumBondNotMet
+- **interface**: `api.errors.nominationPools.MinimumBondNotMet.is`
+- **summary**:    The amount does not meet the minimum bond to either join or create a pool. 
+
+   The depositor can never unbond to a value less than `Pallet::depositor_min_bond`. The  caller does not have nominating permissions for the pool. Members can never unbond to a  value below `MinJoinBond`. 
+ 
+### NoCommissionCurrentSet
+- **interface**: `api.errors.nominationPools.NoCommissionCurrentSet.is`
+- **summary**:    No commission current has been set. 
+ 
+### NoPendingCommission
+- **interface**: `api.errors.nominationPools.NoPendingCommission.is`
+- **summary**:    There is no pending commission to claim. 
+ 
+### NotDestroying
+- **interface**: `api.errors.nominationPools.NotDestroying.is`
+- **summary**:    A pool must be in [`PoolState::Destroying`] in order for the depositor to unbond or for  other members to be permissionlessly unbonded. 
+ 
+### NothingToAdjust
+- **interface**: `api.errors.nominationPools.NothingToAdjust.is`
+- **summary**:    No imbalance in the ED deposit for the pool. 
+ 
+### NothingToSlash
+- **interface**: `api.errors.nominationPools.NothingToSlash.is`
+- **summary**:    No slash pending that can be applied to the member. 
+ 
+### NotKickerOrDestroying
+- **interface**: `api.errors.nominationPools.NotKickerOrDestroying.is`
+- **summary**:    Either a) the caller cannot make a valid kick or b) the pool is not destroying. 
+ 
+### NotMigrated
+- **interface**: `api.errors.nominationPools.NotMigrated.is`
+- **summary**:    The pool or member delegation has not migrated yet to delegate stake. 
+ 
+### NotNominator
+- **interface**: `api.errors.nominationPools.NotNominator.is`
+- **summary**:    The caller does not have nominating permissions for the pool. 
+ 
+### NotOpen
+- **interface**: `api.errors.nominationPools.NotOpen.is`
+- **summary**:    The pool is not open to join 
+ 
+### NotSupported
+- **interface**: `api.errors.nominationPools.NotSupported.is`
+- **summary**:    This call is not allowed in the current state of the pallet. 
+ 
+### OverflowRisk
+- **interface**: `api.errors.nominationPools.OverflowRisk.is`
+- **summary**:    The transaction could not be executed due to overflow risk for the pool. 
+ 
+### PartialUnbondNotAllowedPermissionlessly
+- **interface**: `api.errors.nominationPools.PartialUnbondNotAllowedPermissionlessly.is`
+- **summary**:    Partial unbonding now allowed permissionlessly. 
+ 
+### PoolIdInUse
+- **interface**: `api.errors.nominationPools.PoolIdInUse.is`
+- **summary**:    Pool id currently in use. 
+ 
+### PoolMemberNotFound
+- **interface**: `api.errors.nominationPools.PoolMemberNotFound.is`
+- **summary**:    An account is not a member. 
+ 
+### PoolNotFound
+- **interface**: `api.errors.nominationPools.PoolNotFound.is`
+- **summary**:    A (bonded) pool id does not exist. 
+ 
+### Restricted
+- **interface**: `api.errors.nominationPools.Restricted.is`
+- **summary**:    Account is restricted from participation in pools. This may happen if the account is  staking in another way already. 
+ 
+### RewardPoolNotFound
+- **interface**: `api.errors.nominationPools.RewardPoolNotFound.is`
+- **summary**:    A reward pool does not exist. In all cases this is a system logic error. 
+ 
+### SlashTooLow
+- **interface**: `api.errors.nominationPools.SlashTooLow.is`
+- **summary**:    The slash amount is too low to be applied. 
+ 
+### SubPoolsNotFound
+- **interface**: `api.errors.nominationPools.SubPoolsNotFound.is`
+- **summary**:    A sub pool does not exist. 
+
+___
+
+
 ## parachainSystem
  
 ### HostConfigurationNotAvailable
@@ -881,6 +1530,10 @@ ___
 ### LocalExecutionIncomplete
 - **interface**: `api.errors.polkadotXcm.LocalExecutionIncomplete.is`
 - **summary**:    Local XCM execution incomplete. 
+ 
+### LocalExecutionIncompleteWithError
+- **interface**: `api.errors.polkadotXcm.LocalExecutionIncompleteWithError.is`
+- **summary**:    Local XCM execution incomplete with the actual XCM error and the index of the  instruction that caused the error. 
  
 ### LockNotFound
 - **interface**: `api.errors.polkadotXcm.LockNotFound.is`
@@ -1022,6 +1675,43 @@ ___
 ___
 
 
+## preimage
+ 
+### AlreadyNoted
+- **interface**: `api.errors.preimage.AlreadyNoted.is`
+- **summary**:    Preimage has already been noted on-chain. 
+ 
+### NotAuthorized
+- **interface**: `api.errors.preimage.NotAuthorized.is`
+- **summary**:    The user is not authorized to perform this action. 
+ 
+### NotNoted
+- **interface**: `api.errors.preimage.NotNoted.is`
+- **summary**:    The preimage cannot be removed since it has not yet been noted. 
+ 
+### NotRequested
+- **interface**: `api.errors.preimage.NotRequested.is`
+- **summary**:    The preimage request cannot be removed since no outstanding requests exist. 
+ 
+### Requested
+- **interface**: `api.errors.preimage.Requested.is`
+- **summary**:    A preimage may not be removed when there are outstanding requests. 
+ 
+### TooBig
+- **interface**: `api.errors.preimage.TooBig.is`
+- **summary**:    Preimage is too large to store on-chain. 
+ 
+### TooFew
+- **interface**: `api.errors.preimage.TooFew.is`
+- **summary**:    Too few hashes were requested to be upgraded (i.e. zero). 
+ 
+### TooMany
+- **interface**: `api.errors.preimage.TooMany.is`
+- **summary**:    More than `MAX_HASH_UPGRADE_BULK_COUNT` hashes were requested to be upgraded at once. 
+
+___
+
+
 ## proxy
  
 ### Duplicate
@@ -1055,6 +1745,136 @@ ___
 ### Unproxyable
 - **interface**: `api.errors.proxy.Unproxyable.is`
 - **summary**:    A call which is incompatible with the proxy type's filter was attempted. 
+
+___
+
+
+## recovery
+ 
+### AlreadyProxy
+- **interface**: `api.errors.recovery.AlreadyProxy.is`
+- **summary**:    This account is already set up for recovery 
+ 
+### AlreadyRecoverable
+- **interface**: `api.errors.recovery.AlreadyRecoverable.is`
+- **summary**:    This account is already set up for recovery 
+ 
+### AlreadyStarted
+- **interface**: `api.errors.recovery.AlreadyStarted.is`
+- **summary**:    A recovery process has already started for this account 
+ 
+### AlreadyVouched
+- **interface**: `api.errors.recovery.AlreadyVouched.is`
+- **summary**:    This user has already vouched for this recovery 
+ 
+### BadState
+- **interface**: `api.errors.recovery.BadState.is`
+- **summary**:    Some internal state is broken. 
+ 
+### DelayPeriod
+- **interface**: `api.errors.recovery.DelayPeriod.is`
+- **summary**:    The friend must wait until the delay period to vouch for this recovery 
+ 
+### MaxFriends
+- **interface**: `api.errors.recovery.MaxFriends.is`
+- **summary**:    Friends list must be less than max friends 
+ 
+### NotAllowed
+- **interface**: `api.errors.recovery.NotAllowed.is`
+- **summary**:    User is not allowed to make a call on behalf of this account 
+ 
+### NotEnoughFriends
+- **interface**: `api.errors.recovery.NotEnoughFriends.is`
+- **summary**:    Friends list must be greater than zero and threshold 
+ 
+### NotFriend
+- **interface**: `api.errors.recovery.NotFriend.is`
+- **summary**:    This account is not a friend who can vouch 
+ 
+### NotRecoverable
+- **interface**: `api.errors.recovery.NotRecoverable.is`
+- **summary**:    This account is not set up for recovery 
+ 
+### NotSorted
+- **interface**: `api.errors.recovery.NotSorted.is`
+- **summary**:    Friends list must be sorted and free of duplicates 
+ 
+### NotStarted
+- **interface**: `api.errors.recovery.NotStarted.is`
+- **summary**:    A recovery process has not started for this rescuer 
+ 
+### StillActive
+- **interface**: `api.errors.recovery.StillActive.is`
+- **summary**:    There are still active recovery attempts that need to be closed 
+ 
+### Threshold
+- **interface**: `api.errors.recovery.Threshold.is`
+- **summary**:    The threshold for recovering this account has not been met 
+ 
+### ZeroThreshold
+- **interface**: `api.errors.recovery.ZeroThreshold.is`
+- **summary**:    Threshold must be greater than zero 
+
+___
+
+
+## referenda
+ 
+### BadReferendum
+- **interface**: `api.errors.referenda.BadReferendum.is`
+- **summary**:    The referendum index provided is invalid in this context. 
+ 
+### BadStatus
+- **interface**: `api.errors.referenda.BadStatus.is`
+- **summary**:    The referendum status is invalid for this operation. 
+ 
+### BadTrack
+- **interface**: `api.errors.referenda.BadTrack.is`
+- **summary**:    The track identifier given was invalid. 
+ 
+### Full
+- **interface**: `api.errors.referenda.Full.is`
+- **summary**:    There are already a full complement of referenda in progress for this track. 
+ 
+### HasDeposit
+- **interface**: `api.errors.referenda.HasDeposit.is`
+- **summary**:    Referendum's decision deposit is already paid. 
+ 
+### NoDeposit
+- **interface**: `api.errors.referenda.NoDeposit.is`
+- **summary**:    The deposit cannot be refunded since none was made. 
+ 
+### NoPermission
+- **interface**: `api.errors.referenda.NoPermission.is`
+- **summary**:    The deposit refunder is not the depositor. 
+ 
+### NothingToDo
+- **interface**: `api.errors.referenda.NothingToDo.is`
+- **summary**:    There was nothing to do in the advancement. 
+ 
+### NotOngoing
+- **interface**: `api.errors.referenda.NotOngoing.is`
+- **summary**:    Referendum is not ongoing. 
+ 
+### NoTrack
+- **interface**: `api.errors.referenda.NoTrack.is`
+- **summary**:    No track exists for the proposal origin. 
+ 
+### PreimageNotExist
+- **interface**: `api.errors.referenda.PreimageNotExist.is`
+- **summary**:    The preimage does not exist. 
+ 
+### PreimageStoredWithDifferentLength
+- **interface**: `api.errors.referenda.PreimageStoredWithDifferentLength.is`
+- **summary**:    The preimage is stored with a different length than the one provided. 
+ 
+### QueueEmpty
+- **interface**: `api.errors.referenda.QueueEmpty.is`
+- **summary**:    The queue of the track is empty. 
+ 
+### Unfinished
+- **interface**: `api.errors.referenda.Unfinished.is`
+- **summary**:    Any deposit cannot be refunded until after the decision is over. 
 
 ___
 
@@ -1116,6 +1936,10 @@ ___
 - **interface**: `api.errors.revive.BlobTooLarge.is`
 - **summary**:    The code blob supplied is larger than [`limits::code::BLOB_BYTES`]. 
  
+### CallDataTooLarge
+- **interface**: `api.errors.revive.CallDataTooLarge.is`
+- **summary**:    The calldata exceeds [`limits::CALLDATA_BYTES`]. 
+ 
 ### CannotAddSelfAsDelegateDependency
 - **interface**: `api.errors.revive.CannotAddSelfAsDelegateDependency.is`
 - **summary**:    Can not add a delegate dependency to the code hash of the contract itself. 
@@ -1149,10 +1973,6 @@ ___
 ### ContractTrapped
 - **interface**: `api.errors.revive.ContractTrapped.is`
 - **summary**:    Contract trapped during execution. 
- 
-### DecimalPrecisionLoss
-- **interface**: `api.errors.revive.DecimalPrecisionLoss.is`
-- **summary**:    Failed to convert an EVM balance to a native balance. 
  
 ### DecodingFailed
 - **interface**: `api.errors.revive.DecodingFailed.is`
@@ -1214,10 +2034,6 @@ ___
 - **interface**: `api.errors.revive.MaxDelegateDependenciesReached.is`
 - **summary**:    The contract has reached its maximum number of delegate dependencies. 
  
-### NoChainExtension
-- **interface**: `api.errors.revive.NoChainExtension.is`
-- **summary**:    The chain does not provide a chain extension. Calling the chain extension results  in this error. Note that this usually  shouldn't happen as deploying such contracts  is rejected. 
- 
 ### OutOfBounds
 - **interface**: `api.errors.revive.OutOfBounds.is`
 - **summary**:    A buffer outside of sandbox memory was passed to a contract API function. 
@@ -1229,10 +2045,6 @@ ___
 ### OutOfTransientStorage
 - **interface**: `api.errors.revive.OutOfTransientStorage.is`
 - **summary**:    Can not add more data to transient storage. 
- 
-### PrecompileFailure
-- **interface**: `api.errors.revive.PrecompileFailure.is`
-- **summary**:    Precompile Error 
  
 ### ReenteredPallet
 - **interface**: `api.errors.revive.ReenteredPallet.is`
@@ -1246,13 +2058,17 @@ ___
 - **interface**: `api.errors.revive.RefcountOverOrUnderflow.is`
 - **summary**:    The refcount of a code either over or underflowed. 
  
+### ReturnDataTooLarge
+- **interface**: `api.errors.revive.ReturnDataTooLarge.is`
+- **summary**:    The return data exceeds [`limits::CALLDATA_BYTES`]. 
+ 
 ### StateChangeDenied
 - **interface**: `api.errors.revive.StateChangeDenied.is`
 - **summary**:    A contract attempted to invoke a state modifying API while being in read-only mode. 
  
 ### StaticMemoryTooLarge
 - **interface**: `api.errors.revive.StaticMemoryTooLarge.is`
-- **summary**:    The static memory consumption of the blob will be larger than  [`limits::code::STATIC_MEMORY_BYTES`]. 
+- **summary**:    The contract declares too much memory (ro + rw + stack). 
  
 ### StorageDepositLimitExhausted
 - **interface**: `api.errors.revive.StorageDepositLimitExhausted.is`
@@ -1282,15 +2098,36 @@ ___
  
 ### UnsupportedPrecompileAddress
 - **interface**: `api.errors.revive.UnsupportedPrecompileAddress.is`
-- **summary**:    Unsupported precompile address 
+- **summary**:    Unsupported precompile address. 
  
 ### ValueTooLarge
 - **interface**: `api.errors.revive.ValueTooLarge.is`
-- **summary**:    The size defined in `T::MaxValueSize` was exceeded. 
+- **summary**:    Event body or storage item exceeds [`limits::PAYLOAD_BYTES`]. 
+
+___
+
+
+## scheduler
  
-### XCMDecodeFailed
-- **interface**: `api.errors.revive.XCMDecodeFailed.is`
-- **summary**:    Failed to decode the XCM program. 
+### FailedToSchedule
+- **interface**: `api.errors.scheduler.FailedToSchedule.is`
+- **summary**:    Failed to schedule a call 
+ 
+### Named
+- **interface**: `api.errors.scheduler.Named.is`
+- **summary**:    Attempt to use a non-named function on a named task. 
+ 
+### NotFound
+- **interface**: `api.errors.scheduler.NotFound.is`
+- **summary**:    Cannot find the scheduled call. 
+ 
+### RescheduleNoChange
+- **interface**: `api.errors.scheduler.RescheduleNoChange.is`
+- **summary**:    Reschedule failed because it does not change scheduled time. 
+ 
+### TargetBlockNumberInPast
+- **interface**: `api.errors.scheduler.TargetBlockNumberInPast.is`
+- **summary**:    Given target block number is in the past. 
 
 ___
 
@@ -1316,6 +2153,292 @@ ___
 ### NoKeys
 - **interface**: `api.errors.session.NoKeys.is`
 - **summary**:    No keys are associated with this account. 
+
+___
+
+
+## society
+ 
+### AlreadyBid
+- **interface**: `api.errors.society.AlreadyBid.is`
+- **summary**:    User has already made a bid. 
+ 
+### AlreadyCandidate
+- **interface**: `api.errors.society.AlreadyCandidate.is`
+- **summary**:    User is already a candidate. 
+ 
+### AlreadyElevated
+- **interface**: `api.errors.society.AlreadyElevated.is`
+- **summary**:    The member is already elevated to this rank. 
+ 
+### AlreadyFounded
+- **interface**: `api.errors.society.AlreadyFounded.is`
+- **summary**:    Society already founded. 
+ 
+### AlreadyMember
+- **interface**: `api.errors.society.AlreadyMember.is`
+- **summary**:    User is already a member. 
+ 
+### AlreadyPunished
+- **interface**: `api.errors.society.AlreadyPunished.is`
+- **summary**:    The skeptic has already been punished for this offence. 
+ 
+### AlreadyVouching
+- **interface**: `api.errors.society.AlreadyVouching.is`
+- **summary**:    Member is already vouching or banned from vouching again. 
+ 
+### Approved
+- **interface**: `api.errors.society.Approved.is`
+- **summary**:    The candidacy cannot be dropped as the candidate was clearly approved. 
+ 
+### Expired
+- **interface**: `api.errors.society.Expired.is`
+- **summary**:    The skeptic need not vote on candidates from expired rounds. 
+ 
+### Founder
+- **interface**: `api.errors.society.Founder.is`
+- **summary**:    Cannot remove the founder. 
+ 
+### Head
+- **interface**: `api.errors.society.Head.is`
+- **summary**:    Cannot remove the head of the chain. 
+ 
+### InProgress
+- **interface**: `api.errors.society.InProgress.is`
+- **summary**:    The candidacy cannot be concluded as the voting is still in progress. 
+ 
+### InsufficientFunds
+- **interface**: `api.errors.society.InsufficientFunds.is`
+- **summary**:    Funds are insufficient to pay off society debts. 
+ 
+### InsufficientPot
+- **interface**: `api.errors.society.InsufficientPot.is`
+- **summary**:    Not enough in pot to accept candidate. 
+ 
+### MaxMembers
+- **interface**: `api.errors.society.MaxMembers.is`
+- **summary**:    Too many members in the society. 
+ 
+### NoDefender
+- **interface**: `api.errors.society.NoDefender.is`
+- **summary**:    There is no defender currently. 
+ 
+### NoDeposit
+- **interface**: `api.errors.society.NoDeposit.is`
+- **summary**:    There is no deposit associated with a bid. 
+ 
+### NoPayout
+- **interface**: `api.errors.society.NoPayout.is`
+- **summary**:    Nothing to payout. 
+ 
+### NotApproved
+- **interface**: `api.errors.society.NotApproved.is`
+- **summary**:    The membership cannot be claimed as the candidate was not clearly approved. 
+ 
+### NotBidder
+- **interface**: `api.errors.society.NotBidder.is`
+- **summary**:    User is not a bidder. 
+ 
+### NotCandidate
+- **interface**: `api.errors.society.NotCandidate.is`
+- **summary**:    User is not a candidate. 
+ 
+### NotFounder
+- **interface**: `api.errors.society.NotFounder.is`
+- **summary**:    The caller is not the founder. 
+ 
+### NotGroup
+- **interface**: `api.errors.society.NotGroup.is`
+- **summary**:    Group doesn't exist. 
+ 
+### NotHead
+- **interface**: `api.errors.society.NotHead.is`
+- **summary**:    The caller is not the head. 
+ 
+### NotMember
+- **interface**: `api.errors.society.NotMember.is`
+- **summary**:    User is not a member. 
+ 
+### NotRejected
+- **interface**: `api.errors.society.NotRejected.is`
+- **summary**:    The candidate cannot be kicked as the candidate was not clearly rejected. 
+ 
+### NotSuspended
+- **interface**: `api.errors.society.NotSuspended.is`
+- **summary**:    User is not suspended. 
+ 
+### NotVouchingOnBidder
+- **interface**: `api.errors.society.NotVouchingOnBidder.is`
+- **summary**:    Member is not vouching. 
+ 
+### NoVotes
+- **interface**: `api.errors.society.NoVotes.is`
+- **summary**:    The candidate/defender has no stale votes to remove. 
+ 
+### Rejected
+- **interface**: `api.errors.society.Rejected.is`
+- **summary**:    The candidacy cannot be bestowed as the candidate was clearly rejected. 
+ 
+### Suspended
+- **interface**: `api.errors.society.Suspended.is`
+- **summary**:    User is suspended. 
+ 
+### TooEarly
+- **interface**: `api.errors.society.TooEarly.is`
+- **summary**:    The candidacy cannot be pruned until a full additional intake period has passed. 
+ 
+### Voted
+- **interface**: `api.errors.society.Voted.is`
+- **summary**:    The skeptic already voted. 
+
+___
+
+
+## staking
+ 
+### AlreadyBonded
+- **interface**: `api.errors.staking.AlreadyBonded.is`
+- **summary**:    Stash is already bonded. 
+ 
+### AlreadyClaimed
+- **interface**: `api.errors.staking.AlreadyClaimed.is`
+- **summary**:    Rewards for this era have already been claimed for this validator. 
+ 
+### AlreadyMigrated
+- **interface**: `api.errors.staking.AlreadyMigrated.is`
+- **summary**:    The stake of this account is already migrated to `Fungible` holds. 
+ 
+### AlreadyPaired
+- **interface**: `api.errors.staking.AlreadyPaired.is`
+- **summary**:    Controller is already paired. 
+ 
+### BadState
+- **interface**: `api.errors.staking.BadState.is`
+- **summary**:    Internal state has become somehow corrupted and the operation cannot continue. 
+ 
+### BadTarget
+- **interface**: `api.errors.staking.BadTarget.is`
+- **summary**:    A nomination target was supplied that was blocked or otherwise not a validator. 
+ 
+### BoundNotMet
+- **interface**: `api.errors.staking.BoundNotMet.is`
+- **summary**:    Some bound is not met. 
+ 
+### CancelledSlash
+- **interface**: `api.errors.staking.CancelledSlash.is`
+- **summary**:    The slash has been cancelled and cannot be applied. 
+ 
+### CannotChillOther
+- **interface**: `api.errors.staking.CannotChillOther.is`
+- **summary**:    The user has enough bond and thus cannot be chilled forcefully by an external person. 
+ 
+### CannotReapStash
+- **interface**: `api.errors.staking.CannotReapStash.is`
+- **summary**:    Stash could not be reaped as other pallet might depend on it. 
+ 
+### CannotRestoreLedger
+- **interface**: `api.errors.staking.CannotRestoreLedger.is`
+- **summary**:    Cannot reset a ledger. 
+ 
+### CommissionTooLow
+- **interface**: `api.errors.staking.CommissionTooLow.is`
+- **summary**:    Commission is too low. Must be at least `MinCommission`. 
+ 
+### ControllerDeprecated
+- **interface**: `api.errors.staking.ControllerDeprecated.is`
+- **summary**:    Used when attempting to use deprecated controller account logic. 
+ 
+### DuplicateIndex
+- **interface**: `api.errors.staking.DuplicateIndex.is`
+- **summary**:    Duplicate index. 
+ 
+### EmptyTargets
+- **interface**: `api.errors.staking.EmptyTargets.is`
+- **summary**:    Targets cannot be empty. 
+ 
+### EraNotPrunable
+- **interface**: `api.errors.staking.EraNotPrunable.is`
+- **summary**:    The era is not eligible for pruning. 
+ 
+### EraNotStarted
+- **interface**: `api.errors.staking.EraNotStarted.is`
+- **summary**:    Era not yet started. 
+ 
+### FundedTarget
+- **interface**: `api.errors.staking.FundedTarget.is`
+- **summary**:    Attempting to target a stash that still has funds. 
+ 
+### IncorrectHistoryDepth
+- **interface**: `api.errors.staking.IncorrectHistoryDepth.is`
+- **summary**:    Incorrect previous history depth input provided. 
+ 
+### InsufficientBond
+- **interface**: `api.errors.staking.InsufficientBond.is`
+- **summary**:    Cannot bond, nominate or validate with value less than the minimum defined by  governance (see `MinValidatorBond` and `MinNominatorBond`). If unbonding is the  intention, `chill` first to remove one's role as validator/nominator. 
+ 
+### InvalidEraToReward
+- **interface**: `api.errors.staking.InvalidEraToReward.is`
+- **summary**:    Invalid era to reward. 
+ 
+### InvalidNumberOfNominations
+- **interface**: `api.errors.staking.InvalidNumberOfNominations.is`
+- **summary**:    Invalid number of nominations. 
+ 
+### InvalidPage
+- **interface**: `api.errors.staking.InvalidPage.is`
+- **summary**:    No nominators exist on this page. 
+ 
+### InvalidSlashRecord
+- **interface**: `api.errors.staking.InvalidSlashRecord.is`
+- **summary**:    Slash record not found. 
+ 
+### NoMoreChunks
+- **interface**: `api.errors.staking.NoMoreChunks.is`
+- **summary**:    Can not schedule more unlock chunks. 
+ 
+### NotController
+- **interface**: `api.errors.staking.NotController.is`
+- **summary**:    Not a controller account. 
+ 
+### NotEnoughFunds
+- **interface**: `api.errors.staking.NotEnoughFunds.is`
+- **summary**:    Not enough funds available to withdraw. 
+ 
+### NotStash
+- **interface**: `api.errors.staking.NotStash.is`
+- **summary**:    Not a stash account. 
+ 
+### NoUnlockChunk
+- **interface**: `api.errors.staking.NoUnlockChunk.is`
+- **summary**:    Can not rebond without unlocking chunks. 
+ 
+### Restricted
+- **interface**: `api.errors.staking.Restricted.is`
+- **summary**:    Account is restricted from participation in staking. This may happen if the account is  staking in another way already, such as via pool. 
+ 
+### RewardDestinationRestricted
+- **interface**: `api.errors.staking.RewardDestinationRestricted.is`
+- **summary**:    Provided reward destination is not allowed. 
+ 
+### TooManyNominators
+- **interface**: `api.errors.staking.TooManyNominators.is`
+- **summary**:    There are too many nominators in the system. Governance needs to adjust the staking  settings to keep things safe for the runtime. 
+ 
+### TooManyTargets
+- **interface**: `api.errors.staking.TooManyTargets.is`
+- **summary**:    Too many nomination targets supplied. 
+ 
+### TooManyValidators
+- **interface**: `api.errors.staking.TooManyValidators.is`
+- **summary**:    There are too many validator candidates in the system. Governance needs to adjust the  staking settings to keep things safe for the runtime. 
+ 
+### UnappliedSlashesInPreviousEra
+- **interface**: `api.errors.staking.UnappliedSlashesInPreviousEra.is`
+- **summary**:    Unapplied slashes in the recently concluded era is blocking this operation.  See `Call::apply_slash` to apply them. 
+ 
+### VirtualStakerNotAllowed
+- **interface**: `api.errors.staking.VirtualStakerNotAllowed.is`
+- **summary**:    Operation not allowed for virtual stakers. 
 
 ___
 
@@ -1357,6 +2480,10 @@ ___
 - **interface**: `api.errors.system.CallFiltered.is`
 - **summary**:    The origin filter prevent the call to be dispatched. 
  
+### FailedTask
+- **interface**: `api.errors.system.FailedTask.is`
+- **summary**:    The specified [`Task`] failed during execution. 
+ 
 ### FailedToExtractRuntimeVersion
 - **interface**: `api.errors.system.FailedToExtractRuntimeVersion.is`
 - **summary**:    Failed to extract the runtime version from the new runtime. 
@@ -1366,6 +2493,10 @@ ___
 ### InvalidSpecName
 - **interface**: `api.errors.system.InvalidSpecName.is`
 - **summary**:    The name of specification does not match between the current runtime  and the new runtime. 
+ 
+### InvalidTask
+- **interface**: `api.errors.system.InvalidTask.is`
+- **summary**:    The specified [`Task`] is not valid. 
  
 ### MultiBlockMigrationsOngoing
 - **interface**: `api.errors.system.MultiBlockMigrationsOngoing.is`
@@ -1394,11 +2525,64 @@ ___
 ___
 
 
+## treasury
+ 
+### AlreadyAttempted
+- **interface**: `api.errors.treasury.AlreadyAttempted.is`
+- **summary**:    The payment has already been attempted. 
+ 
+### EarlyPayout
+- **interface**: `api.errors.treasury.EarlyPayout.is`
+- **summary**:    The spend is not yet eligible for payout. 
+ 
+### FailedToConvertBalance
+- **interface**: `api.errors.treasury.FailedToConvertBalance.is`
+- **summary**:    The balance of the asset kind is not convertible to the balance of the native asset. 
+ 
+### Inconclusive
+- **interface**: `api.errors.treasury.Inconclusive.is`
+- **summary**:    The payment has neither failed nor succeeded yet. 
+ 
+### InsufficientPermission
+- **interface**: `api.errors.treasury.InsufficientPermission.is`
+- **summary**:    The spend origin is valid but the amount it is allowed to spend is lower than the  amount to be spent. 
+ 
+### InvalidIndex
+- **interface**: `api.errors.treasury.InvalidIndex.is`
+- **summary**:    No proposal, bounty or spend at that index. 
+ 
+### NotAttempted
+- **interface**: `api.errors.treasury.NotAttempted.is`
+- **summary**:    The payout was not yet attempted/claimed. 
+ 
+### PayoutError
+- **interface**: `api.errors.treasury.PayoutError.is`
+- **summary**:    There was some issue with the mechanism of payment. 
+ 
+### ProposalNotApproved
+- **interface**: `api.errors.treasury.ProposalNotApproved.is`
+- **summary**:    Proposal has not been approved. 
+ 
+### SpendExpired
+- **interface**: `api.errors.treasury.SpendExpired.is`
+- **summary**:    The spend has expired and cannot be claimed. 
+ 
+### TooManyApprovals
+- **interface**: `api.errors.treasury.TooManyApprovals.is`
+- **summary**:    Too many approvals in the queue. 
+
+___
+
+
 ## uniques
  
 ### AlreadyExists
 - **interface**: `api.errors.uniques.AlreadyExists.is`
 - **summary**:    The item ID has already been used for an item. 
+ 
+### AttributeNotFound
+- **interface**: `api.errors.uniques.AttributeNotFound.is`
+- **summary**:    An attribute is not found. 
  
 ### BadWitness
 - **interface**: `api.errors.uniques.BadWitness.is`
@@ -1436,6 +2620,10 @@ ___
 - **interface**: `api.errors.uniques.NoDelegate.is`
 - **summary**:    There is no delegate approved. 
  
+### NoMetadata
+- **interface**: `api.errors.uniques.NoMetadata.is`
+- **summary**:    No metadata is found. 
+ 
 ### NoPermission
 - **interface**: `api.errors.uniques.NoPermission.is`
 - **summary**:    The signing account has no permission to do the operation. 
@@ -1460,9 +2648,17 @@ ___
 - **interface**: `api.errors.uniques.UnknownItem.is`
 - **summary**:    The given item ID is unknown. 
  
+### WrongAttribute
+- **interface**: `api.errors.uniques.WrongAttribute.is`
+- **summary**:    Wrong attribute key/value bytes supplied. 
+ 
 ### WrongDelegate
 - **interface**: `api.errors.uniques.WrongDelegate.is`
 - **summary**:    The delegate turned out to be different to what was expected. 
+ 
+### WrongMetadata
+- **interface**: `api.errors.uniques.WrongMetadata.is`
+- **summary**:    Wrong metadata key/value bytes supplied. 
  
 ### WrongOwner
 - **interface**: `api.errors.uniques.WrongOwner.is`
@@ -1501,6 +2697,44 @@ ___
 ### ScheduleIndexOutOfBounds
 - **interface**: `api.errors.vesting.ScheduleIndexOutOfBounds.is`
 - **summary**:    An index was out of bounds of the vesting schedules. 
+
+___
+
+
+## voterList
+ 
+### List
+- **interface**: `api.errors.voterList.List.is`
+- **summary**:    A error in the list interface implementation. 
+ 
+### Locked
+- **interface**: `api.errors.voterList.Locked.is`
+- **summary**:    Could not update a node, because the pallet is locked. 
+
+___
+
+
+## whitelist
+ 
+### CallAlreadyWhitelisted
+- **interface**: `api.errors.whitelist.CallAlreadyWhitelisted.is`
+- **summary**:    The call was already whitelisted; No-Op. 
+ 
+### CallIsNotWhitelisted
+- **interface**: `api.errors.whitelist.CallIsNotWhitelisted.is`
+- **summary**:    The call was not whitelisted. 
+ 
+### InvalidCallWeightWitness
+- **interface**: `api.errors.whitelist.InvalidCallWeightWitness.is`
+- **summary**:    The weight of the decoded call was higher than the witness. 
+ 
+### UnavailablePreImage
+- **interface**: `api.errors.whitelist.UnavailablePreImage.is`
+- **summary**:    The preimage of the call hash could not be loaded. 
+ 
+### UndecodableCall
+- **interface**: `api.errors.whitelist.UndecodableCall.is`
+- **summary**:    The call could not be decoded. 
 
 ___
 

--- a/docs/asset-hub-kusama/events.md
+++ b/docs/asset-hub-kusama/events.md
@@ -6,7 +6,13 @@ Events are emitted for certain operations on the runtime. The following sections
 
 (NOTE: These were generated from a static/snapshot view of a recent default asset-hub-kusama runtime. Some items may not be available in older nodes, or in any customized implementations.)
 
+- **[ahMigrator](#ahmigrator)**
+
+- **[ahOps](#ahops)**
+
 - **[assetConversion](#assetconversion)**
+
+- **[assetRate](#assetrate)**
 
 - **[assets](#assets)**
 
@@ -14,13 +20,33 @@ Events are emitted for certain operations on the runtime. The following sections
 
 - **[balances](#balances)**
 
+- **[bounties](#bounties)**
+
+- **[childBounties](#childbounties)**
+
+- **[claims](#claims)**
+
 - **[collatorSelection](#collatorselection)**
+
+- **[convictionVoting](#convictionvoting)**
 
 - **[cumulusXcm](#cumulusxcm)**
 
+- **[delegatedStaking](#delegatedstaking)**
+
 - **[foreignAssets](#foreignassets)**
 
+- **[indices](#indices)**
+
 - **[messageQueue](#messagequeue)**
+
+- **[multiBlockElection](#multiblockelection)**
+
+- **[multiBlockElectionSigned](#multiblockelectionsigned)**
+
+- **[multiBlockElectionVerifier](#multiblockelectionverifier)**
+
+- **[multiBlockMigrations](#multiblockmigrations)**
 
 - **[multisig](#multisig)**
 
@@ -28,17 +54,35 @@ Events are emitted for certain operations on the runtime. The following sections
 
 - **[nfts](#nfts)**
 
+- **[nominationPools](#nominationpools)**
+
 - **[parachainSystem](#parachainsystem)**
+
+- **[parameters](#parameters)**
 
 - **[polkadotXcm](#polkadotxcm)**
 
 - **[poolAssets](#poolassets)**
 
+- **[preimage](#preimage)**
+
 - **[proxy](#proxy)**
+
+- **[recovery](#recovery)**
+
+- **[referenda](#referenda)**
 
 - **[revive](#revive)**
 
+- **[scheduler](#scheduler)**
+
 - **[session](#session)**
+
+- **[society](#society)**
+
+- **[staking](#staking)**
+
+- **[stakingRcClient](#stakingrcclient)**
 
 - **[stateTrieMigration](#statetriemigration)**
 
@@ -48,11 +92,17 @@ Events are emitted for certain operations on the runtime. The following sections
 
 - **[transactionPayment](#transactionpayment)**
 
+- **[treasury](#treasury)**
+
 - **[uniques](#uniques)**
 
 - **[utility](#utility)**
 
 - **[vesting](#vesting)**
+
+- **[voterList](#voterlist)**
+
+- **[whitelist](#whitelist)**
 
 - **[xcmpQueue](#xcmpqueue)**
 
@@ -60,31 +110,125 @@ Events are emitted for certain operations on the runtime. The following sections
 ___
 
 
+## ahMigrator
+ 
+### AccountTranslatedParachainSovereign(`AccountId32`, `AccountId32`)
+- **interface**: `api.events.ahMigrator.AccountTranslatedParachainSovereign.is`
+ 
+### AccountTranslatedParachainSovereignDerived(`AccountId32`, `AccountId32`, `u16`)
+- **interface**: `api.events.ahMigrator.AccountTranslatedParachainSovereignDerived.is`
+ 
+### AssetHubMigrationFinished()
+- **interface**: `api.events.ahMigrator.AssetHubMigrationFinished.is`
+- **summary**:    The Asset Hub Migration finished. 
+
+   This event is equivalent to `StageTransition { new: MigrationDone, .. }` but is easier  to understand. The finishing is immediate and affects all events happening  afterwards. 
+ 
+### AssetHubMigrationStarted()
+- **interface**: `api.events.ahMigrator.AssetHubMigrationStarted.is`
+- **summary**:    The Asset Hub Migration started and is active until `AssetHubMigrationFinished` is  emitted. 
+
+   This event is equivalent to `StageTransition { new: DataMigrationOngoing, .. }` but is  easier to understand. The activation is immediate and affects all events happening  afterwards. 
+ 
+### BalancesBeforeRecordConsumed(`u128`, `u128`)
+- **interface**: `api.events.ahMigrator.BalancesBeforeRecordConsumed.is`
+- **summary**:    The balances before the migration were consumed. 
+ 
+### BalancesBeforeRecordSet(`u128`, `u128`)
+- **interface**: `api.events.ahMigrator.BalancesBeforeRecordSet.is`
+- **summary**:    The balances before the migration were recorded. 
+ 
+### BatchProcessed(`PalletAhMigratorPalletEventName`, `u32`, `u32`)
+- **interface**: `api.events.ahMigrator.BatchProcessed.is`
+- **summary**:    We processed a batch of messages for this pallet. 
+ 
+### BatchReceived(`PalletAhMigratorPalletEventName`, `u32`)
+- **interface**: `api.events.ahMigrator.BatchReceived.is`
+- **summary**:    We received a batch of messages that will be integrated into a pallet. 
+ 
+### DmpQueuePriorityConfigSet(`PalletRcMigratorQueuePriority`, `PalletRcMigratorQueuePriority`)
+- **interface**: `api.events.ahMigrator.DmpQueuePriorityConfigSet.is`
+- **summary**:    The DMP queue priority config was set. 
+ 
+### DmpQueuePrioritySet(`bool`, `u32`, `u32`)
+- **interface**: `api.events.ahMigrator.DmpQueuePrioritySet.is`
+- **summary**:    Whether the DMP queue was prioritized for the next block. 
+ 
+### ManagerSet(`Option<AccountId32>`, `Option<AccountId32>`)
+- **interface**: `api.events.ahMigrator.ManagerSet.is`
+- **summary**:    The manager account id was set. 
+ 
+### ReferendumCanceled(`u32`)
+- **interface**: `api.events.ahMigrator.ReferendumCanceled.is`
+- **summary**:    A referendum was cancelled because it could not be mapped. 
+ 
+### StageTransition(`PalletAhMigratorMigrationStage`, `PalletAhMigratorMigrationStage`)
+- **interface**: `api.events.ahMigrator.StageTransition.is`
+- **summary**:    A stage transition has occurred. 
+ 
+### XcmSent(`StagingXcmV5Location`, `StagingXcmV5Location`, `StagingXcmV5Xcm`, `[u8;32]`)
+- **interface**: `api.events.ahMigrator.XcmSent.is`
+- **summary**:    An XCM message was sent. 
+
+___
+
+
+## ahOps
+ 
+### CrowdloanUnreserveRemaining(`AccountId32`, `u32`, `u128`)
+- **interface**: `api.events.ahOps.CrowdloanUnreserveRemaining.is`
+- **summary**:    Some amount for a crowdloan reserve could not be unreserved and needs manual cleanup. 
+ 
+### LeaseUnreserveRemaining(`AccountId32`, `u32`, `u128`)
+- **interface**: `api.events.ahOps.LeaseUnreserveRemaining.is`
+- **summary**:    Some lease reserve could not be unreserved and needs manual cleanup. 
+ 
+### SovereignMigrated(`u32`, `AccountId32`, `AccountId32`, `Option<u16>`)
+- **interface**: `api.events.ahOps.SovereignMigrated.is`
+- **summary**:    A sovereign parachain account has been migrated from its child to sibling  representation. 
+
+___
+
+
 ## assetConversion
  
-### LiquidityAdded(`AccountId32`, `AccountId32`, `(StagingXcmV4Location,StagingXcmV4Location)`, `u128`, `u128`, `u32`, `u128`)
+### LiquidityAdded(`AccountId32`, `AccountId32`, `(StagingXcmV5Location,StagingXcmV5Location)`, `u128`, `u128`, `u32`, `u128`)
 - **interface**: `api.events.assetConversion.LiquidityAdded.is`
 - **summary**:    A successful call of the `AddLiquidity` extrinsic will create this event. 
  
-### LiquidityRemoved(`AccountId32`, `AccountId32`, `(StagingXcmV4Location,StagingXcmV4Location)`, `u128`, `u128`, `u32`, `u128`, `Permill`)
+### LiquidityRemoved(`AccountId32`, `AccountId32`, `(StagingXcmV5Location,StagingXcmV5Location)`, `u128`, `u128`, `u32`, `u128`, `Permill`)
 - **interface**: `api.events.assetConversion.LiquidityRemoved.is`
 - **summary**:    A successful call of the `RemoveLiquidity` extrinsic will create this event. 
  
-### PoolCreated(`AccountId32`, `(StagingXcmV4Location,StagingXcmV4Location)`, `AccountId32`, `u32`)
+### PoolCreated(`AccountId32`, `(StagingXcmV5Location,StagingXcmV5Location)`, `AccountId32`, `u32`)
 - **interface**: `api.events.assetConversion.PoolCreated.is`
 - **summary**:    A successful call of the `CreatePool` extrinsic will create this event. 
  
-### SwapCreditExecuted(`u128`, `u128`, `Vec<(StagingXcmV4Location,u128)>`)
+### SwapCreditExecuted(`u128`, `u128`, `Vec<(StagingXcmV5Location,u128)>`)
 - **interface**: `api.events.assetConversion.SwapCreditExecuted.is`
 - **summary**:    Assets have been converted from one to another. 
  
-### SwapExecuted(`AccountId32`, `AccountId32`, `u128`, `u128`, `Vec<(StagingXcmV4Location,u128)>`)
+### SwapExecuted(`AccountId32`, `AccountId32`, `u128`, `u128`, `Vec<(StagingXcmV5Location,u128)>`)
 - **interface**: `api.events.assetConversion.SwapExecuted.is`
 - **summary**:    Assets have been converted from one to another. Both `SwapExactTokenForToken`  and `SwapTokenForExactToken` will generate this event. 
  
-### Touched(`(StagingXcmV4Location,StagingXcmV4Location)`, `AccountId32`)
+### Touched(`(StagingXcmV5Location,StagingXcmV5Location)`, `AccountId32`)
 - **interface**: `api.events.assetConversion.Touched.is`
 - **summary**:    Pool has been touched in order to fulfill operational requirements. 
+
+___
+
+
+## assetRate
+ 
+### AssetRateCreated(`PolkadotRuntimeCommonImplsVersionedLocatableAsset`, `u128`)
+- **interface**: `api.events.assetRate.AssetRateCreated.is`
+ 
+### AssetRateRemoved(`PolkadotRuntimeCommonImplsVersionedLocatableAsset`)
+- **interface**: `api.events.assetRate.AssetRateRemoved.is`
+ 
+### AssetRateUpdated(`PolkadotRuntimeCommonImplsVersionedLocatableAsset`, `u128`, `u128`)
+- **interface**: `api.events.assetRate.AssetRateUpdated.is`
 
 ___
 
@@ -204,7 +348,7 @@ ___
 - **interface**: `api.events.assetTxPayment.AssetRefundFailed.is`
 - **summary**:    A swap of the refund in native currency back to asset failed. 
  
-### AssetTxFeePaid(`AccountId32`, `u128`, `u128`, `StagingXcmV4Location`)
+### AssetTxFeePaid(`AccountId32`, `u128`, `u128`, `StagingXcmV5Location`)
 - **interface**: `api.events.assetTxPayment.AssetTxFeePaid.is`
 - **summary**:    A transaction fee `actual_fee`, of which `tip` was added to the minimum inclusion fee,  has been paid by `who` in an asset `asset_id`. 
 
@@ -285,6 +429,10 @@ ___
 - **interface**: `api.events.balances.Transfer.is`
 - **summary**:    Transfer succeeded. 
  
+### Unexpected(`PalletBalancesUnexpectedKind`)
+- **interface**: `api.events.balances.Unexpected.is`
+- **summary**:    An unexpected/defensive event was triggered. 
+ 
 ### Unlocked(`AccountId32`, `u128`)
 - **interface**: `api.events.balances.Unlocked.is`
 - **summary**:    Some balance was unlocked. 
@@ -300,6 +448,89 @@ ___
 ### Withdraw(`AccountId32`, `u128`)
 - **interface**: `api.events.balances.Withdraw.is`
 - **summary**:    Some amount was withdrawn from the account (e.g. for transaction fees). 
+
+___
+
+
+## bounties
+ 
+### BountyApproved(`u32`)
+- **interface**: `api.events.bounties.BountyApproved.is`
+- **summary**:    A bounty is approved. 
+ 
+### BountyAwarded(`u32`, `AccountId32`)
+- **interface**: `api.events.bounties.BountyAwarded.is`
+- **summary**:    A bounty is awarded to a beneficiary. 
+ 
+### BountyBecameActive(`u32`)
+- **interface**: `api.events.bounties.BountyBecameActive.is`
+- **summary**:    A bounty proposal is funded and became active. 
+ 
+### BountyCanceled(`u32`)
+- **interface**: `api.events.bounties.BountyCanceled.is`
+- **summary**:    A bounty is cancelled. 
+ 
+### BountyClaimed(`u32`, `u128`, `AccountId32`)
+- **interface**: `api.events.bounties.BountyClaimed.is`
+- **summary**:    A bounty is claimed by beneficiary. 
+ 
+### BountyExtended(`u32`)
+- **interface**: `api.events.bounties.BountyExtended.is`
+- **summary**:    A bounty expiry is extended. 
+ 
+### BountyProposed(`u32`)
+- **interface**: `api.events.bounties.BountyProposed.is`
+- **summary**:    New bounty proposal. 
+ 
+### BountyRejected(`u32`, `u128`)
+- **interface**: `api.events.bounties.BountyRejected.is`
+- **summary**:    A bounty proposal was rejected; funds were slashed. 
+ 
+### CuratorAccepted(`u32`, `AccountId32`)
+- **interface**: `api.events.bounties.CuratorAccepted.is`
+- **summary**:    A bounty curator is accepted. 
+ 
+### CuratorProposed(`u32`, `AccountId32`)
+- **interface**: `api.events.bounties.CuratorProposed.is`
+- **summary**:    A bounty curator is proposed. 
+ 
+### CuratorUnassigned(`u32`)
+- **interface**: `api.events.bounties.CuratorUnassigned.is`
+- **summary**:    A bounty curator is unassigned. 
+ 
+### DepositPoked(`u32`, `AccountId32`, `u128`, `u128`)
+- **interface**: `api.events.bounties.DepositPoked.is`
+- **summary**:    A bounty deposit has been poked. 
+
+___
+
+
+## childBounties
+ 
+### Added(`u32`, `u32`)
+- **interface**: `api.events.childBounties.Added.is`
+- **summary**:    A child-bounty is added. 
+ 
+### Awarded(`u32`, `u32`, `AccountId32`)
+- **interface**: `api.events.childBounties.Awarded.is`
+- **summary**:    A child-bounty is awarded to a beneficiary. 
+ 
+### Canceled(`u32`, `u32`)
+- **interface**: `api.events.childBounties.Canceled.is`
+- **summary**:    A child-bounty is cancelled. 
+ 
+### Claimed(`u32`, `u32`, `u128`, `AccountId32`)
+- **interface**: `api.events.childBounties.Claimed.is`
+- **summary**:    A child-bounty is claimed by beneficiary. 
+
+___
+
+
+## claims
+ 
+### Claimed(`AccountId32`, `EthereumAddress`, `u128`)
+- **interface**: `api.events.claims.Claimed.is`
+- **summary**:    Someone claimed some DOTs. 
 
 ___
 
@@ -349,6 +580,31 @@ ___
 ___
 
 
+## convictionVoting
+ 
+### Delegated(`AccountId32`, `AccountId32`)
+- **interface**: `api.events.convictionVoting.Delegated.is`
+- **summary**:    An account has delegated their vote to another account. \[who, target\] 
+ 
+### Undelegated(`AccountId32`)
+- **interface**: `api.events.convictionVoting.Undelegated.is`
+- **summary**:    An \[account\] has cancelled a previous delegation operation. 
+ 
+### Voted(`AccountId32`, `PalletConvictionVotingVoteAccountVote`)
+- **interface**: `api.events.convictionVoting.Voted.is`
+- **summary**:    An account has voted 
+ 
+### VoteRemoved(`AccountId32`, `PalletConvictionVotingVoteAccountVote`)
+- **interface**: `api.events.convictionVoting.VoteRemoved.is`
+- **summary**:    A vote has been removed 
+ 
+### VoteUnlocked(`AccountId32`, `u16`)
+- **interface**: `api.events.convictionVoting.VoteUnlocked.is`
+- **summary**:    The lockup period of a conviction vote expired, and the funds have been unlocked. 
+
+___
+
+
 ## cumulusXcm
  
 ### ExecutedDownward(`[u8;32]`, `StagingXcmV5TraitsOutcome`)
@@ -366,111 +622,153 @@ ___
 ___
 
 
+## delegatedStaking
+ 
+### Delegated(`AccountId32`, `AccountId32`, `u128`)
+- **interface**: `api.events.delegatedStaking.Delegated.is`
+- **summary**:    Funds delegated by a delegator. 
+ 
+### MigratedDelegation(`AccountId32`, `AccountId32`, `u128`)
+- **interface**: `api.events.delegatedStaking.MigratedDelegation.is`
+- **summary**:    Unclaimed delegation funds migrated to delegator. 
+ 
+### Released(`AccountId32`, `AccountId32`, `u128`)
+- **interface**: `api.events.delegatedStaking.Released.is`
+- **summary**:    Funds released to a delegator. 
+ 
+### Slashed(`AccountId32`, `AccountId32`, `u128`)
+- **interface**: `api.events.delegatedStaking.Slashed.is`
+- **summary**:    Funds slashed from a delegator. 
+
+___
+
+
 ## foreignAssets
  
-### AccountsDestroyed(`StagingXcmV4Location`, `u32`, `u32`)
+### AccountsDestroyed(`StagingXcmV5Location`, `u32`, `u32`)
 - **interface**: `api.events.foreignAssets.AccountsDestroyed.is`
 - **summary**:    Accounts were destroyed for given asset. 
  
-### ApprovalCancelled(`StagingXcmV4Location`, `AccountId32`, `AccountId32`)
+### ApprovalCancelled(`StagingXcmV5Location`, `AccountId32`, `AccountId32`)
 - **interface**: `api.events.foreignAssets.ApprovalCancelled.is`
 - **summary**:    An approval for account `delegate` was cancelled by `owner`. 
  
-### ApprovalsDestroyed(`StagingXcmV4Location`, `u32`, `u32`)
+### ApprovalsDestroyed(`StagingXcmV5Location`, `u32`, `u32`)
 - **interface**: `api.events.foreignAssets.ApprovalsDestroyed.is`
 - **summary**:    Approvals were destroyed for given asset. 
  
-### ApprovedTransfer(`StagingXcmV4Location`, `AccountId32`, `AccountId32`, `u128`)
+### ApprovedTransfer(`StagingXcmV5Location`, `AccountId32`, `AccountId32`, `u128`)
 - **interface**: `api.events.foreignAssets.ApprovedTransfer.is`
 - **summary**:    (Additional) funds have been approved for transfer to a destination account. 
  
-### AssetFrozen(`StagingXcmV4Location`)
+### AssetFrozen(`StagingXcmV5Location`)
 - **interface**: `api.events.foreignAssets.AssetFrozen.is`
 - **summary**:    Some asset `asset_id` was frozen. 
  
-### AssetMinBalanceChanged(`StagingXcmV4Location`, `u128`)
+### AssetMinBalanceChanged(`StagingXcmV5Location`, `u128`)
 - **interface**: `api.events.foreignAssets.AssetMinBalanceChanged.is`
 - **summary**:    The min_balance of an asset has been updated by the asset owner. 
  
-### AssetStatusChanged(`StagingXcmV4Location`)
+### AssetStatusChanged(`StagingXcmV5Location`)
 - **interface**: `api.events.foreignAssets.AssetStatusChanged.is`
 - **summary**:    An asset has had its attributes changed by the `Force` origin. 
  
-### AssetThawed(`StagingXcmV4Location`)
+### AssetThawed(`StagingXcmV5Location`)
 - **interface**: `api.events.foreignAssets.AssetThawed.is`
 - **summary**:    Some asset `asset_id` was thawed. 
  
-### Blocked(`StagingXcmV4Location`, `AccountId32`)
+### Blocked(`StagingXcmV5Location`, `AccountId32`)
 - **interface**: `api.events.foreignAssets.Blocked.is`
 - **summary**:    Some account `who` was blocked. 
  
-### Burned(`StagingXcmV4Location`, `AccountId32`, `u128`)
+### Burned(`StagingXcmV5Location`, `AccountId32`, `u128`)
 - **interface**: `api.events.foreignAssets.Burned.is`
 - **summary**:    Some assets were destroyed. 
  
-### Created(`StagingXcmV4Location`, `AccountId32`, `AccountId32`)
+### Created(`StagingXcmV5Location`, `AccountId32`, `AccountId32`)
 - **interface**: `api.events.foreignAssets.Created.is`
 - **summary**:    Some asset class was created. 
  
-### Deposited(`StagingXcmV4Location`, `AccountId32`, `u128`)
+### Deposited(`StagingXcmV5Location`, `AccountId32`, `u128`)
 - **interface**: `api.events.foreignAssets.Deposited.is`
 - **summary**:    Some assets were deposited (e.g. for transaction fees). 
  
-### Destroyed(`StagingXcmV4Location`)
+### Destroyed(`StagingXcmV5Location`)
 - **interface**: `api.events.foreignAssets.Destroyed.is`
 - **summary**:    An asset class was destroyed. 
  
-### DestructionStarted(`StagingXcmV4Location`)
+### DestructionStarted(`StagingXcmV5Location`)
 - **interface**: `api.events.foreignAssets.DestructionStarted.is`
 - **summary**:    An asset class is in the process of being destroyed. 
  
-### ForceCreated(`StagingXcmV4Location`, `AccountId32`)
+### ForceCreated(`StagingXcmV5Location`, `AccountId32`)
 - **interface**: `api.events.foreignAssets.ForceCreated.is`
 - **summary**:    Some asset class was force-created. 
  
-### Frozen(`StagingXcmV4Location`, `AccountId32`)
+### Frozen(`StagingXcmV5Location`, `AccountId32`)
 - **interface**: `api.events.foreignAssets.Frozen.is`
 - **summary**:    Some account `who` was frozen. 
  
-### Issued(`StagingXcmV4Location`, `AccountId32`, `u128`)
+### Issued(`StagingXcmV5Location`, `AccountId32`, `u128`)
 - **interface**: `api.events.foreignAssets.Issued.is`
 - **summary**:    Some assets were issued. 
  
-### MetadataCleared(`StagingXcmV4Location`)
+### MetadataCleared(`StagingXcmV5Location`)
 - **interface**: `api.events.foreignAssets.MetadataCleared.is`
 - **summary**:    Metadata has been cleared for an asset. 
  
-### MetadataSet(`StagingXcmV4Location`, `Bytes`, `Bytes`, `u8`, `bool`)
+### MetadataSet(`StagingXcmV5Location`, `Bytes`, `Bytes`, `u8`, `bool`)
 - **interface**: `api.events.foreignAssets.MetadataSet.is`
 - **summary**:    New metadata has been set for an asset. 
  
-### OwnerChanged(`StagingXcmV4Location`, `AccountId32`)
+### OwnerChanged(`StagingXcmV5Location`, `AccountId32`)
 - **interface**: `api.events.foreignAssets.OwnerChanged.is`
 - **summary**:    The owner changed. 
  
-### TeamChanged(`StagingXcmV4Location`, `AccountId32`, `AccountId32`, `AccountId32`)
+### TeamChanged(`StagingXcmV5Location`, `AccountId32`, `AccountId32`, `AccountId32`)
 - **interface**: `api.events.foreignAssets.TeamChanged.is`
 - **summary**:    The management team changed. 
  
-### Thawed(`StagingXcmV4Location`, `AccountId32`)
+### Thawed(`StagingXcmV5Location`, `AccountId32`)
 - **interface**: `api.events.foreignAssets.Thawed.is`
 - **summary**:    Some account `who` was thawed. 
  
-### Touched(`StagingXcmV4Location`, `AccountId32`, `AccountId32`)
+### Touched(`StagingXcmV5Location`, `AccountId32`, `AccountId32`)
 - **interface**: `api.events.foreignAssets.Touched.is`
 - **summary**:    Some account `who` was created with a deposit from `depositor`. 
  
-### Transferred(`StagingXcmV4Location`, `AccountId32`, `AccountId32`, `u128`)
+### Transferred(`StagingXcmV5Location`, `AccountId32`, `AccountId32`, `u128`)
 - **interface**: `api.events.foreignAssets.Transferred.is`
 - **summary**:    Some assets were transferred. 
  
-### TransferredApproved(`StagingXcmV4Location`, `AccountId32`, `AccountId32`, `AccountId32`, `u128`)
+### TransferredApproved(`StagingXcmV5Location`, `AccountId32`, `AccountId32`, `AccountId32`, `u128`)
 - **interface**: `api.events.foreignAssets.TransferredApproved.is`
 - **summary**:    An `amount` was transferred in its entirety from `owner` to `destination` by  the approved `delegate`. 
  
-### Withdrawn(`StagingXcmV4Location`, `AccountId32`, `u128`)
+### Withdrawn(`StagingXcmV5Location`, `AccountId32`, `u128`)
 - **interface**: `api.events.foreignAssets.Withdrawn.is`
 - **summary**:    Some assets were withdrawn from the account (e.g. for transaction fees). 
+
+___
+
+
+## indices
+ 
+### DepositPoked(`AccountId32`, `u32`, `u128`, `u128`)
+- **interface**: `api.events.indices.DepositPoked.is`
+- **summary**:    A deposit to reserve an index has been poked/reconsidered. 
+ 
+### IndexAssigned(`AccountId32`, `u32`)
+- **interface**: `api.events.indices.IndexAssigned.is`
+- **summary**:    A account index was assigned. 
+ 
+### IndexFreed(`u32`)
+- **interface**: `api.events.indices.IndexFreed.is`
+- **summary**:    A account index has been freed up (unassigned). 
+ 
+### IndexFrozen(`u32`, `AccountId32`)
+- **interface**: `api.events.indices.IndexFrozen.is`
+- **summary**:    A account index has been frozen to its current account ID. 
 
 ___
 
@@ -492,6 +790,120 @@ ___
 ### ProcessingFailed(`H256`, `CumulusPrimitivesCoreAggregateMessageOrigin`, `FrameSupportMessagesProcessMessageError`)
 - **interface**: `api.events.messageQueue.ProcessingFailed.is`
 - **summary**:    Message discarded due to an error in the `MessageProcessor` (usually a format error). 
+
+___
+
+
+## multiBlockElection
+ 
+### PhaseTransitioned(`PalletElectionProviderMultiBlockPhase`, `PalletElectionProviderMultiBlockPhase`)
+- **interface**: `api.events.multiBlockElection.PhaseTransitioned.is`
+- **summary**:    A phase transition happened. Only checks major changes in the variants, not minor inner  values. 
+ 
+### UnexpectedTargetSnapshotFailed()
+- **interface**: `api.events.multiBlockElection.UnexpectedTargetSnapshotFailed.is`
+- **summary**:    Target snapshot creation failed 
+ 
+### UnexpectedVoterSnapshotFailed()
+- **interface**: `api.events.multiBlockElection.UnexpectedVoterSnapshotFailed.is`
+- **summary**:    Voter snapshot creation failed 
+
+___
+
+
+## multiBlockElectionSigned
+ 
+### Bailed(`u32`, `AccountId32`)
+- **interface**: `api.events.multiBlockElectionSigned.Bailed.is`
+- **summary**:    The given account has bailed. 
+ 
+### Discarded(`u32`, `AccountId32`)
+- **interface**: `api.events.multiBlockElectionSigned.Discarded.is`
+- **summary**:    The given account has been discarded. 
+ 
+### Ejected(`u32`, `AccountId32`)
+- **interface**: `api.events.multiBlockElectionSigned.Ejected.is`
+- **summary**:    The given solution, for the given round, was ejected. 
+ 
+### Registered(`u32`, `AccountId32`, `SpNposElectionsElectionScore`)
+- **interface**: `api.events.multiBlockElectionSigned.Registered.is`
+- **summary**:    Upcoming submission has been registered for the given account, with the given score. 
+ 
+### Rewarded(`u32`, `AccountId32`, `u128`)
+- **interface**: `api.events.multiBlockElectionSigned.Rewarded.is`
+- **summary**:    The given account has been rewarded with the given amount. 
+ 
+### Slashed(`u32`, `AccountId32`, `u128`)
+- **interface**: `api.events.multiBlockElectionSigned.Slashed.is`
+- **summary**:    The given account has been slashed with the given amount. 
+ 
+### Stored(`u32`, `AccountId32`, `u32`)
+- **interface**: `api.events.multiBlockElectionSigned.Stored.is`
+- **summary**:    A page of solution solution with the given index has been stored for the given account. 
+
+___
+
+
+## multiBlockElectionVerifier
+ 
+### Queued(`SpNposElectionsElectionScore`, `Option<SpNposElectionsElectionScore>`)
+- **interface**: `api.events.multiBlockElectionVerifier.Queued.is`
+- **summary**:    A solution with the given score has replaced our current best solution. 
+ 
+### VerificationFailed(`u32`, `PalletElectionProviderMultiBlockVerifierFeasibilityError`)
+- **interface**: `api.events.multiBlockElectionVerifier.VerificationFailed.is`
+- **summary**:    A verification failed at the given page. 
+
+   NOTE: if the index is 0, then this could mean either the feasibility of the last page  was wrong, or the final checks of `finalize_verification` failed. 
+ 
+### Verified(`u32`, `u32`)
+- **interface**: `api.events.multiBlockElectionVerifier.Verified.is`
+- **summary**:    The given page of a solution has been verified, with the given number of winners being  found in it. 
+
+___
+
+
+## multiBlockMigrations
+ 
+### HistoricCleared(`Option<Bytes>`)
+- **interface**: `api.events.multiBlockMigrations.HistoricCleared.is`
+- **summary**:    The set of historical migrations has been cleared. 
+ 
+### MigrationAdvanced(`u32`, `u32`)
+- **interface**: `api.events.multiBlockMigrations.MigrationAdvanced.is`
+- **summary**:    A migration progressed. 
+ 
+### MigrationCompleted(`u32`, `u32`)
+- **interface**: `api.events.multiBlockMigrations.MigrationCompleted.is`
+- **summary**:    A Migration completed. 
+ 
+### MigrationFailed(`u32`, `u32`)
+- **interface**: `api.events.multiBlockMigrations.MigrationFailed.is`
+- **summary**:    A Migration failed. 
+
+   This implies that the whole upgrade failed and governance intervention is required. 
+ 
+### MigrationSkipped(`u32`)
+- **interface**: `api.events.multiBlockMigrations.MigrationSkipped.is`
+- **summary**:    A migration was skipped since it was already executed in the past. 
+ 
+### UpgradeCompleted()
+- **interface**: `api.events.multiBlockMigrations.UpgradeCompleted.is`
+- **summary**:    The current runtime upgrade completed. 
+
+   This implies that all of its migrations completed successfully as well. 
+ 
+### UpgradeFailed()
+- **interface**: `api.events.multiBlockMigrations.UpgradeFailed.is`
+- **summary**:    Runtime upgrade failed. 
+
+   This is very bad and will require governance intervention. 
+ 
+### UpgradeStarted(`u32`)
+- **interface**: `api.events.multiBlockMigrations.UpgradeStarted.is`
+- **summary**:    A Runtime upgrade started. 
+
+   Its end is indicated by `UpgradeCompleted` or `UpgradeFailed`. 
 
 ___
 
@@ -691,6 +1103,115 @@ ___
 ___
 
 
+## nominationPools
+ 
+### Bonded(`AccountId32`, `u32`, `u128`, `bool`)
+- **interface**: `api.events.nominationPools.Bonded.is`
+- **summary**:    A member has became bonded in a pool. 
+ 
+### Created(`AccountId32`, `u32`)
+- **interface**: `api.events.nominationPools.Created.is`
+- **summary**:    A pool has been created. 
+ 
+### Destroyed(`u32`)
+- **interface**: `api.events.nominationPools.Destroyed.is`
+- **summary**:    A pool has been destroyed. 
+ 
+### GlobalParamsUpdated(`u128`, `u128`, `Option<u32>`, `Option<u32>`, `Option<u32>`, `Option<Perbill>`)
+- **interface**: `api.events.nominationPools.GlobalParamsUpdated.is`
+- **summary**:    Global parameters regulating nomination pools have been updated. 
+ 
+### MemberClaimPermissionUpdated(`AccountId32`, `PalletNominationPoolsClaimPermission`)
+- **interface**: `api.events.nominationPools.MemberClaimPermissionUpdated.is`
+- **summary**:    A pool member's claim permission has been updated. 
+ 
+### MemberRemoved(`u32`, `AccountId32`, `u128`)
+- **interface**: `api.events.nominationPools.MemberRemoved.is`
+- **summary**:    A member has been removed from a pool. 
+
+   The removal can be voluntary (withdrawn all unbonded funds) or involuntary (kicked).  Any funds that are still delegated (i.e. dangling delegation) are released and are  represented by `released_balance`. 
+ 
+### MetadataUpdated(`u32`, `AccountId32`)
+- **interface**: `api.events.nominationPools.MetadataUpdated.is`
+- **summary**:    A pool's metadata was updated. 
+ 
+### MinBalanceDeficitAdjusted(`u32`, `u128`)
+- **interface**: `api.events.nominationPools.MinBalanceDeficitAdjusted.is`
+- **summary**:    Topped up deficit in frozen ED of the reward pool. 
+ 
+### MinBalanceExcessAdjusted(`u32`, `u128`)
+- **interface**: `api.events.nominationPools.MinBalanceExcessAdjusted.is`
+- **summary**:    Claimed excess frozen ED of af the reward pool. 
+ 
+### PaidOut(`AccountId32`, `u32`, `u128`)
+- **interface**: `api.events.nominationPools.PaidOut.is`
+- **summary**:    A payout has been made to a member. 
+ 
+### PoolCommissionChangeRateUpdated(`u32`, `PalletNominationPoolsCommissionChangeRate`)
+- **interface**: `api.events.nominationPools.PoolCommissionChangeRateUpdated.is`
+- **summary**:    A pool's commission `change_rate` has been changed. 
+ 
+### PoolCommissionClaimed(`u32`, `u128`)
+- **interface**: `api.events.nominationPools.PoolCommissionClaimed.is`
+- **summary**:    Pool commission has been claimed. 
+ 
+### PoolCommissionClaimPermissionUpdated(`u32`, `Option<PalletNominationPoolsCommissionClaimPermission>`)
+- **interface**: `api.events.nominationPools.PoolCommissionClaimPermissionUpdated.is`
+- **summary**:    Pool commission claim permission has been updated. 
+ 
+### PoolCommissionUpdated(`u32`, `Option<(Perbill,AccountId32)>`)
+- **interface**: `api.events.nominationPools.PoolCommissionUpdated.is`
+- **summary**:    A pool's commission setting has been changed. 
+ 
+### PoolMaxCommissionUpdated(`u32`, `Perbill`)
+- **interface**: `api.events.nominationPools.PoolMaxCommissionUpdated.is`
+- **summary**:    A pool's maximum commission setting has been changed. 
+ 
+### PoolNominationMade(`u32`, `AccountId32`)
+- **interface**: `api.events.nominationPools.PoolNominationMade.is`
+- **summary**:    A pool's nominating account (or the pool's root account) has nominated a validator set  on behalf of the pool. 
+ 
+### PoolNominatorChilled(`u32`, `AccountId32`)
+- **interface**: `api.events.nominationPools.PoolNominatorChilled.is`
+- **summary**:    The pool is chilled i.e. no longer nominating. 
+ 
+### PoolSlashed(`u32`, `u128`)
+- **interface**: `api.events.nominationPools.PoolSlashed.is`
+- **summary**:    The active balance of pool `pool_id` has been slashed to `balance`. 
+ 
+### RolesUpdated(`Option<AccountId32>`, `Option<AccountId32>`, `Option<AccountId32>`)
+- **interface**: `api.events.nominationPools.RolesUpdated.is`
+- **summary**:    The roles of a pool have been updated to the given new roles. Note that the depositor  can never change. 
+ 
+### StateChanged(`u32`, `PalletNominationPoolsPoolState`)
+- **interface**: `api.events.nominationPools.StateChanged.is`
+- **summary**:    The state of a pool has changed 
+ 
+### Unbonded(`AccountId32`, `u32`, `u128`, `u128`, `u32`)
+- **interface**: `api.events.nominationPools.Unbonded.is`
+- **summary**:    A member has unbonded from their pool. 
+
+   - `balance` is the corresponding balance of the number of points that has been  requested to be unbonded (the argument of the `unbond` transaction) from the bonded  pool. 
+
+  - `points` is the number of points that are issued as a result of `balance` being dissolved into the corresponding unbonding pool. 
+
+  - `era` is the era in which the balance will be unbonded. In the absence of slashing, these values will match. In the presence of slashing, the  number of points that are issued in the unbonding pool will be less than the amount  requested to be unbonded. 
+ 
+### UnbondingPoolSlashed(`u32`, `u32`, `u128`)
+- **interface**: `api.events.nominationPools.UnbondingPoolSlashed.is`
+- **summary**:    The unbond pool at `era` of pool `pool_id` has been slashed to `balance`. 
+ 
+### Withdrawn(`AccountId32`, `u32`, `u128`, `u128`)
+- **interface**: `api.events.nominationPools.Withdrawn.is`
+- **summary**:    A member has withdrawn from their pool. 
+
+   The given number of `points` have been dissolved in return of `balance`. 
+
+   Similar to `Unbonded` event, in the absence of slashing, the ratio of point to balance  will be 1. 
+
+___
+
+
 ## parachainSystem
  
 ### DownwardMessagesProcessed(`SpWeightsWeightV2Weight`, `H256`)
@@ -716,6 +1237,17 @@ ___
 ### ValidationFunctionStored()
 - **interface**: `api.events.parachainSystem.ValidationFunctionStored.is`
 - **summary**:    The validation function has been scheduled to apply. 
+
+___
+
+
+## parameters
+ 
+### Updated(`AssetHubKusamaRuntimeRuntimeParametersKey`, `Option<AssetHubKusamaRuntimeRuntimeParametersValue>`, `Option<AssetHubKusamaRuntimeRuntimeParametersValue>`)
+- **interface**: `api.events.parameters.Updated.is`
+- **summary**:    A Parameter was set. 
+
+   Is also emitted when the value was not changed. 
 
 ___
 
@@ -956,6 +1488,23 @@ ___
 ___
 
 
+## preimage
+ 
+### Cleared(`H256`)
+- **interface**: `api.events.preimage.Cleared.is`
+- **summary**:    A preimage has ben cleared. 
+ 
+### Noted(`H256`)
+- **interface**: `api.events.preimage.Noted.is`
+- **summary**:    A preimage has been noted. 
+ 
+### Requested(`H256`)
+- **interface**: `api.events.preimage.Requested.is`
+- **summary**:    A preimage has been requested. 
+
+___
+
+
 ## proxy
  
 ### Announced(`AccountId32`, `AccountId32`, `H256`)
@@ -981,6 +1530,110 @@ ___
 ### PureCreated(`AccountId32`, `AccountId32`, `AssetHubKusamaRuntimeProxyType`, `u16`)
 - **interface**: `api.events.proxy.PureCreated.is`
 - **summary**:    A pure account has been created by new proxy with given  disambiguation index and proxy type. 
+ 
+### PureKilled(`AccountId32`, `AccountId32`, `AssetHubKusamaRuntimeProxyType`, `u16`)
+- **interface**: `api.events.proxy.PureKilled.is`
+- **summary**:    A pure proxy was killed by its spawner. 
+
+___
+
+
+## recovery
+ 
+### AccountRecovered(`AccountId32`, `AccountId32`)
+- **interface**: `api.events.recovery.AccountRecovered.is`
+- **summary**:    Lost account has been successfully recovered by rescuer account. 
+ 
+### DepositPoked(`AccountId32`, `PalletRecoveryDepositKind`, `u128`, `u128`)
+- **interface**: `api.events.recovery.DepositPoked.is`
+- **summary**:    A deposit has been updated. 
+ 
+### RecoveryClosed(`AccountId32`, `AccountId32`)
+- **interface**: `api.events.recovery.RecoveryClosed.is`
+- **summary**:    A recovery process for lost account by rescuer account has been closed. 
+ 
+### RecoveryCreated(`AccountId32`)
+- **interface**: `api.events.recovery.RecoveryCreated.is`
+- **summary**:    A recovery process has been set up for an account. 
+ 
+### RecoveryInitiated(`AccountId32`, `AccountId32`)
+- **interface**: `api.events.recovery.RecoveryInitiated.is`
+- **summary**:    A recovery process has been initiated for lost account by rescuer account. 
+ 
+### RecoveryRemoved(`AccountId32`)
+- **interface**: `api.events.recovery.RecoveryRemoved.is`
+- **summary**:    A recovery process has been removed for an account. 
+ 
+### RecoveryVouched(`AccountId32`, `AccountId32`, `AccountId32`)
+- **interface**: `api.events.recovery.RecoveryVouched.is`
+- **summary**:    A recovery process for lost account by rescuer account has been vouched for by sender. 
+
+___
+
+
+## referenda
+ 
+### Approved(`u32`)
+- **interface**: `api.events.referenda.Approved.is`
+- **summary**:    A referendum has been approved and its proposal has been scheduled. 
+ 
+### Cancelled(`u32`, `PalletConvictionVotingTally`)
+- **interface**: `api.events.referenda.Cancelled.is`
+- **summary**:    A referendum has been cancelled. 
+ 
+### ConfirmAborted(`u32`)
+- **interface**: `api.events.referenda.ConfirmAborted.is`
+ 
+### Confirmed(`u32`, `PalletConvictionVotingTally`)
+- **interface**: `api.events.referenda.Confirmed.is`
+- **summary**:    A referendum has ended its confirmation phase and is ready for approval. 
+ 
+### ConfirmStarted(`u32`)
+- **interface**: `api.events.referenda.ConfirmStarted.is`
+ 
+### DecisionDepositPlaced(`u32`, `AccountId32`, `u128`)
+- **interface**: `api.events.referenda.DecisionDepositPlaced.is`
+- **summary**:    The decision deposit has been placed. 
+ 
+### DecisionDepositRefunded(`u32`, `AccountId32`, `u128`)
+- **interface**: `api.events.referenda.DecisionDepositRefunded.is`
+- **summary**:    The decision deposit has been refunded. 
+ 
+### DecisionStarted(`u32`, `u16`, `FrameSupportPreimagesBounded`, `PalletConvictionVotingTally`)
+- **interface**: `api.events.referenda.DecisionStarted.is`
+- **summary**:    A referendum has moved into the deciding phase. 
+ 
+### DepositSlashed(`AccountId32`, `u128`)
+- **interface**: `api.events.referenda.DepositSlashed.is`
+- **summary**:    A deposit has been slashed. 
+ 
+### Killed(`u32`, `PalletConvictionVotingTally`)
+- **interface**: `api.events.referenda.Killed.is`
+- **summary**:    A referendum has been killed. 
+ 
+### MetadataCleared(`u32`, `H256`)
+- **interface**: `api.events.referenda.MetadataCleared.is`
+- **summary**:    Metadata for a referendum has been cleared. 
+ 
+### MetadataSet(`u32`, `H256`)
+- **interface**: `api.events.referenda.MetadataSet.is`
+- **summary**:    Metadata for a referendum has been set. 
+ 
+### Rejected(`u32`, `PalletConvictionVotingTally`)
+- **interface**: `api.events.referenda.Rejected.is`
+- **summary**:    A proposal has been rejected by referendum. 
+ 
+### SubmissionDepositRefunded(`u32`, `AccountId32`, `u128`)
+- **interface**: `api.events.referenda.SubmissionDepositRefunded.is`
+- **summary**:    The submission deposit has been refunded. 
+ 
+### Submitted(`u32`, `u16`, `FrameSupportPreimagesBounded`)
+- **interface**: `api.events.referenda.Submitted.is`
+- **summary**:    A referendum has been submitted. 
+ 
+### TimedOut(`u32`, `PalletConvictionVotingTally`)
+- **interface**: `api.events.referenda.TimedOut.is`
+- **summary**:    A referendum has been timed out without being decided. 
 
 ___
 
@@ -990,11 +1643,64 @@ ___
 ### ContractEmitted(`H160`, `Bytes`, `Vec<H256>`)
 - **interface**: `api.events.revive.ContractEmitted.is`
 - **summary**:    A custom event emitted by the contract. 
+ 
+### Instantiated(`H160`, `H160`)
+- **interface**: `api.events.revive.Instantiated.is`
+- **summary**:    Contract deployed by deployer at the specified address. 
+
+___
+
+
+## scheduler
+ 
+### AgendaIncomplete(`u32`)
+- **interface**: `api.events.scheduler.AgendaIncomplete.is`
+- **summary**:    Agenda is incomplete from `when`. 
+ 
+### CallUnavailable(`(u32,u32)`, `Option<[u8;32]>`)
+- **interface**: `api.events.scheduler.CallUnavailable.is`
+- **summary**:    The call for the provided hash was not found so the task has been aborted. 
+ 
+### Canceled(`u32`, `u32`)
+- **interface**: `api.events.scheduler.Canceled.is`
+- **summary**:    Canceled some task. 
+ 
+### Dispatched(`(u32,u32)`, `Option<[u8;32]>`, `Result<Null, SpRuntimeDispatchError>`)
+- **interface**: `api.events.scheduler.Dispatched.is`
+- **summary**:    Dispatched some task. 
+ 
+### PeriodicFailed(`(u32,u32)`, `Option<[u8;32]>`)
+- **interface**: `api.events.scheduler.PeriodicFailed.is`
+- **summary**:    The given task was unable to be renewed since the agenda is full at that block. 
+ 
+### PermanentlyOverweight(`(u32,u32)`, `Option<[u8;32]>`)
+- **interface**: `api.events.scheduler.PermanentlyOverweight.is`
+- **summary**:    The given task can never be executed since it is overweight. 
+ 
+### RetryCancelled(`(u32,u32)`, `Option<[u8;32]>`)
+- **interface**: `api.events.scheduler.RetryCancelled.is`
+- **summary**:    Cancel a retry configuration for some task. 
+ 
+### RetryFailed(`(u32,u32)`, `Option<[u8;32]>`)
+- **interface**: `api.events.scheduler.RetryFailed.is`
+- **summary**:    The given task was unable to be retried since the agenda is full at that block or there  was not enough weight to reschedule it. 
+ 
+### RetrySet(`(u32,u32)`, `Option<[u8;32]>`, `u32`, `u8`)
+- **interface**: `api.events.scheduler.RetrySet.is`
+- **summary**:    Set a retry configuration for some task. 
+ 
+### Scheduled(`u32`, `u32`)
+- **interface**: `api.events.scheduler.Scheduled.is`
+- **summary**:    Scheduled some task. 
 
 ___
 
 
 ## session
+ 
+### NewQueued()
+- **interface**: `api.events.session.NewQueued.is`
+- **summary**:    The `NewSession` event in the current block also implies a new validator set to be  queued. 
  
 ### NewSession(`u32`)
 - **interface**: `api.events.session.NewSession.is`
@@ -1007,6 +1713,212 @@ ___
 ### ValidatorReenabled(`AccountId32`)
 - **interface**: `api.events.session.ValidatorReenabled.is`
 - **summary**:    Validator has been re-enabled. 
+
+___
+
+
+## society
+ 
+### AutoUnbid(`AccountId32`)
+- **interface**: `api.events.society.AutoUnbid.is`
+- **summary**:    A candidate was dropped (due to an excess of bids in the system). 
+ 
+### Bid(`AccountId32`, `u128`)
+- **interface**: `api.events.society.Bid.is`
+- **summary**:    A membership bid just happened. The given account is the candidate's ID and their offer  is the second. 
+ 
+### CandidateSuspended(`AccountId32`)
+- **interface**: `api.events.society.CandidateSuspended.is`
+- **summary**:    A candidate has been suspended 
+ 
+### Challenged(`AccountId32`)
+- **interface**: `api.events.society.Challenged.is`
+- **summary**:    A member has been challenged 
+ 
+### DefenderVote(`AccountId32`, `bool`)
+- **interface**: `api.events.society.DefenderVote.is`
+- **summary**:    A vote has been placed for a defending member 
+ 
+### Deposit(`u128`)
+- **interface**: `api.events.society.Deposit.is`
+- **summary**:    Some funds were deposited into the society account. 
+ 
+### DepositPoked(`AccountId32`, `u128`, `u128`)
+- **interface**: `api.events.society.DepositPoked.is`
+- **summary**:    A deposit was poked / adjusted. 
+ 
+### Elevated(`AccountId32`, `u32`)
+- **interface**: `api.events.society.Elevated.is`
+- **summary**:    A \[member\] got elevated to \[rank\]. 
+ 
+### Founded(`AccountId32`)
+- **interface**: `api.events.society.Founded.is`
+- **summary**:    The society is founded by the given identity. 
+ 
+### Inducted(`AccountId32`, `Vec<AccountId32>`)
+- **interface**: `api.events.society.Inducted.is`
+- **summary**:    A group of candidates have been inducted. The batch's primary is the first value, the  batch in full is the second. 
+ 
+### MemberSuspended(`AccountId32`)
+- **interface**: `api.events.society.MemberSuspended.is`
+- **summary**:    A member has been suspended 
+ 
+### NewParams(`PalletSocietyGroupParams`)
+- **interface**: `api.events.society.NewParams.is`
+- **summary**:    A new set of \[params\] has been set for the group. 
+ 
+### SuspendedMemberJudgement(`AccountId32`, `bool`)
+- **interface**: `api.events.society.SuspendedMemberJudgement.is`
+- **summary**:    A suspended member has been judged. 
+ 
+### Unbid(`AccountId32`)
+- **interface**: `api.events.society.Unbid.is`
+- **summary**:    A candidate was dropped (by their request). 
+ 
+### Unfounded(`AccountId32`)
+- **interface**: `api.events.society.Unfounded.is`
+- **summary**:    Society is unfounded. 
+ 
+### Unvouch(`AccountId32`)
+- **interface**: `api.events.society.Unvouch.is`
+- **summary**:    A candidate was dropped (by request of who vouched for them). 
+ 
+### Vote(`AccountId32`, `AccountId32`, `bool`)
+- **interface**: `api.events.society.Vote.is`
+- **summary**:    A vote has been placed 
+ 
+### Vouch(`AccountId32`, `u128`, `AccountId32`)
+- **interface**: `api.events.society.Vouch.is`
+- **summary**:    A membership bid just happened by vouching. The given account is the candidate's ID and  their offer is the second. The vouching party is the third. 
+
+___
+
+
+## staking
+ 
+### Bonded(`AccountId32`, `u128`)
+- **interface**: `api.events.staking.Bonded.is`
+- **summary**:    An account has bonded this amount. \[stash, amount\] 
+
+   NOTE: This event is only emitted when funds are bonded via a dispatchable. Notably,  it will not be emitted for staking rewards when they are added to stake. 
+ 
+### Chilled(`AccountId32`)
+- **interface**: `api.events.staking.Chilled.is`
+- **summary**:    An account has stopped participating as either a validator or nominator. 
+ 
+### ControllerBatchDeprecated(`u32`)
+- **interface**: `api.events.staking.ControllerBatchDeprecated.is`
+- **summary**:    Report of a controller batch deprecation. 
+ 
+### CurrencyMigrated(`AccountId32`, `u128`)
+- **interface**: `api.events.staking.CurrencyMigrated.is`
+- **summary**:    Staking balance migrated from locks to holds, with any balance that could not be held  is force withdrawn. 
+ 
+### EraPaid(`u32`, `u128`, `u128`)
+- **interface**: `api.events.staking.EraPaid.is`
+- **summary**:    The era payout has been set; the first balance is the validator-payout; the second is  the remainder from the maximum amount of reward. 
+ 
+### EraPruned(`u32`)
+- **interface**: `api.events.staking.EraPruned.is`
+- **summary**:    An old era with the given index was pruned. 
+ 
+### ForceEra(`PalletStakingAsyncForcing`)
+- **interface**: `api.events.staking.ForceEra.is`
+ 
+### Kicked(`AccountId32`, `AccountId32`)
+- **interface**: `api.events.staking.Kicked.is`
+- **summary**:    A nominator has been kicked from a validator. 
+ 
+### OffenceReported(`u32`, `AccountId32`, `Perbill`)
+- **interface**: `api.events.staking.OffenceReported.is`
+- **summary**:    An offence for the given validator, for the given percentage of their stake, at the  given era as been reported. 
+ 
+### OffenceTooOld(`u32`, `AccountId32`, `Perbill`)
+- **interface**: `api.events.staking.OffenceTooOld.is`
+- **summary**:    An offence was reported that was too old to be processed, and thus was dropped. 
+ 
+### OldSlashingReportDiscarded(`u32`)
+- **interface**: `api.events.staking.OldSlashingReportDiscarded.is`
+- **summary**:    An old slashing report from a prior era was discarded because it could  not be processed. 
+ 
+### PagedElectionProceeded(`u32`, `Result<u32, u32>`)
+- **interface**: `api.events.staking.PagedElectionProceeded.is`
+- **summary**:    A page from a multi-page election was fetched. A number of these are followed by  `StakersElected`. 
+
+   `Ok(count)` indicates the give number of stashes were added.  `Err(index)` indicates that the stashes after index were dropped.  `Err(0)` indicates that an error happened but no stashes were dropped nor added. 
+
+   The error indicates that a number of validators were dropped due to excess size, but  the overall election will continue. 
+ 
+### PayoutStarted(`u32`, `AccountId32`, `u32`, `Option<u32>`)
+- **interface**: `api.events.staking.PayoutStarted.is`
+- **summary**:    A Page of stakers rewards are getting paid. `next` is `None` if all pages are claimed. 
+ 
+### Rewarded(`AccountId32`, `PalletStakingAsyncRewardDestination`, `u128`)
+- **interface**: `api.events.staking.Rewarded.is`
+- **summary**:    The nominator has been rewarded by this amount to this destination. 
+ 
+### SessionRotated(`u32`, `u32`, `u32`)
+- **interface**: `api.events.staking.SessionRotated.is`
+- **summary**:    Session change has been triggered. 
+
+   If planned_era is one era ahead of active_era, it implies new era is being planned and  election is ongoing. 
+ 
+### SlashCancelled(`u32`, `AccountId32`)
+- **interface**: `api.events.staking.SlashCancelled.is`
+- **summary**:    An unapplied slash has been cancelled. 
+ 
+### SlashComputed(`u32`, `u32`, `AccountId32`, `u32`)
+- **interface**: `api.events.staking.SlashComputed.is`
+- **summary**:    An offence has been processed and the corresponding slash has been computed. 
+ 
+### Slashed(`AccountId32`, `u128`)
+- **interface**: `api.events.staking.Slashed.is`
+- **summary**:    A staker (validator or nominator) has been slashed by the given amount. 
+ 
+### SnapshotTargetsSizeExceeded(`u32`)
+- **interface**: `api.events.staking.SnapshotTargetsSizeExceeded.is`
+- **summary**:    Targets size limit reached. 
+ 
+### SnapshotVotersSizeExceeded(`u32`)
+- **interface**: `api.events.staking.SnapshotVotersSizeExceeded.is`
+- **summary**:    Voters size limit reached. 
+ 
+### StakerRemoved(`AccountId32`)
+- **interface**: `api.events.staking.StakerRemoved.is`
+- **summary**:    A subsequent event of `Withdrawn`, indicating that `stash` was fully removed from the  system. 
+ 
+### Unbonded(`AccountId32`, `u128`)
+- **interface**: `api.events.staking.Unbonded.is`
+- **summary**:    An account has unbonded this amount. 
+ 
+### Unexpected(`PalletStakingAsyncPalletUnexpectedKind`)
+- **interface**: `api.events.staking.Unexpected.is`
+- **summary**:    Something occurred that should never happen under normal operation.  Logged as an event for fail-safe observability. 
+ 
+### ValidatorPrefsSet(`AccountId32`, `PalletStakingAsyncValidatorPrefs`)
+- **interface**: `api.events.staking.ValidatorPrefsSet.is`
+- **summary**:    A validator has set their preferences. 
+ 
+### Withdrawn(`AccountId32`, `u128`)
+- **interface**: `api.events.staking.Withdrawn.is`
+- **summary**:    An account has called `withdraw_unbonded` and removed unbonding chunks worth `Balance`  from the unlocking queue. 
+
+___
+
+
+## stakingRcClient
+ 
+### OffenceReceived(`u32`, `u32`)
+- **interface**: `api.events.stakingRcClient.OffenceReceived.is`
+- **summary**:    A new offence was reported. 
+ 
+### SessionReportReceived(`u32`, `Option<(u64,u32)>`, `u32`, `bool`)
+- **interface**: `api.events.stakingRcClient.SessionReportReceived.is`
+- **summary**:    A said session report was received. 
+ 
+### Unexpected(`PalletStakingAsyncRcClientUnexpectedKind`)
+- **interface**: `api.events.stakingRcClient.Unexpected.is`
+- **summary**:    Something occurred that should never happen under normal operation.  Logged as an event for fail-safe observability. 
 
 ___
 
@@ -1062,6 +1974,18 @@ ___
 - **interface**: `api.events.system.Remarked.is`
 - **summary**:    On on-chain remark happened. 
  
+### TaskCompleted(`AssetHubKusamaRuntimeRuntimeTask`)
+- **interface**: `api.events.system.TaskCompleted.is`
+- **summary**:    A [`Task`] has finished executing. 
+ 
+### TaskFailed(`AssetHubKusamaRuntimeRuntimeTask`, `SpRuntimeDispatchError`)
+- **interface**: `api.events.system.TaskFailed.is`
+- **summary**:    A [`Task`] failed during execution. 
+ 
+### TaskStarted(`AssetHubKusamaRuntimeRuntimeTask`)
+- **interface**: `api.events.system.TaskStarted.is`
+- **summary**:    A [`Task`] has started executing 
+ 
 ### UpgradeAuthorized(`H256`, `bool`)
 - **interface**: `api.events.system.UpgradeAuthorized.is`
 - **summary**:    An upgrade was authorized. 
@@ -1087,6 +2011,59 @@ ___
 ### TransactionFeePaid(`AccountId32`, `u128`, `u128`)
 - **interface**: `api.events.transactionPayment.TransactionFeePaid.is`
 - **summary**:    A transaction fee `actual_fee`, of which `tip` was added to the minimum inclusion fee,  has been paid by `who`. 
+
+___
+
+
+## treasury
+ 
+### AssetSpendApproved(`u32`, `PolkadotRuntimeCommonImplsVersionedLocatableAsset`, `u128`, `ParachainsCommonPayVersionedLocatableAccount`, `u32`, `u32`)
+- **interface**: `api.events.treasury.AssetSpendApproved.is`
+- **summary**:    A new asset spend proposal has been approved. 
+ 
+### AssetSpendVoided(`u32`)
+- **interface**: `api.events.treasury.AssetSpendVoided.is`
+- **summary**:    An approved spend was voided. 
+ 
+### Awarded(`u32`, `u128`, `AccountId32`)
+- **interface**: `api.events.treasury.Awarded.is`
+- **summary**:    Some funds have been allocated. 
+ 
+### Burnt(`u128`)
+- **interface**: `api.events.treasury.Burnt.is`
+- **summary**:    Some of our funds have been burnt. 
+ 
+### Deposit(`u128`)
+- **interface**: `api.events.treasury.Deposit.is`
+- **summary**:    Some funds have been deposited. 
+ 
+### Paid(`u32`, `u64`)
+- **interface**: `api.events.treasury.Paid.is`
+- **summary**:    A payment happened. 
+ 
+### PaymentFailed(`u32`, `u64`)
+- **interface**: `api.events.treasury.PaymentFailed.is`
+- **summary**:    A payment failed and can be retried. 
+ 
+### Rollover(`u128`)
+- **interface**: `api.events.treasury.Rollover.is`
+- **summary**:    Spending has finished; this is the amount that rolls over until next spend. 
+ 
+### SpendApproved(`u32`, `u128`, `AccountId32`)
+- **interface**: `api.events.treasury.SpendApproved.is`
+- **summary**:    A new spend proposal has been approved. 
+ 
+### Spending(`u128`)
+- **interface**: `api.events.treasury.Spending.is`
+- **summary**:    We have ended a spend period and will now allocate funds. 
+ 
+### SpendProcessed(`u32`)
+- **interface**: `api.events.treasury.SpendProcessed.is`
+- **summary**:    A spend was processed and removed from the storage. It might have been successfully  paid or it may have expired. 
+ 
+### UpdatedInactive(`u128`, `u128`)
+- **interface**: `api.events.treasury.UpdatedInactive.is`
+- **summary**:    The inactive funds of the pallet have been updated. 
 
 ___
 
@@ -1247,9 +2224,40 @@ ___
 - **interface**: `api.events.vesting.VestingCompleted.is`
 - **summary**:    An \[account\] has become fully vested. 
  
+### VestingCreated(`AccountId32`, `u32`)
+- **interface**: `api.events.vesting.VestingCreated.is`
+- **summary**:    A vesting schedule has been created. 
+ 
 ### VestingUpdated(`AccountId32`, `u128`)
 - **interface**: `api.events.vesting.VestingUpdated.is`
 - **summary**:    The amount vested has been updated. This could indicate a change in funds available.  The balance given is the amount which is left unvested (and thus locked). 
+
+___
+
+
+## voterList
+ 
+### Rebagged(`AccountId32`, `u64`, `u64`)
+- **interface**: `api.events.voterList.Rebagged.is`
+- **summary**:    Moved an account from one bag to another. 
+ 
+### ScoreUpdated(`AccountId32`, `u64`)
+- **interface**: `api.events.voterList.ScoreUpdated.is`
+- **summary**:    Updated the score of some account to the given amount. 
+
+___
+
+
+## whitelist
+ 
+### CallWhitelisted(`H256`)
+- **interface**: `api.events.whitelist.CallWhitelisted.is`
+ 
+### WhitelistedCallDispatched(`H256`, `Result<FrameSupportDispatchPostDispatchInfo, SpRuntimeDispatchErrorWithPostInfo>`)
+- **interface**: `api.events.whitelist.WhitelistedCallDispatched.is`
+ 
+### WhitelistedCallRemoved(`H256`)
+- **interface**: `api.events.whitelist.WhitelistedCallRemoved.is`
 
 ___
 

--- a/docs/asset-hub-kusama/extrinsics.md
+++ b/docs/asset-hub-kusama/extrinsics.md
@@ -6,19 +6,45 @@ The following sections contain Extrinsics methods are part of the default asset-
 
 (NOTE: These were generated from a static/snapshot view of a recent default asset-hub-kusama runtime. Some items may not be available in older nodes, or in any customized implementations.)
 
+- **[ahMigrator](#ahmigrator)**
+
+- **[ahOps](#ahops)**
+
 - **[assetConversion](#assetconversion)**
+
+- **[assetRate](#assetrate)**
 
 - **[assets](#assets)**
 
 - **[balances](#balances)**
 
+- **[bounties](#bounties)**
+
+- **[childBounties](#childbounties)**
+
+- **[claims](#claims)**
+
 - **[collatorSelection](#collatorselection)**
+
+- **[convictionVoting](#convictionvoting)**
 
 - **[cumulusXcm](#cumulusxcm)**
 
 - **[foreignAssets](#foreignassets)**
 
+- **[indices](#indices)**
+
 - **[messageQueue](#messagequeue)**
+
+- **[multiBlockElection](#multiblockelection)**
+
+- **[multiBlockElectionSigned](#multiblockelectionsigned)**
+
+- **[multiBlockElectionUnsigned](#multiblockelectionunsigned)**
+
+- **[multiBlockElectionVerifier](#multiblockelectionverifier)**
+
+- **[multiBlockMigrations](#multiblockmigrations)**
 
 - **[multisig](#multisig)**
 
@@ -26,21 +52,39 @@ The following sections contain Extrinsics methods are part of the default asset-
 
 - **[nfts](#nfts)**
 
+- **[nominationPools](#nominationpools)**
+
 - **[parachainInfo](#parachaininfo)**
 
 - **[parachainSystem](#parachainsystem)**
+
+- **[parameters](#parameters)**
 
 - **[polkadotXcm](#polkadotxcm)**
 
 - **[poolAssets](#poolassets)**
 
+- **[preimage](#preimage)**
+
 - **[proxy](#proxy)**
+
+- **[recovery](#recovery)**
+
+- **[referenda](#referenda)**
 
 - **[remoteProxyRelayChain](#remoteproxyrelaychain)**
 
 - **[revive](#revive)**
 
+- **[scheduler](#scheduler)**
+
 - **[session](#session)**
+
+- **[society](#society)**
+
+- **[staking](#staking)**
+
+- **[stakingRcClient](#stakingrcclient)**
 
 - **[stateTrieMigration](#statetriemigration)**
 
@@ -50,11 +94,17 @@ The following sections contain Extrinsics methods are part of the default asset-
 
 - **[toPolkadotXcmRouter](#topolkadotxcmrouter)**
 
+- **[treasury](#treasury)**
+
 - **[uniques](#uniques)**
 
 - **[utility](#utility)**
 
 - **[vesting](#vesting)**
+
+- **[voterList](#voterlist)**
+
+- **[whitelist](#whitelist)**
 
 - **[xcmpQueue](#xcmpqueue)**
 
@@ -62,9 +112,184 @@ The following sections contain Extrinsics methods are part of the default asset-
 ___
 
 
+## ahMigrator
+ 
+### finishMigration(data: `Option<PalletRcMigratorMigrationFinishedData>`)
+- **interface**: `api.tx.ahMigrator.finishMigration`
+- **summary**:    Finish the migration. 
+
+   This is typically called by the Relay Chain to signal the migration has finished. 
+
+   The `data` parameter might be `None` if we are running the migration for a second time  for some pallets and have already performed the checking account balance correction,  so we do not need to do it this time. 
+ 
+### forceSetStage(stage: `PalletAhMigratorMigrationStage`)
+- **interface**: `api.tx.ahMigrator.forceSetStage`
+- **summary**:    Set the migration stage. 
+
+   This call is intended for emergency use only and is guarded by the  [`Config::AdminOrigin`]. 
+ 
+### receiveAccounts(accounts: `Vec<PalletRcMigratorAccountsAccount>`)
+- **interface**: `api.tx.ahMigrator.receiveAccounts`
+- **summary**:    Receive accounts from the Relay Chain. 
+
+   The accounts sent with `pallet_rc_migrator::Pallet::migrate_accounts` function. 
+ 
+### receiveAssetRates(rates: `Vec<(PolkadotRuntimeCommonImplsVersionedLocatableAsset,u128)>`)
+- **interface**: `api.tx.ahMigrator.receiveAssetRates`
+ 
+### receiveBagsListMessages(messages: `Vec<PalletRcMigratorStakingBagsListPortableBagsListMessage>`)
+- **interface**: `api.tx.ahMigrator.receiveBagsListMessages`
+ 
+### receiveBountiesMessages(messages: `Vec<PalletRcMigratorBountiesRcBountiesMessage>`)
+- **interface**: `api.tx.ahMigrator.receiveBountiesMessages`
+ 
+### receiveChildBountiesMessages(messages: `Vec<PalletRcMigratorChildBountiesPortableChildBountiesMessage>`)
+- **interface**: `api.tx.ahMigrator.receiveChildBountiesMessages`
+ 
+### receiveClaims(messages: `Vec<PalletRcMigratorClaimsRcClaimsMessage>`)
+- **interface**: `api.tx.ahMigrator.receiveClaims`
+ 
+### receiveConvictionVotingMessages(messages: `Vec<PalletRcMigratorConvictionVotingRcConvictionVotingMessage>`)
+- **interface**: `api.tx.ahMigrator.receiveConvictionVotingMessages`
+ 
+### receiveCrowdloanMessages(messages: `Vec<PalletRcMigratorCrowdloanRcCrowdloanMessage>`)
+- **interface**: `api.tx.ahMigrator.receiveCrowdloanMessages`
+ 
+### receiveDelegatedStakingMessages(messages: `Vec<PalletRcMigratorStakingDelegatedStakingPortableDelegatedStakingMessage>`)
+- **interface**: `api.tx.ahMigrator.receiveDelegatedStakingMessages`
+ 
+### receiveIndices(indices: `Vec<PalletRcMigratorIndicesRcIndicesIndex>`)
+- **interface**: `api.tx.ahMigrator.receiveIndices`
+ 
+### receiveMultisigs(accounts: `Vec<PalletRcMigratorMultisigRcMultisig>`)
+- **interface**: `api.tx.ahMigrator.receiveMultisigs`
+- **summary**:    Receive multisigs from the Relay Chain. 
+
+   This will be called from an XCM `Transact` inside a DMP from the relay chain. The  multisigs were prepared by  `pallet_rc_migrator::multisig::MultisigMigrator::migrate_many`. 
+ 
+### receiveNomPoolsMessages(messages: `Vec<PalletRcMigratorStakingNomPoolsRcNomPoolsMessage>`)
+- **interface**: `api.tx.ahMigrator.receiveNomPoolsMessages`
+ 
+### receivePreimageChunks(chunks: `Vec<PalletRcMigratorPreimageChunksRcPreimageChunk>`)
+- **interface**: `api.tx.ahMigrator.receivePreimageChunks`
+ 
+### receivePreimageLegacyStatus(legacy_status: `Vec<PalletRcMigratorPreimageLegacyRequestStatusRcPreimageLegacyStatus>`)
+- **interface**: `api.tx.ahMigrator.receivePreimageLegacyStatus`
+ 
+### receivePreimageRequestStatus(request_status: `Vec<PalletRcMigratorPreimageRequestStatusPortableRequestStatus>`)
+- **interface**: `api.tx.ahMigrator.receivePreimageRequestStatus`
+ 
+### receiveProxyAnnouncements(announcements: `Vec<PalletRcMigratorProxyRcProxyAnnouncement>`)
+- **interface**: `api.tx.ahMigrator.receiveProxyAnnouncements`
+- **summary**:    Receive proxy announcements from the Relay Chain. 
+ 
+### receiveProxyProxies(proxies: `Vec<PalletRcMigratorProxyRcProxy>`)
+- **interface**: `api.tx.ahMigrator.receiveProxyProxies`
+- **summary**:    Receive proxies from the Relay Chain. 
+ 
+### receiveRecoveryMessages(messages: `Vec<PalletRcMigratorRecoveryPortableRecoveryMessage>`)
+- **interface**: `api.tx.ahMigrator.receiveRecoveryMessages`
+ 
+### receiveReferendaMetadata(metadata: `Vec<(u32,H256)>`)
+- **interface**: `api.tx.ahMigrator.receiveReferendaMetadata`
+ 
+### receiveReferendaValues(values: `Vec<PalletRcMigratorReferendaReferendaMessage>`)
+- **interface**: `api.tx.ahMigrator.receiveReferendaValues`
+- **summary**:    Receive referendum counts, deciding counts, votes for the track queue. 
+ 
+### receiveReferendums(referendums: `Vec<(u32,PalletReferendaReferendumInfoRcPalletsOrigin)>`)
+- **interface**: `api.tx.ahMigrator.receiveReferendums`
+- **summary**:    Receive referendums from the Relay Chain. 
+ 
+### receiveSchedulerAgendaMessages(messages: `Vec<PalletRcMigratorSchedulerSchedulerAgendaMessage>`)
+- **interface**: `api.tx.ahMigrator.receiveSchedulerAgendaMessages`
+ 
+### receiveSchedulerMessages(messages: `Vec<PalletRcMigratorSchedulerRcSchedulerMessage>`)
+- **interface**: `api.tx.ahMigrator.receiveSchedulerMessages`
+ 
+### receiveSocietyMessages(messages: `Vec<PalletRcMigratorSocietyPortableSocietyMessage>`)
+- **interface**: `api.tx.ahMigrator.receiveSocietyMessages`
+ 
+### receiveStakingMessages(messages: `Vec<PalletRcMigratorStakingMessagePortableStakingMessage>`)
+- **interface**: `api.tx.ahMigrator.receiveStakingMessages`
+ 
+### receiveTreasuryMessages(messages: `Vec<PalletRcMigratorTreasuryPortableTreasuryMessage>`)
+- **interface**: `api.tx.ahMigrator.receiveTreasuryMessages`
+ 
+### receiveVestingSchedules(schedules: `Vec<PalletRcMigratorVestingRcVestingSchedule>`)
+- **interface**: `api.tx.ahMigrator.receiveVestingSchedules`
+ 
+### sendXcmMessage(dest: `XcmVersionedLocation`, message: `XcmVersionedXcm`)
+- **interface**: `api.tx.ahMigrator.sendXcmMessage`
+- **summary**:    XCM send call identical to the [`pallet_xcm::Pallet::send`] call but with the  [Config::SendXcm] router which will be able to send messages to the Relay Chain during  the migration. 
+ 
+### setDmpQueuePriority(new: `PalletRcMigratorQueuePriority`)
+- **interface**: `api.tx.ahMigrator.setDmpQueuePriority`
+- **summary**:    Set the DMP queue priority configuration. 
+
+   Can only be called by the `AdminOrigin`. 
+ 
+### setManager(new: `Option<AccountId32>`)
+- **interface**: `api.tx.ahMigrator.setManager`
+- **summary**:    Set the manager account id. 
+
+   The manager has the similar to [`Config::AdminOrigin`] privileges except that it  can not set the manager account id via `set_manager` call. 
+ 
+### startMigration()
+- **interface**: `api.tx.ahMigrator.startMigration`
+- **summary**:    Start the data migration. 
+
+   This is typically called by the Relay Chain to start the migration on the Asset Hub and  receive a handshake message indicating the Asset Hub's readiness. 
+
+___
+
+
+## ahOps
+ 
+### transferToPostMigrationTreasury(asset_id: `StagingXcmV5Location`)
+- **interface**: `api.tx.ahOps.transferToPostMigrationTreasury`
+- **summary**:    Transfer the balance from the pre-migration treasury account to the post-migration  treasury account. 
+
+   This call can only be called after the migration is completed. 
+ 
+### unreserveCrowdloanReserve(block: `u32`, depositor: `Option<AccountId32>`, para_id: `u32`)
+- **interface**: `api.tx.ahOps.unreserveCrowdloanReserve`
+- **summary**:    Unreserve the deposit that was taken for creating a crowdloan. 
+
+   This can be called once either: 
+
+  - The crowdloan failed to win an auction and timed out
+
+  - Won an auction, all leases expired and all contributions are withdrawn
+
+   Can be called by any signed origin. The condition that all contributions are withdrawn  is in place since the reserve acts as a storage deposit. 
+ 
+### unreserveLeaseDeposit(block: `u32`, depositor: `Option<AccountId32>`, para_id: `u32`)
+- **interface**: `api.tx.ahOps.unreserveLeaseDeposit`
+- **summary**:    Unreserve the deposit that was taken for creating a crowdloan. 
+
+   This can be called by any signed origin. It unreserves the lease deposit on the account  that won the lease auction. It can be unreserved once all leases expired. Note that it  will be called automatically from `withdraw_crowdloan_contribution` for the matching  crowdloan account. 
+
+   Solo bidder accounts that won lease auctions can use this to unreserve their amount. 
+ 
+### withdrawCrowdloanContribution(block: `u32`, depositor: `Option<AccountId32>`, para_id: `u32`)
+- **interface**: `api.tx.ahOps.withdrawCrowdloanContribution`
+- **summary**:    Withdraw the contribution of a finished crowdloan. 
+
+   A crowdloan contribution can be withdrawn if either: 
+
+  - The crowdloan failed to in an auction and timed out
+
+  - Won an auction and all leases expired
+
+   Can be called by any signed origin. 
+
+___
+
+
 ## assetConversion
  
-### addLiquidity(asset1: `StagingXcmV4Location`, asset2: `StagingXcmV4Location`, amount1_desired: `u128`, amount2_desired: `u128`, amount1_min: `u128`, amount2_min: `u128`, mint_to: `AccountId32`)
+### addLiquidity(asset1: `StagingXcmV5Location`, asset2: `StagingXcmV5Location`, amount1_desired: `u128`, amount2_desired: `u128`, amount1_min: `u128`, amount2_min: `u128`, mint_to: `AccountId32`)
 - **interface**: `api.tx.assetConversion.addLiquidity`
 - **summary**:    Provide liquidity into the pool of `asset1` and `asset2`.  NOTE: an optimal amount of asset1 and asset2 will be calculated and  might be different than the provided `amount1_desired`/`amount2_desired`  thus you should provide the min amount you're happy to provide.  Params `amount1_min`/`amount2_min` represent that.  `mint_to` will be sent the liquidity tokens that represent this share of the pool. 
 
@@ -72,29 +297,29 @@ ___
 
    Once liquidity is added, someone may successfully call  [`Pallet::swap_exact_tokens_for_tokens`]. 
  
-### createPool(asset1: `StagingXcmV4Location`, asset2: `StagingXcmV4Location`)
+### createPool(asset1: `StagingXcmV5Location`, asset2: `StagingXcmV5Location`)
 - **interface**: `api.tx.assetConversion.createPool`
 - **summary**:    Creates an empty liquidity pool and an associated new `lp_token` asset  (the id of which is returned in the `Event::PoolCreated` event). 
 
    Once a pool is created, someone may [`Pallet::add_liquidity`] to it. 
  
-### removeLiquidity(asset1: `StagingXcmV4Location`, asset2: `StagingXcmV4Location`, lp_token_burn: `u128`, amount1_min_receive: `u128`, amount2_min_receive: `u128`, withdraw_to: `AccountId32`)
+### removeLiquidity(asset1: `StagingXcmV5Location`, asset2: `StagingXcmV5Location`, lp_token_burn: `u128`, amount1_min_receive: `u128`, amount2_min_receive: `u128`, withdraw_to: `AccountId32`)
 - **interface**: `api.tx.assetConversion.removeLiquidity`
 - **summary**:    Allows you to remove liquidity by providing the `lp_token_burn` tokens that will be  burned in the process. With the usage of `amount1_min_receive`/`amount2_min_receive`  it's possible to control the min amount of returned tokens you're happy with. 
  
-### swapExactTokensForTokens(path: `Vec<StagingXcmV4Location>`, amount_in: `u128`, amount_out_min: `u128`, send_to: `AccountId32`, keep_alive: `bool`)
+### swapExactTokensForTokens(path: `Vec<StagingXcmV5Location>`, amount_in: `u128`, amount_out_min: `u128`, send_to: `AccountId32`, keep_alive: `bool`)
 - **interface**: `api.tx.assetConversion.swapExactTokensForTokens`
 - **summary**:    Swap the exact amount of `asset1` into `asset2`.  `amount_out_min` param allows you to specify the min amount of the `asset2`  you're happy to receive. 
 
    [`AssetConversionApi::quote_price_exact_tokens_for_tokens`] runtime call can be called  for a quote. 
  
-### swapTokensForExactTokens(path: `Vec<StagingXcmV4Location>`, amount_out: `u128`, amount_in_max: `u128`, send_to: `AccountId32`, keep_alive: `bool`)
+### swapTokensForExactTokens(path: `Vec<StagingXcmV5Location>`, amount_out: `u128`, amount_in_max: `u128`, send_to: `AccountId32`, keep_alive: `bool`)
 - **interface**: `api.tx.assetConversion.swapTokensForExactTokens`
 - **summary**:    Swap any amount of `asset1` to get the exact amount of `asset2`.  `amount_in_max` param allows to specify the max amount of the `asset1`  you're happy to provide. 
 
    [`AssetConversionApi::quote_price_tokens_for_exact_tokens`] runtime call can be called  for a quote. 
  
-### touch(asset1: `StagingXcmV4Location`, asset2: `StagingXcmV4Location`)
+### touch(asset1: `StagingXcmV5Location`, asset2: `StagingXcmV5Location`)
 - **interface**: `api.tx.assetConversion.touch`
 - **summary**:    Touch an existing pool to fulfill prerequisites before providing liquidity, such as  ensuring that the pool's accounts are in place. It is typically useful when a pool  creator removes the pool's accounts and does not provide a liquidity. This action may  involve holding assets from the caller as a deposit for creating the pool's accounts. 
 
@@ -105,6 +330,35 @@ ___
   - `asset2`: The asset ID of an existing pool with a pair (asset1, asset2).
 
    Emits `Touched` event when successful. 
+
+___
+
+
+## assetRate
+ 
+### create(asset_kind: `PolkadotRuntimeCommonImplsVersionedLocatableAsset`, rate: `u128`)
+- **interface**: `api.tx.assetRate.create`
+- **summary**:    Initialize a conversion rate to native balance for the given asset. 
+
+   #### Complexity 
+
+  - O(1)
+ 
+### remove(asset_kind: `PolkadotRuntimeCommonImplsVersionedLocatableAsset`)
+- **interface**: `api.tx.assetRate.remove`
+- **summary**:    Remove an existing conversion rate to native balance for the given asset. 
+
+   #### Complexity 
+
+  - O(1)
+ 
+### update(asset_kind: `PolkadotRuntimeCommonImplsVersionedLocatableAsset`, rate: `u128`)
+- **interface**: `api.tx.assetRate.update`
+- **summary**:    Update the conversion rate to native balance for the given asset. 
+
+   #### Complexity 
+
+  - O(1)
 
 ___
 
@@ -707,6 +961,372 @@ ___
 ___
 
 
+## bounties
+ 
+### acceptCurator(bounty_id: `Compact<u32>`)
+- **interface**: `api.tx.bounties.acceptCurator`
+- **summary**:    Accept the curator role for a bounty.  A deposit will be reserved from curator and refund upon successful payout. 
+
+   May only be called from the curator. 
+
+   #### Complexity 
+
+  - O(1).
+ 
+### approveBounty(bounty_id: `Compact<u32>`)
+- **interface**: `api.tx.bounties.approveBounty`
+- **summary**:    Approve a bounty proposal. At a later time, the bounty will be funded and become active  and the original deposit will be returned. 
+
+   May only be called from `T::SpendOrigin`. 
+
+   #### Complexity 
+
+  - O(1).
+ 
+### approveBountyWithCurator(bounty_id: `Compact<u32>`, curator: `MultiAddress`, fee: `Compact<u128>`)
+- **interface**: `api.tx.bounties.approveBountyWithCurator`
+- **summary**:    Approve bountry and propose a curator simultaneously.  This call is a shortcut to calling `approve_bounty` and `propose_curator` separately. 
+
+   May only be called from `T::SpendOrigin`. 
+
+   - `bounty_id`: Bounty ID to approve. 
+
+  - `curator`: The curator account whom will manage this bounty.
+
+  - `fee`: The curator fee.
+
+   #### Complexity 
+
+  - O(1).
+ 
+### awardBounty(bounty_id: `Compact<u32>`, beneficiary: `MultiAddress`)
+- **interface**: `api.tx.bounties.awardBounty`
+- **summary**:    Award bounty to a beneficiary account. The beneficiary will be able to claim the funds  after a delay. 
+
+   The dispatch origin for this call must be the curator of this bounty. 
+
+   - `bounty_id`: Bounty ID to award. 
+
+  - `beneficiary`: The beneficiary account whom will receive the payout.
+
+   #### Complexity 
+
+  - O(1).
+ 
+### claimBounty(bounty_id: `Compact<u32>`)
+- **interface**: `api.tx.bounties.claimBounty`
+- **summary**:    Claim the payout from an awarded bounty after payout delay. 
+
+   The dispatch origin for this call must be the beneficiary of this bounty. 
+
+   - `bounty_id`: Bounty ID to claim. 
+
+   #### Complexity 
+
+  - O(1).
+ 
+### closeBounty(bounty_id: `Compact<u32>`)
+- **interface**: `api.tx.bounties.closeBounty`
+- **summary**:    Cancel a proposed or active bounty. All the funds will be sent to treasury and  the curator deposit will be unreserved if possible. 
+
+   Only `T::RejectOrigin` is able to cancel a bounty. 
+
+   - `bounty_id`: Bounty ID to cancel. 
+
+   #### Complexity 
+
+  - O(1).
+ 
+### extendBountyExpiry(bounty_id: `Compact<u32>`, remark: `Bytes`)
+- **interface**: `api.tx.bounties.extendBountyExpiry`
+- **summary**:    Extend the expiry time of an active bounty. 
+
+   The dispatch origin for this call must be the curator of this bounty. 
+
+   - `bounty_id`: Bounty ID to extend. 
+
+  - `remark`: additional information.
+
+   #### Complexity 
+
+  - O(1).
+ 
+### pokeDeposit(bounty_id: `Compact<u32>`)
+- **interface**: `api.tx.bounties.pokeDeposit`
+- **summary**:    Poke the deposit reserved for creating a bounty proposal. 
+
+   This can be used by accounts to update their reserved amount. 
+
+   The dispatch origin for this call must be _Signed_. 
+
+   Parameters: 
+
+  - `bounty_id`: The bounty id for which to adjust the deposit.
+
+   If the deposit is updated, the difference will be reserved/unreserved from the  proposer's account. 
+
+   The transaction is made free if the deposit is updated and paid otherwise. 
+
+   Emits `DepositPoked` if the deposit is updated. 
+ 
+### proposeBounty(value: `Compact<u128>`, description: `Bytes`)
+- **interface**: `api.tx.bounties.proposeBounty`
+- **summary**:    Propose a new bounty. 
+
+   The dispatch origin for this call must be _Signed_. 
+
+   Payment: `TipReportDepositBase` will be reserved from the origin account, as well as  `DataDepositPerByte` for each byte in `reason`. It will be unreserved upon approval,  or slashed when rejected. 
+
+   - `curator`: The curator account whom will manage this bounty. 
+
+  - `fee`: The curator fee.
+
+  - `value`: The total payment amount of this bounty, curator fee included.
+
+  - `description`: The description of this bounty.
+ 
+### proposeCurator(bounty_id: `Compact<u32>`, curator: `MultiAddress`, fee: `Compact<u128>`)
+- **interface**: `api.tx.bounties.proposeCurator`
+- **summary**:    Propose a curator to a funded bounty. 
+
+   May only be called from `T::SpendOrigin`. 
+
+   #### Complexity 
+
+  - O(1).
+ 
+### unassignCurator(bounty_id: `Compact<u32>`)
+- **interface**: `api.tx.bounties.unassignCurator`
+- **summary**:    Unassign curator from a bounty. 
+
+   This function can only be called by the `RejectOrigin` a signed origin. 
+
+   If this function is called by the `RejectOrigin`, we assume that the curator is  malicious or inactive. As a result, we will slash the curator when possible. 
+
+   If the origin is the curator, we take this as a sign they are unable to do their job and  they willingly give up. We could slash them, but for now we allow them to recover their  deposit and exit without issue. (We may want to change this if it is abused.) 
+
+   Finally, the origin can be anyone if and only if the curator is "inactive". This allows  anyone in the community to call out that a curator is not doing their due diligence, and  we should pick a new curator. In this case the curator should also be slashed. 
+
+   #### Complexity 
+
+  - O(1).
+
+___
+
+
+## childBounties
+ 
+### acceptCurator(parent_bounty_id: `Compact<u32>`, child_bounty_id: `Compact<u32>`)
+- **interface**: `api.tx.childBounties.acceptCurator`
+- **summary**:    Accept the curator role for the child-bounty. 
+
+   The dispatch origin for this call must be the curator of this  child-bounty. 
+
+   A deposit will be reserved from the curator and refund upon  successful payout or cancellation. 
+
+   Fee for curator is deducted from curator fee of parent bounty. 
+
+   Parent bounty must be in active state, for this child-bounty call to  work. 
+
+   Child-bounty must be in "CuratorProposed" state, for processing the  call. And state of child-bounty is moved to "Active" on successful  call completion. 
+
+   - `parent_bounty_id`: Index of parent bounty. 
+
+  - `child_bounty_id`: Index of child bounty.
+ 
+### addChildBounty(parent_bounty_id: `Compact<u32>`, value: `Compact<u128>`, description: `Bytes`)
+- **interface**: `api.tx.childBounties.addChildBounty`
+- **summary**:    Add a new child-bounty. 
+
+   The dispatch origin for this call must be the curator of parent  bounty and the parent bounty must be in "active" state. 
+
+   Child-bounty gets added successfully & fund gets transferred from  parent bounty to child-bounty account, if parent bounty has enough  funds, else the call fails. 
+
+   Upper bound to maximum number of active  child bounties that can be  added are managed via runtime trait config  [`Config::MaxActiveChildBountyCount`]. 
+
+   If the call is success, the status of child-bounty is updated to  "Added". 
+
+   - `parent_bounty_id`: Index of parent bounty for which child-bounty is being added. 
+
+  - `value`: Value for executing the proposal.
+
+  - `description`: Text description for the child-bounty.
+ 
+### awardChildBounty(parent_bounty_id: `Compact<u32>`, child_bounty_id: `Compact<u32>`, beneficiary: `MultiAddress`)
+- **interface**: `api.tx.childBounties.awardChildBounty`
+- **summary**:    Award child-bounty to a beneficiary. 
+
+   The beneficiary will be able to claim the funds after a delay. 
+
+   The dispatch origin for this call must be the parent curator or  curator of this child-bounty. 
+
+   Parent bounty must be in active state, for this child-bounty call to  work. 
+
+   Child-bounty must be in active state, for processing the call. And  state of child-bounty is moved to "PendingPayout" on successful call  completion. 
+
+   - `parent_bounty_id`: Index of parent bounty. 
+
+  - `child_bounty_id`: Index of child bounty.
+
+  - `beneficiary`: Beneficiary account.
+ 
+### claimChildBounty(parent_bounty_id: `Compact<u32>`, child_bounty_id: `Compact<u32>`)
+- **interface**: `api.tx.childBounties.claimChildBounty`
+- **summary**:    Claim the payout from an awarded child-bounty after payout delay. 
+
+   The dispatch origin for this call may be any signed origin. 
+
+   Call works independent of parent bounty state, No need for parent  bounty to be in active state. 
+
+   The Beneficiary is paid out with agreed bounty value. Curator fee is  paid & curator deposit is unreserved. 
+
+   Child-bounty must be in "PendingPayout" state, for processing the  call. And instance of child-bounty is removed from the state on  successful call completion. 
+
+   - `parent_bounty_id`: Index of parent bounty. 
+
+  - `child_bounty_id`: Index of child bounty.
+ 
+### closeChildBounty(parent_bounty_id: `Compact<u32>`, child_bounty_id: `Compact<u32>`)
+- **interface**: `api.tx.childBounties.closeChildBounty`
+- **summary**:    Cancel a proposed or active child-bounty. Child-bounty account funds  are transferred to parent bounty account. The child-bounty curator  deposit may be unreserved if possible. 
+
+   The dispatch origin for this call must be either parent curator or  `T::RejectOrigin`. 
+
+   If the state of child-bounty is `Active`, curator deposit is  unreserved. 
+
+   If the state of child-bounty is `PendingPayout`, call fails &  returns `PendingPayout` error. 
+
+   For the origin other than T::RejectOrigin, parent bounty must be in  active state, for this child-bounty call to work. For origin  T::RejectOrigin execution is forced. 
+
+   Instance of child-bounty is removed from the state on successful  call completion. 
+
+   - `parent_bounty_id`: Index of parent bounty. 
+
+  - `child_bounty_id`: Index of child bounty.
+ 
+### proposeCurator(parent_bounty_id: `Compact<u32>`, child_bounty_id: `Compact<u32>`, curator: `MultiAddress`, fee: `Compact<u128>`)
+- **interface**: `api.tx.childBounties.proposeCurator`
+- **summary**:    Propose curator for funded child-bounty. 
+
+   The dispatch origin for this call must be curator of parent bounty. 
+
+   Parent bounty must be in active state, for this child-bounty call to  work. 
+
+   Child-bounty must be in "Added" state, for processing the call. And  state of child-bounty is moved to "CuratorProposed" on successful  call completion. 
+
+   - `parent_bounty_id`: Index of parent bounty. 
+
+  - `child_bounty_id`: Index of child bounty.
+
+  - `curator`: Address of child-bounty curator.
+
+  - `fee`: payment fee to child-bounty curator for execution.
+ 
+### unassignCurator(parent_bounty_id: `Compact<u32>`, child_bounty_id: `Compact<u32>`)
+- **interface**: `api.tx.childBounties.unassignCurator`
+- **summary**:    Unassign curator from a child-bounty. 
+
+   The dispatch origin for this call can be either `RejectOrigin`, or  the curator of the parent bounty, or any signed origin. 
+
+   For the origin other than T::RejectOrigin and the child-bounty  curator, parent bounty must be in active state, for this call to  work. We allow child-bounty curator and T::RejectOrigin to execute  this call irrespective of the parent bounty state. 
+
+   If this function is called by the `RejectOrigin` or the  parent bounty curator, we assume that the child-bounty curator is  malicious or inactive. As a result, child-bounty curator deposit is  slashed. 
+
+   If the origin is the child-bounty curator, we take this as a sign  that they are unable to do their job, and are willingly giving up.  We could slash the deposit, but for now we allow them to unreserve  their deposit and exit without issue. (We may want to change this if  it is abused.) 
+
+   Finally, the origin can be anyone iff the child-bounty curator is  "inactive". Expiry update due of parent bounty is used to estimate  inactive state of child-bounty curator. 
+
+   This allows anyone in the community to call out that a child-bounty  curator is not doing their due diligence, and we should pick a new  one. In this case the child-bounty curator deposit is slashed. 
+
+   State of child-bounty is moved to Added state on successful call  completion. 
+
+   - `parent_bounty_id`: Index of parent bounty. 
+
+  - `child_bounty_id`: Index of child bounty.
+
+___
+
+
+## claims
+ 
+### attest(statement: `Bytes`)
+- **interface**: `api.tx.claims.attest`
+- **summary**:    Attest to a statement, needed to finalize the claims process. 
+
+   WARNING: Insecure unless your chain includes `PrevalidateAttests` as a  `TransactionExtension`. 
+
+   Unsigned Validation:  A call to attest is deemed valid if the sender has a `Preclaim` registered  and provides a `statement` which is expected for the account. 
+
+   Parameters: 
+
+  - `statement`: The identity of the statement which is being attested to in the signature. 
+
+    
+ 
+### claim(dest: `AccountId32`, ethereum_signature: `PolkadotRuntimeCommonClaimsEcdsaSignature`)
+- **interface**: `api.tx.claims.claim`
+- **summary**:    Make a claim to collect your DOTs. 
+
+   The dispatch origin for this call must be _None_. 
+
+   Unsigned Validation:  A call to claim is deemed valid if the signature provided matches  the expected signed message of: 
+
+   > Ethereum Signed Message:  > (configured prefix string)(address) 
+
+   and `address` matches the `dest` account. 
+
+   Parameters: 
+
+  - `dest`: The destination account to payout the claim.
+
+  - `ethereum_signature`: The signature of an ethereum signed message matching the format described above. 
+
+    
+ 
+### claimAttest(dest: `AccountId32`, ethereum_signature: `PolkadotRuntimeCommonClaimsEcdsaSignature`, statement: `Bytes`)
+- **interface**: `api.tx.claims.claimAttest`
+- **summary**:    Make a claim to collect your DOTs by signing a statement. 
+
+   The dispatch origin for this call must be _None_. 
+
+   Unsigned Validation:  A call to `claim_attest` is deemed valid if the signature provided matches  the expected signed message of: 
+
+   > Ethereum Signed Message:  > (configured prefix string)(address)(statement) 
+
+   and `address` matches the `dest` account; the `statement` must match that which is  expected according to your purchase arrangement. 
+
+   Parameters: 
+
+  - `dest`: The destination account to payout the claim.
+
+  - `ethereum_signature`: The signature of an ethereum signed message matching the format described above. 
+
+  - `statement`: The identity of the statement which is being attested to in the signature. 
+
+    
+ 
+### mintClaim(who: `EthereumAddress`, value: `u128`, vesting_schedule: `Option<(u128,u128,u32)>`, statement: `Option<PolkadotRuntimeCommonClaimsStatementKind>`)
+- **interface**: `api.tx.claims.mintClaim`
+- **summary**:    Mint a new claim to collect DOTs. 
+
+   The dispatch origin for this call must be _Root_. 
+
+   Parameters: 
+
+  - `who`: The Ethereum address allowed to collect this claim.
+
+  - `value`: The number of DOTs that will be claimed.
+
+  - `vesting_schedule`: An optional vesting schedule for these DOTs.
+
+    
+ 
+### moveClaim(old: `EthereumAddress`, new: `EthereumAddress`, maybe_preclaim: `Option<AccountId32>`)
+- **interface**: `api.tx.claims.moveClaim`
+
+___
+
+
 ## collatorSelection
  
 ### addInvulnerable(who: `AccountId32`)
@@ -774,6 +1394,125 @@ ___
 ___
 
 
+## convictionVoting
+ 
+### delegate(class: `u16`, to: `MultiAddress`, conviction: `PalletConvictionVotingConviction`, balance: `u128`)
+- **interface**: `api.tx.convictionVoting.delegate`
+- **summary**:    Delegate the voting power (with some given conviction) of the sending account for a  particular class of polls. 
+
+   The balance delegated is locked for as long as it's delegated, and thereafter for the  time appropriate for the conviction's lock period. 
+
+   The dispatch origin of this call must be _Signed_, and the signing account must either: 
+
+  - be delegating already; or
+
+  - have no voting activity (if there is, then it will need to be removed through `remove_vote`). 
+
+   - `to`: The account whose voting the `target` account's voting power will follow. 
+
+  - `class`: The class of polls to delegate. To delegate multiple classes, multiple calls to this function are required. 
+
+  - `conviction`: The conviction that will be attached to the delegated votes. When the account is undelegated, the funds will be locked for the corresponding period. 
+
+  - `balance`: The amount of the account's balance to be used in delegating. This must not be more than the account's current balance. 
+
+   Emits `Delegated`. 
+
+   Weight: `O(R)` where R is the number of polls the voter delegating to has  voted on. Weight is initially charged as if maximum votes, but is refunded later. 
+ 
+### removeOtherVote(target: `MultiAddress`, class: `u16`, index: `u32`)
+- **interface**: `api.tx.convictionVoting.removeOtherVote`
+- **summary**:    Remove a vote for a poll. 
+
+   If the `target` is equal to the signer, then this function is exactly equivalent to  `remove_vote`. If not equal to the signer, then the vote must have expired,  either because the poll was cancelled, because the voter lost the poll or  because the conviction period is over. 
+
+   The dispatch origin of this call must be _Signed_. 
+
+   - `target`: The account of the vote to be removed; this account must have voted for poll  `index`. 
+
+  - `index`: The index of poll of the vote to be removed.
+
+  - `class`: The class of the poll.
+
+   Weight: `O(R + log R)` where R is the number of polls that `target` has voted on.  Weight is calculated for the maximum number of vote. 
+ 
+### removeVote(class: `Option<u16>`, index: `u32`)
+- **interface**: `api.tx.convictionVoting.removeVote`
+- **summary**:    Remove a vote for a poll. 
+
+   If: 
+
+  - the poll was cancelled, or
+
+  - the poll is ongoing, or
+
+  - the poll has ended such that
+
+  - the vote of the account was in opposition to the result; or
+
+  - there was no conviction to the account's vote; or
+
+  - the account made a split vote ...then the vote is removed cleanly and a following call to `unlock` may result in more  funds being available. 
+
+   If, however, the poll has ended and: 
+
+  - it finished corresponding to the vote of the account, and
+
+  - the account made a standard vote with conviction, and
+
+  - the lock period of the conviction is not over ...then the lock will be aggregated into the overall account's lock, which may involve 
+
+  *overlocking* (where the two locks are combined into a single lock that is the maximum of both the amount locked and the time is it locked for). 
+
+   The dispatch origin of this call must be _Signed_, and the signer must have a vote  registered for poll `index`. 
+
+   - `index`: The index of poll of the vote to be removed. 
+
+  - `class`: Optional parameter, if given it indicates the class of the poll. For polls which have finished or are cancelled, this must be `Some`. 
+
+   Weight: `O(R + log R)` where R is the number of polls that `target` has voted on.  Weight is calculated for the maximum number of vote. 
+ 
+### undelegate(class: `u16`)
+- **interface**: `api.tx.convictionVoting.undelegate`
+- **summary**:    Undelegate the voting power of the sending account for a particular class of polls. 
+
+   Tokens may be unlocked following once an amount of time consistent with the lock period  of the conviction with which the delegation was issued has passed. 
+
+   The dispatch origin of this call must be _Signed_ and the signing account must be  currently delegating. 
+
+   - `class`: The class of polls to remove the delegation from. 
+
+   Emits `Undelegated`. 
+
+   Weight: `O(R)` where R is the number of polls the voter delegating to has  voted on. Weight is initially charged as if maximum votes, but is refunded later. 
+ 
+### unlock(class: `u16`, target: `MultiAddress`)
+- **interface**: `api.tx.convictionVoting.unlock`
+- **summary**:    Remove the lock caused by prior voting/delegating which has expired within a particular  class. 
+
+   The dispatch origin of this call must be _Signed_. 
+
+   - `class`: The class of polls to unlock. 
+
+  - `target`: The account to remove the lock on.
+
+   Weight: `O(R)` with R number of vote of target. 
+ 
+### vote(poll_index: `Compact<u32>`, vote: `PalletConvictionVotingVoteAccountVote`)
+- **interface**: `api.tx.convictionVoting.vote`
+- **summary**:    Vote in a poll. If `vote.is_aye()`, the vote is to enact the proposal;  otherwise it is a vote to keep the status quo. 
+
+   The dispatch origin of this call must be _Signed_. 
+
+   - `poll_index`: The index of the poll to vote for. 
+
+  - `vote`: The vote configuration.
+
+   Weight: `O(R)` where R is the number of polls the voter has voted on. 
+
+___
+
+
 ## cumulusXcm
 
 ___
@@ -781,7 +1520,7 @@ ___
 
 ## foreignAssets
  
-### approveTransfer(id: `StagingXcmV4Location`, delegate: `MultiAddress`, amount: `Compact<u128>`)
+### approveTransfer(id: `StagingXcmV5Location`, delegate: `MultiAddress`, amount: `Compact<u128>`)
 - **interface**: `api.tx.foreignAssets.approveTransfer`
 - **summary**:    Approve an amount of asset for transfer by a delegated third-party account. 
 
@@ -801,7 +1540,7 @@ ___
 
    Weight: `O(1)` 
  
-### block(id: `StagingXcmV4Location`, who: `MultiAddress`)
+### block(id: `StagingXcmV5Location`, who: `MultiAddress`)
 - **interface**: `api.tx.foreignAssets.block`
 - **summary**:    Disallow further unprivileged transfers of an asset `id` to and from an account `who`. 
 
@@ -815,7 +1554,7 @@ ___
 
    Weight: `O(1)` 
  
-### burn(id: `StagingXcmV4Location`, who: `MultiAddress`, amount: `Compact<u128>`)
+### burn(id: `StagingXcmV5Location`, who: `MultiAddress`, amount: `Compact<u128>`)
 - **interface**: `api.tx.foreignAssets.burn`
 - **summary**:    Reduce the balance of `who` by as much as possible up to `amount` assets of `id`. 
 
@@ -833,7 +1572,7 @@ ___
 
    Weight: `O(1)`  Modes: Post-existence of `who`; Pre & post Zombie-status of `who`. 
  
-### cancelApproval(id: `StagingXcmV4Location`, delegate: `MultiAddress`)
+### cancelApproval(id: `StagingXcmV5Location`, delegate: `MultiAddress`)
 - **interface**: `api.tx.foreignAssets.cancelApproval`
 - **summary**:    Cancel all of some asset approved for delegated transfer by a third-party account. 
 
@@ -849,7 +1588,7 @@ ___
 
    Weight: `O(1)` 
  
-### clearMetadata(id: `StagingXcmV4Location`)
+### clearMetadata(id: `StagingXcmV5Location`)
 - **interface**: `api.tx.foreignAssets.clearMetadata`
 - **summary**:    Clear the metadata for an asset. 
 
@@ -863,7 +1602,7 @@ ___
 
    Weight: `O(1)` 
  
-### create(id: `StagingXcmV4Location`, admin: `MultiAddress`, min_balance: `u128`)
+### create(id: `StagingXcmV5Location`, admin: `MultiAddress`, min_balance: `u128`)
 - **interface**: `api.tx.foreignAssets.create`
 - **summary**:    Issue a new class of fungible assets from a public origin. 
 
@@ -885,7 +1624,7 @@ ___
 
    Weight: `O(1)` 
  
-### destroyAccounts(id: `StagingXcmV4Location`)
+### destroyAccounts(id: `StagingXcmV5Location`)
 - **interface**: `api.tx.foreignAssets.destroyAccounts`
 - **summary**:    Destroy all accounts associated with a given asset. 
 
@@ -897,7 +1636,7 @@ ___
 
    Each call emits the `Event::DestroyedAccounts` event. 
  
-### destroyApprovals(id: `StagingXcmV4Location`)
+### destroyApprovals(id: `StagingXcmV5Location`)
 - **interface**: `api.tx.foreignAssets.destroyApprovals`
 - **summary**:    Destroy all approvals associated with a given asset up to the max (T::RemoveItemsLimit). 
 
@@ -909,7 +1648,7 @@ ___
 
    Each call emits the `Event::DestroyedApprovals` event. 
  
-### finishDestroy(id: `StagingXcmV4Location`)
+### finishDestroy(id: `StagingXcmV5Location`)
 - **interface**: `api.tx.foreignAssets.finishDestroy`
 - **summary**:    Complete destroying asset and unreserve currency. 
 
@@ -919,7 +1658,7 @@ ___
 
    Each successful call emits the `Event::Destroyed` event. 
  
-### forceAssetStatus(id: `StagingXcmV4Location`, owner: `MultiAddress`, issuer: `MultiAddress`, admin: `MultiAddress`, freezer: `MultiAddress`, min_balance: `Compact<u128>`, is_sufficient: `bool`, is_frozen: `bool`)
+### forceAssetStatus(id: `StagingXcmV5Location`, owner: `MultiAddress`, issuer: `MultiAddress`, admin: `MultiAddress`, freezer: `MultiAddress`, min_balance: `Compact<u128>`, is_sufficient: `bool`, is_frozen: `bool`)
 - **interface**: `api.tx.foreignAssets.forceAssetStatus`
 - **summary**:    Alter the attributes of a given asset. 
 
@@ -945,7 +1684,7 @@ ___
 
    Weight: `O(1)` 
  
-### forceCancelApproval(id: `StagingXcmV4Location`, owner: `MultiAddress`, delegate: `MultiAddress`)
+### forceCancelApproval(id: `StagingXcmV5Location`, owner: `MultiAddress`, delegate: `MultiAddress`)
 - **interface**: `api.tx.foreignAssets.forceCancelApproval`
 - **summary**:    Cancel all of some asset approved for delegated transfer by a third-party account. 
 
@@ -961,7 +1700,7 @@ ___
 
    Weight: `O(1)` 
  
-### forceClearMetadata(id: `StagingXcmV4Location`)
+### forceClearMetadata(id: `StagingXcmV5Location`)
 - **interface**: `api.tx.foreignAssets.forceClearMetadata`
 - **summary**:    Clear the metadata for an asset. 
 
@@ -975,7 +1714,7 @@ ___
 
    Weight: `O(1)` 
  
-### forceCreate(id: `StagingXcmV4Location`, owner: `MultiAddress`, is_sufficient: `bool`, min_balance: `Compact<u128>`)
+### forceCreate(id: `StagingXcmV5Location`, owner: `MultiAddress`, is_sufficient: `bool`, min_balance: `Compact<u128>`)
 - **interface**: `api.tx.foreignAssets.forceCreate`
 - **summary**:    Issue a new class of fungible assets from a privileged origin. 
 
@@ -995,7 +1734,7 @@ ___
 
    Weight: `O(1)` 
  
-### forceSetMetadata(id: `StagingXcmV4Location`, name: `Bytes`, symbol: `Bytes`, decimals: `u8`, is_frozen: `bool`)
+### forceSetMetadata(id: `StagingXcmV5Location`, name: `Bytes`, symbol: `Bytes`, decimals: `u8`, is_frozen: `bool`)
 - **interface**: `api.tx.foreignAssets.forceSetMetadata`
 - **summary**:    Force the metadata for an asset to some value. 
 
@@ -1015,7 +1754,7 @@ ___
 
    Weight: `O(N + S)` where N and S are the length of the name and symbol respectively. 
  
-### forceTransfer(id: `StagingXcmV4Location`, source: `MultiAddress`, dest: `MultiAddress`, amount: `Compact<u128>`)
+### forceTransfer(id: `StagingXcmV5Location`, source: `MultiAddress`, dest: `MultiAddress`, amount: `Compact<u128>`)
 - **interface**: `api.tx.foreignAssets.forceTransfer`
 - **summary**:    Move some assets from one account to another. 
 
@@ -1033,7 +1772,7 @@ ___
 
    Weight: `O(1)`  Modes: Pre-existence of `dest`; Post-existence of `source`; Account pre-existence of  `dest`. 
  
-### freeze(id: `StagingXcmV4Location`, who: `MultiAddress`)
+### freeze(id: `StagingXcmV5Location`, who: `MultiAddress`)
 - **interface**: `api.tx.foreignAssets.freeze`
 - **summary**:    Disallow further unprivileged transfers of an asset `id` from an account `who`. `who`  must already exist as an entry in `Account`s of the asset. If you want to freeze an  account that does not have an entry, use `touch_other` first. 
 
@@ -1047,7 +1786,7 @@ ___
 
    Weight: `O(1)` 
  
-### freezeAsset(id: `StagingXcmV4Location`)
+### freezeAsset(id: `StagingXcmV5Location`)
 - **interface**: `api.tx.foreignAssets.freezeAsset`
 - **summary**:    Disallow further unprivileged transfers for the asset class. 
 
@@ -1059,7 +1798,7 @@ ___
 
    Weight: `O(1)` 
  
-### mint(id: `StagingXcmV4Location`, beneficiary: `MultiAddress`, amount: `Compact<u128>`)
+### mint(id: `StagingXcmV5Location`, beneficiary: `MultiAddress`, amount: `Compact<u128>`)
 - **interface**: `api.tx.foreignAssets.mint`
 - **summary**:    Mint assets of a particular class. 
 
@@ -1075,7 +1814,7 @@ ___
 
    Weight: `O(1)`  Modes: Pre-existing balance of `beneficiary`; Account pre-existence of `beneficiary`. 
  
-### refund(id: `StagingXcmV4Location`, allow_burn: `bool`)
+### refund(id: `StagingXcmV5Location`, allow_burn: `bool`)
 - **interface**: `api.tx.foreignAssets.refund`
 - **summary**:    Return the deposit (if any) of an asset account or a consumer reference (if any) of an  account. 
 
@@ -1089,7 +1828,7 @@ ___
 
    Emits `Refunded` event when successful. 
  
-### refundOther(id: `StagingXcmV4Location`, who: `MultiAddress`)
+### refundOther(id: `StagingXcmV5Location`, who: `MultiAddress`)
 - **interface**: `api.tx.foreignAssets.refundOther`
 - **summary**:    Return the deposit (if any) of a target asset account. Useful if you are the depositor. 
 
@@ -1103,7 +1842,7 @@ ___
 
    Emits `Refunded` event when successful. 
  
-### setMetadata(id: `StagingXcmV4Location`, name: `Bytes`, symbol: `Bytes`, decimals: `u8`)
+### setMetadata(id: `StagingXcmV5Location`, name: `Bytes`, symbol: `Bytes`, decimals: `u8`)
 - **interface**: `api.tx.foreignAssets.setMetadata`
 - **summary**:    Set the metadata for an asset. 
 
@@ -1123,7 +1862,7 @@ ___
 
    Weight: `O(1)` 
  
-### setMinBalance(id: `StagingXcmV4Location`, min_balance: `u128`)
+### setMinBalance(id: `StagingXcmV5Location`, min_balance: `u128`)
 - **interface**: `api.tx.foreignAssets.setMinBalance`
 - **summary**:    Sets the minimum balance of an asset. 
 
@@ -1137,7 +1876,7 @@ ___
 
    Emits `AssetMinBalanceChanged` event when successful. 
  
-### setTeam(id: `StagingXcmV4Location`, issuer: `MultiAddress`, admin: `MultiAddress`, freezer: `MultiAddress`)
+### setTeam(id: `StagingXcmV5Location`, issuer: `MultiAddress`, admin: `MultiAddress`, freezer: `MultiAddress`)
 - **interface**: `api.tx.foreignAssets.setTeam`
 - **summary**:    Change the Issuer, Admin and Freezer of an asset. 
 
@@ -1155,7 +1894,7 @@ ___
 
    Weight: `O(1)` 
  
-### startDestroy(id: `StagingXcmV4Location`)
+### startDestroy(id: `StagingXcmV5Location`)
 - **interface**: `api.tx.foreignAssets.startDestroy`
 - **summary**:    Start the process of destroying a fungible asset class. 
 
@@ -1167,7 +1906,7 @@ ___
 
    It will fail with either [`Error::ContainsHolds`] or [`Error::ContainsFreezes`] if  an account contains holds or freezes in place. 
  
-### thaw(id: `StagingXcmV4Location`, who: `MultiAddress`)
+### thaw(id: `StagingXcmV5Location`, who: `MultiAddress`)
 - **interface**: `api.tx.foreignAssets.thaw`
 - **summary**:    Allow unprivileged transfers to and from an account again. 
 
@@ -1181,7 +1920,7 @@ ___
 
    Weight: `O(1)` 
  
-### thawAsset(id: `StagingXcmV4Location`)
+### thawAsset(id: `StagingXcmV5Location`)
 - **interface**: `api.tx.foreignAssets.thawAsset`
 - **summary**:    Allow unprivileged transfers for the asset again. 
 
@@ -1193,7 +1932,7 @@ ___
 
    Weight: `O(1)` 
  
-### touch(id: `StagingXcmV4Location`)
+### touch(id: `StagingXcmV5Location`)
 - **interface**: `api.tx.foreignAssets.touch`
 - **summary**:    Create an asset account for non-provider assets. 
 
@@ -1205,7 +1944,7 @@ ___
 
    Emits `Touched` event when successful. 
  
-### touchOther(id: `StagingXcmV4Location`, who: `MultiAddress`)
+### touchOther(id: `StagingXcmV5Location`, who: `MultiAddress`)
 - **interface**: `api.tx.foreignAssets.touchOther`
 - **summary**:    Create an asset account for `who`. 
 
@@ -1219,7 +1958,7 @@ ___
 
    Emits `Touched` event when successful. 
  
-### transfer(id: `StagingXcmV4Location`, target: `MultiAddress`, amount: `Compact<u128>`)
+### transfer(id: `StagingXcmV5Location`, target: `MultiAddress`, amount: `Compact<u128>`)
 - **interface**: `api.tx.foreignAssets.transfer`
 - **summary**:    Move some assets from the sender account to another. 
 
@@ -1235,7 +1974,7 @@ ___
 
    Weight: `O(1)`  Modes: Pre-existence of `target`; Post-existence of sender; Account pre-existence of  `target`. 
  
-### transferAll(id: `StagingXcmV4Location`, dest: `MultiAddress`, keep_alive: `bool`)
+### transferAll(id: `StagingXcmV5Location`, dest: `MultiAddress`, keep_alive: `bool`)
 - **interface**: `api.tx.foreignAssets.transferAll`
 - **summary**:    Transfer the entire transferable balance from the caller asset account. 
 
@@ -1249,7 +1988,7 @@ ___
 
   - `keep_alive`: A boolean to determine if the `transfer_all` operation should send all of the funds the asset account has, causing the sender asset account to be killed  (false), or transfer everything except at least the minimum balance, which will  guarantee to keep the sender asset account alive (true). 
  
-### transferApproved(id: `StagingXcmV4Location`, owner: `MultiAddress`, destination: `MultiAddress`, amount: `Compact<u128>`)
+### transferApproved(id: `StagingXcmV5Location`, owner: `MultiAddress`, destination: `MultiAddress`, amount: `Compact<u128>`)
 - **interface**: `api.tx.foreignAssets.transferApproved`
 - **summary**:    Transfer some asset balance from a previously delegated account to some third-party  account. 
 
@@ -1269,7 +2008,7 @@ ___
 
    Weight: `O(1)` 
  
-### transferKeepAlive(id: `StagingXcmV4Location`, target: `MultiAddress`, amount: `Compact<u128>`)
+### transferKeepAlive(id: `StagingXcmV5Location`, target: `MultiAddress`, amount: `Compact<u128>`)
 - **interface**: `api.tx.foreignAssets.transferKeepAlive`
 - **summary**:    Move some assets from the sender account to another, keeping the sender account alive. 
 
@@ -1285,7 +2024,7 @@ ___
 
    Weight: `O(1)`  Modes: Pre-existence of `target`; Post-existence of sender; Account pre-existence of  `target`. 
  
-### transferOwnership(id: `StagingXcmV4Location`, owner: `MultiAddress`)
+### transferOwnership(id: `StagingXcmV5Location`, owner: `MultiAddress`)
 - **interface**: `api.tx.foreignAssets.transferOwnership`
 - **summary**:    Change the Owner of an asset. 
 
@@ -1298,6 +2037,103 @@ ___
    Emits `OwnerChanged`. 
 
    Weight: `O(1)` 
+
+___
+
+
+## indices
+ 
+### claim(index: `u32`)
+- **interface**: `api.tx.indices.claim`
+- **summary**:    Assign an previously unassigned index. 
+
+   Payment: `Deposit` is reserved from the sender account. 
+
+   The dispatch origin for this call must be _Signed_. 
+
+   - `index`: the index to be claimed. This must not be in use. 
+
+   Emits `IndexAssigned` if successful. 
+
+   #### Complexity 
+
+  - `O(1)`.
+ 
+### forceTransfer(new: `MultiAddress`, index: `u32`, freeze: `bool`)
+- **interface**: `api.tx.indices.forceTransfer`
+- **summary**:    Force an index to an account. This doesn't require a deposit. If the index is already  held, then any deposit is reimbursed to its current owner. 
+
+   The dispatch origin for this call must be _Root_. 
+
+   - `index`: the index to be (re-)assigned. 
+
+  - `new`: the new owner of the index. This function is a no-op if it is equal to sender.
+
+  - `freeze`: if set to `true`, will freeze the index so it cannot be transferred.
+
+   Emits `IndexAssigned` if successful. 
+
+   #### Complexity 
+
+  - `O(1)`.
+ 
+### free(index: `u32`)
+- **interface**: `api.tx.indices.free`
+- **summary**:    Free up an index owned by the sender. 
+
+   Payment: Any previous deposit placed for the index is unreserved in the sender account. 
+
+   The dispatch origin for this call must be _Signed_ and the sender must own the index. 
+
+   - `index`: the index to be freed. This must be owned by the sender. 
+
+   Emits `IndexFreed` if successful. 
+
+   #### Complexity 
+
+  - `O(1)`.
+ 
+### freeze(index: `u32`)
+- **interface**: `api.tx.indices.freeze`
+- **summary**:    Freeze an index so it will always point to the sender account. This consumes the  deposit. 
+
+   The dispatch origin for this call must be _Signed_ and the signing account must have a  non-frozen account `index`. 
+
+   - `index`: the index to be frozen in place. 
+
+   Emits `IndexFrozen` if successful. 
+
+   #### Complexity 
+
+  - `O(1)`.
+ 
+### pokeDeposit(index: `u32`)
+- **interface**: `api.tx.indices.pokeDeposit`
+- **summary**:    Poke the deposit reserved for an index. 
+
+   The dispatch origin for this call must be _Signed_ and the signing account must have a  non-frozen account `index`. 
+
+   The transaction fees is waived if the deposit is changed after poking/reconsideration. 
+
+   - `index`: the index whose deposit is to be poked/reconsidered. 
+
+   Emits `DepositPoked` if successful. 
+ 
+### transfer(new: `MultiAddress`, index: `u32`)
+- **interface**: `api.tx.indices.transfer`
+- **summary**:    Assign an index already owned by the sender to another account. The balance reservation  is effectively transferred to the new account. 
+
+   The dispatch origin for this call must be _Signed_. 
+
+   - `index`: the index to be re-assigned. This must be owned by the sender. 
+
+  - `new`: the new owner of the index. This function is a no-op if it is equal to sender.
+
+   Emits `IndexAssigned` if successful. 
+
+   #### Complexity 
+
+  - `O(1)`.
 
 ___
 
@@ -1325,6 +2161,111 @@ ___
 ### reapPage(message_origin: `CumulusPrimitivesCoreAggregateMessageOrigin`, page_index: `u32`)
 - **interface**: `api.tx.messageQueue.reapPage`
 - **summary**:    Remove a page which has no more messages remaining to be processed or is stale. 
+
+___
+
+
+## multiBlockElection
+ 
+### manage(op: `PalletElectionProviderMultiBlockAdminOperation`)
+- **interface**: `api.tx.multiBlockElection.manage`
+- **summary**:    Manage this pallet. 
+
+   The origin of this call must be [`Config::AdminOrigin`]. 
+
+   See [`AdminOperation`] for various operations that are possible. 
+
+___
+
+
+## multiBlockElectionSigned
+ 
+### bail()
+- **interface**: `api.tx.multiBlockElectionSigned.bail`
+- **summary**:    Retract a submission. 
+
+   A portion of the deposit may be returned, based on the [`Config::BailoutGraceRatio`]. 
+
+   This will fully remove the solution from storage. 
+ 
+### clearOldRoundData(round: `u32`, witness_pages: `u32`)
+- **interface**: `api.tx.multiBlockElectionSigned.clearOldRoundData`
+- **summary**:    Clear the data of a submitter form an old round. 
+
+   The dispatch origin of this call must be signed, and the original submitter. 
+
+   This can only be called for submissions that end up being discarded, as in they are not  processed and they end up lingering in the queue. 
+ 
+### register(claimed_score: `SpNposElectionsElectionScore`)
+- **interface**: `api.tx.multiBlockElectionSigned.register`
+- **summary**:    Register oneself for an upcoming signed election. 
+ 
+### setInvulnerables(inv: `Vec<AccountId32>`)
+- **interface**: `api.tx.multiBlockElectionSigned.setInvulnerables`
+- **summary**:    Set the invulnerable list. 
+
+   Dispatch origin must the the same as [`crate::Config::AdminOrigin`]. 
+ 
+### submitPage(page: `u32`, maybe_solution: `Option<AssetHubKusamaRuntimeStakingNposCompactSolution24>`)
+- **interface**: `api.tx.multiBlockElectionSigned.submitPage`
+- **summary**:    Submit a single page of a solution. 
+
+   Must always come after [`Pallet::register`]. 
+
+   `maybe_solution` can be set to `None` to erase the page. 
+
+   Collects deposits from the signed origin based on [`Config::DepositBase`] and  [`Config::DepositPerPage`]. 
+
+___
+
+
+## multiBlockElectionUnsigned
+ 
+### submitUnsigned(paged_solution: `PalletElectionProviderMultiBlockPagedRawSolution`)
+- **interface**: `api.tx.multiBlockElectionUnsigned.submitUnsigned`
+- **summary**:    Submit an unsigned solution. 
+
+   This works very much like an inherent, as only the validators are permitted to submit  anything. By default validators will compute this call in their `offchain_worker` hook  and try and submit it back. 
+
+   This is different from signed page submission mainly in that the solution page is  verified on the fly. 
+
+   The `paged_solution` may contain at most [`Config::MinerPages`] pages. They are  interpreted as msp -> lsp, as per [`crate::Pallet::msp_range_for`]. 
+
+   For example, if `Pages = 4`, and `MinerPages = 2`, our full snapshot range would be [0,  1, 2, 3], with 3 being msp. But, in this case, then the `paged_raw_solution.pages` is  expected to correspond to `[snapshot(2), snapshot(3)]`. 
+
+___
+
+
+## multiBlockElectionVerifier
+
+___
+
+
+## multiBlockMigrations
+ 
+### clearHistoric(selector: `PalletMigrationsHistoricCleanupSelector`)
+- **interface**: `api.tx.multiBlockMigrations.clearHistoric`
+- **summary**:    Clears the `Historic` set. 
+
+   `map_cursor` must be set to the last value that was returned by the  `HistoricCleared` event. The first time `None` can be used. `limit` must be chosen in a  way that will result in a sensible weight. 
+ 
+### forceOnboardMbms()
+- **interface**: `api.tx.multiBlockMigrations.forceOnboardMbms`
+- **summary**:    Forces the onboarding of the migrations. 
+
+   This process happens automatically on a runtime upgrade. It is in place as an emergency  measurement. The cursor needs to be `None` for this to succeed. 
+ 
+### forceSetActiveCursor(index: `u32`, inner_cursor: `Option<Bytes>`, started_at: `Option<u32>`)
+- **interface**: `api.tx.multiBlockMigrations.forceSetActiveCursor`
+- **summary**:    Allows root to set an active cursor to forcefully start/forward the migration process. 
+
+   This is an edge-case version of [`Self::force_set_cursor`] that allows to set the  `started_at` value to the next block number. Otherwise this would not be possible, since  `force_set_cursor` takes an absolute block number. Setting `started_at` to `None`  indicates that the current block number plus one should be used. 
+ 
+### forceSetCursor(cursor: `Option<PalletMigrationsMigrationCursor>`)
+- **interface**: `api.tx.multiBlockMigrations.forceSetCursor`
+- **summary**:    Allows root to set a cursor to forcefully start, stop or forward the migration process. 
+
+   Should normally not be needed and is only in place as emergency measure. Note that  restarting the migration process in this manner will not call the  [`MigrationStatusHandler::started`] hook or emit an `UpgradeStarted` event. 
 
 ___
 
@@ -2170,6 +3111,301 @@ ___
 ___
 
 
+## nominationPools
+ 
+### adjustPoolDeposit(pool_id: `u32`)
+- **interface**: `api.tx.nominationPools.adjustPoolDeposit`
+- **summary**:    Top up the deficit or withdraw the excess ED from the pool. 
+
+   When a pool is created, the pool depositor transfers ED to the reward account of the  pool. ED is subject to change and over time, the deposit in the reward account may be  insufficient to cover the ED deficit of the pool or vice-versa where there is excess  deposit to the pool. This call allows anyone to adjust the ED deposit of the  pool by either topping up the deficit or claiming the excess. 
+ 
+### applySlash(member_account: `MultiAddress`)
+- **interface**: `api.tx.nominationPools.applySlash`
+- **summary**:    Apply a pending slash on a member. 
+
+   Fails unless [`crate::pallet::Config::StakeAdapter`] is of strategy type:  [`adapter::StakeStrategyType::Delegate`]. 
+
+   The pending slash amount of the member must be equal or more than `ExistentialDeposit`.  This call can be dispatched permissionlessly (i.e. by any account). If the execution  is successful, fee is refunded and caller may be rewarded with a part of the slash  based on the [`crate::pallet::Config::StakeAdapter`] configuration. 
+ 
+### bondExtra(extra: `PalletNominationPoolsBondExtra`)
+- **interface**: `api.tx.nominationPools.bondExtra`
+- **summary**:    Bond `extra` more funds from `origin` into the pool to which they already belong. 
+
+   Additional funds can come from either the free balance of the account, of from the  accumulated rewards, see [`BondExtra`]. 
+
+   Bonding extra funds implies an automatic payout of all pending rewards as well.  See `bond_extra_other` to bond pending rewards of `other` members. 
+ 
+### bondExtraOther(member: `MultiAddress`, extra: `PalletNominationPoolsBondExtra`)
+- **interface**: `api.tx.nominationPools.bondExtraOther`
+- **summary**:    `origin` bonds funds from `extra` for some pool member `member` into their respective  pools. 
+
+   `origin` can bond extra funds from free balance or pending rewards when `origin ==  other`. 
+
+   In the case of `origin != other`, `origin` can only bond extra pending rewards of  `other` members assuming set_claim_permission for the given member is  `PermissionlessCompound` or `PermissionlessAll`. 
+ 
+### chill(pool_id: `u32`)
+- **interface**: `api.tx.nominationPools.chill`
+- **summary**:    Chill on behalf of the pool. 
+
+   The dispatch origin of this call can be signed by the pool nominator or the pool  root role, same as [`Pallet::nominate`]. 
+
+   This directly forwards the call to an implementation of `StakingInterface` (e.g.,  `pallet-staking`) through [`Config::StakeAdapter`], on behalf of the bonded pool. 
+
+   Under certain conditions, this call can be dispatched permissionlessly (i.e. by any  account). 
+
+   #### Conditions for a permissionless dispatch: 
+
+  * When pool depositor has less than `MinNominatorBond` staked, otherwise pool members are unable to unbond. 
+
+   #### Conditions for permissioned dispatch: 
+
+  * The caller is the pool's nominator or root.
+ 
+### claimCommission(pool_id: `u32`)
+- **interface**: `api.tx.nominationPools.claimCommission`
+- **summary**:    Claim pending commission. 
+
+   The `root` role of the pool is _always_ allowed to claim the pool's commission. 
+
+   If the pool has set `CommissionClaimPermission::Permissionless`, then any account can  trigger the process of claiming the pool's commission. 
+
+   If the pool has set its `CommissionClaimPermission` to `Account(acc)`, then only  accounts 
+
+  * `acc`, and
+
+  * the pool's root account
+
+   may call this extrinsic on behalf of the pool. 
+
+   Pending commissions are paid out and added to the total claimed commission.  The total pending commission is reset to zero. 
+ 
+### claimPayout()
+- **interface**: `api.tx.nominationPools.claimPayout`
+- **summary**:    A bonded member can use this to claim their payout based on the rewards that the pool  has accumulated since their last claimed payout (OR since joining if this is their first  time claiming rewards). The payout will be transferred to the member's account. 
+
+   The member will earn rewards pro rata based on the members stake vs the sum of the  members in the pools stake. Rewards do not "expire". 
+
+   See `claim_payout_other` to claim rewards on behalf of some `other` pool member. 
+ 
+### claimPayoutOther(other: `AccountId32`)
+- **interface**: `api.tx.nominationPools.claimPayoutOther`
+- **summary**:    `origin` can claim payouts on some pool member `other`'s behalf. 
+
+   Pool member `other` must have a `PermissionlessWithdraw` or `PermissionlessAll` claim  permission for this call to be successful. 
+ 
+### create(amount: `Compact<u128>`, root: `MultiAddress`, nominator: `MultiAddress`, bouncer: `MultiAddress`)
+- **interface**: `api.tx.nominationPools.create`
+- **summary**:    Create a new delegation pool. 
+
+   #### Arguments 
+
+   * `amount` - The amount of funds to delegate to the pool. This also acts of a sort of  deposit since the pools creator cannot fully unbond funds until the pool is being  destroyed. 
+
+  * `index` - A disambiguation index for creating the account. Likely only useful when creating multiple pools in the same extrinsic. 
+
+  * `root` - The account to set as [`PoolRoles::root`].
+
+  * `nominator` - The account to set as the [`PoolRoles::nominator`].
+
+  * `bouncer` - The account to set as the [`PoolRoles::bouncer`].
+
+   #### Note 
+
+   In addition to `amount`, the caller will transfer the existential deposit; so the caller  needs at have at least `amount + existential_deposit` transferable. 
+ 
+### createWithPoolId(amount: `Compact<u128>`, root: `MultiAddress`, nominator: `MultiAddress`, bouncer: `MultiAddress`, pool_id: `u32`)
+- **interface**: `api.tx.nominationPools.createWithPoolId`
+- **summary**:    Create a new delegation pool with a previously used pool id 
+
+   #### Arguments 
+
+   same as `create` with the inclusion of 
+
+  * `pool_id` - `A valid PoolId.
+ 
+### join(amount: `Compact<u128>`, pool_id: `u32`)
+- **interface**: `api.tx.nominationPools.join`
+- **summary**:    Stake funds with a pool. The amount to bond is delegated (or transferred based on  [`adapter::StakeStrategyType`]) from the member to the pool account and immediately  increases the pool's bond. 
+
+   The method of transferring the amount to the pool account is determined by  [`adapter::StakeStrategyType`]. If the pool is configured to use  [`adapter::StakeStrategyType::Delegate`], the funds remain in the account of  the `origin`, while the pool gains the right to use these funds for staking. 
+
+   #### Note 
+
+   * An account can only be a member of a single pool. 
+
+  * An account cannot join the same pool multiple times.
+
+  * This call will *not* dust the member account, so the member must have at least `existential deposit + amount` in their account. 
+
+  * Only a pool with [`PoolState::Open`] can be joined
+ 
+### migrateDelegation(member_account: `MultiAddress`)
+- **interface**: `api.tx.nominationPools.migrateDelegation`
+- **summary**:    Migrates delegated funds from the pool account to the `member_account`. 
+
+   Fails unless [`crate::pallet::Config::StakeAdapter`] is of strategy type:  [`adapter::StakeStrategyType::Delegate`]. 
+
+   This is a permission-less call and refunds any fee if claim is successful. 
+
+   If the pool has migrated to delegation based staking, the staked tokens of pool members  can be moved and held in their own account. See [`adapter::DelegateStake`] 
+ 
+### migratePoolToDelegateStake(pool_id: `u32`)
+- **interface**: `api.tx.nominationPools.migratePoolToDelegateStake`
+- **summary**:    Migrate pool from [`adapter::StakeStrategyType::Transfer`] to  [`adapter::StakeStrategyType::Delegate`]. 
+
+   Fails unless [`crate::pallet::Config::StakeAdapter`] is of strategy type:  [`adapter::StakeStrategyType::Delegate`]. 
+
+   This call can be dispatched permissionlessly, and refunds any fee if successful. 
+
+   If the pool has already migrated to delegation based staking, this call will fail. 
+ 
+### nominate(pool_id: `u32`, validators: `Vec<AccountId32>`)
+- **interface**: `api.tx.nominationPools.nominate`
+- **summary**:    Nominate on behalf of the pool. 
+
+   The dispatch origin of this call must be signed by the pool nominator or the pool  root role. 
+
+   This directly forwards the call to an implementation of `StakingInterface` (e.g.,  `pallet-staking`) through [`Config::StakeAdapter`], on behalf of the bonded pool. 
+
+   #### Note 
+
+   In addition to a `root` or `nominator` role of `origin`, the pool's depositor needs to  have at least `depositor_min_bond` in the pool to start nominating. 
+ 
+### poolWithdrawUnbonded(pool_id: `u32`, num_slashing_spans: `u32`)
+- **interface**: `api.tx.nominationPools.poolWithdrawUnbonded`
+- **summary**:    Call `withdraw_unbonded` for the pools account. This call can be made by any account. 
+
+   This is useful if there are too many unlocking chunks to call `unbond`, and some  can be cleared by withdrawing. In the case there are too many unlocking chunks, the user  would probably see an error like `NoMoreChunks` emitted from the staking system when  they attempt to unbond. 
+ 
+### setClaimPermission(permission: `PalletNominationPoolsClaimPermission`)
+- **interface**: `api.tx.nominationPools.setClaimPermission`
+- **summary**:    Allows a pool member to set a claim permission to allow or disallow permissionless  bonding and withdrawing. 
+
+   #### Arguments 
+
+   * `origin` - Member of a pool. 
+
+  * `permission` - The permission to be applied.
+ 
+### setCommission(pool_id: `u32`, new_commission: `Option<(Perbill,AccountId32)>`)
+- **interface**: `api.tx.nominationPools.setCommission`
+- **summary**:    Set the commission of a pool.  Both a commission percentage and a commission payee must be provided in the `current`  tuple. Where a `current` of `None` is provided, any current commission will be removed. 
+
+   - If a `None` is supplied to `new_commission`, existing commission will be removed. 
+ 
+### setCommissionChangeRate(pool_id: `u32`, change_rate: `PalletNominationPoolsCommissionChangeRate`)
+- **interface**: `api.tx.nominationPools.setCommissionChangeRate`
+- **summary**:    Set the commission change rate for a pool. 
+
+   Initial change rate is not bounded, whereas subsequent updates can only be more  restrictive than the current. 
+ 
+### setCommissionClaimPermission(pool_id: `u32`, permission: `Option<PalletNominationPoolsCommissionClaimPermission>`)
+- **interface**: `api.tx.nominationPools.setCommissionClaimPermission`
+- **summary**:    Set or remove a pool's commission claim permission. 
+
+   Determines who can claim the pool's pending commission. Only the `Root` role of the pool  is able to configure commission claim permissions. 
+ 
+### setCommissionMax(pool_id: `u32`, max_commission: `Perbill`)
+- **interface**: `api.tx.nominationPools.setCommissionMax`
+- **summary**:    Set the maximum commission of a pool. 
+
+   - Initial max can be set to any `Perbill`, and only smaller values thereafter. 
+
+  - Current commission will be lowered in the event it is higher than a new max commission. 
+ 
+### setConfigs(min_join_bond: `PalletNominationPoolsConfigOpU128`, min_create_bond: `PalletNominationPoolsConfigOpU128`, max_pools: `PalletNominationPoolsConfigOpU32`, max_members: `PalletNominationPoolsConfigOpU32`, max_members_per_pool: `PalletNominationPoolsConfigOpU32`, global_max_commission: `PalletNominationPoolsConfigOpPerbill`)
+- **interface**: `api.tx.nominationPools.setConfigs`
+- **summary**:    Update configurations for the nomination pools. The origin for this call must be  [`Config::AdminOrigin`]. 
+
+   #### Arguments 
+
+   * `min_join_bond` - Set [`MinJoinBond`]. 
+
+  * `min_create_bond` - Set [`MinCreateBond`].
+
+  * `max_pools` - Set [`MaxPools`].
+
+  * `max_members` - Set [`MaxPoolMembers`].
+
+  * `max_members_per_pool` - Set [`MaxPoolMembersPerPool`].
+
+  * `global_max_commission` - Set [`GlobalMaxCommission`].
+ 
+### setMetadata(pool_id: `u32`, metadata: `Bytes`)
+- **interface**: `api.tx.nominationPools.setMetadata`
+- **summary**:    Set a new metadata for the pool. 
+
+   The dispatch origin of this call must be signed by the bouncer, or the root role of the  pool. 
+ 
+### setState(pool_id: `u32`, state: `PalletNominationPoolsPoolState`)
+- **interface**: `api.tx.nominationPools.setState`
+- **summary**:    Set a new state for the pool. 
+
+   If a pool is already in the `Destroying` state, then under no condition can its state  change again. 
+
+   The dispatch origin of this call must be either: 
+
+   1. signed by the bouncer, or the root role of the pool,  2. if the pool conditions to be open are NOT met (as described by `ok_to_be_open`), and  then the state of the pool can be permissionlessly changed to `Destroying`. 
+ 
+### unbond(member_account: `MultiAddress`, unbonding_points: `Compact<u128>`)
+- **interface**: `api.tx.nominationPools.unbond`
+- **summary**:    Unbond up to `unbonding_points` of the `member_account`'s funds from the pool. It  implicitly collects the rewards one last time, since not doing so would mean some  rewards would be forfeited. 
+
+   Under certain conditions, this call can be dispatched permissionlessly (i.e. by any  account). 
+
+   #### Conditions for a permissionless dispatch. 
+
+   * The pool is blocked and the caller is either the root or bouncer. This is refereed to  as a kick. 
+
+  * The pool is destroying and the member is not the depositor.
+
+  * The pool is destroying, the member is the depositor and no other members are in the pool. 
+
+   #### Conditions for permissioned dispatch (i.e. the caller is also the  `member_account`): 
+
+   * The caller is not the depositor. 
+
+  * The caller is the depositor, the pool is destroying and no other members are in the pool. 
+
+   #### Note 
+
+   If there are too many unlocking chunks to unbond with the pool account,  [`Call::pool_withdraw_unbonded`] can be called to try and minimize unlocking chunks.  The [`StakingInterface::unbond`] will implicitly call [`Call::pool_withdraw_unbonded`]  to try to free chunks if necessary (ie. if unbound was called and no unlocking chunks  are available). However, it may not be possible to release the current unlocking chunks,  in which case, the result of this call will likely be the `NoMoreChunks` error from the  staking system. 
+ 
+### updateRoles(pool_id: `u32`, new_root: `PalletNominationPoolsConfigOpAccountId32`, new_nominator: `PalletNominationPoolsConfigOpAccountId32`, new_bouncer: `PalletNominationPoolsConfigOpAccountId32`)
+- **interface**: `api.tx.nominationPools.updateRoles`
+- **summary**:    Update the roles of the pool. 
+
+   The root is the only entity that can change any of the roles, including itself,  excluding the depositor, who can never change. 
+
+   It emits an event, notifying UIs of the role change. This event is quite relevant to  most pool members and they should be informed of changes to pool roles. 
+ 
+### withdrawUnbonded(member_account: `MultiAddress`, num_slashing_spans: `u32`)
+- **interface**: `api.tx.nominationPools.withdrawUnbonded`
+- **summary**:    Withdraw unbonded funds from `member_account`. If no bonded funds can be unbonded, an  error is returned. 
+
+   Under certain conditions, this call can be dispatched permissionlessly (i.e. by any  account). 
+
+   #### Conditions for a permissionless dispatch 
+
+   * The pool is in destroy mode and the target is not the depositor. 
+
+  * The target is the depositor and they are the only member in the sub pools.
+
+  * The pool is blocked and the caller is either the root or bouncer.
+
+   #### Conditions for permissioned dispatch 
+
+   * The caller is the target and they are not the depositor. 
+
+   #### Note 
+
+   - If the target is the depositor, the pool will be destroyed. 
+
+  - If the pool has any pending slash, we also try to slash the member before letting them withdraw. This calculation adds some weight overhead and is only defensive. In reality,  pool slashes must have been already applied via permissionless [`Call::apply_slash`]. 
+
+___
+
+
 ## parachainInfo
 
 ___
@@ -2177,7 +3413,7 @@ ___
 
 ## parachainSystem
  
-### setValidationData(data: `CumulusPrimitivesParachainInherentParachainInherentData`)
+### setValidationData(data: `CumulusPalletParachainSystemParachainInherentBasicParachainInherentData`, inbound_messages_data: `CumulusPalletParachainSystemParachainInherentInboundMessagesData`)
 - **interface**: `api.tx.parachainSystem.setValidationData`
 - **summary**:    Set the current validation data. 
 
@@ -2189,6 +3425,17 @@ ___
  
 ### sudoSendUpwardMessage(message: `Bytes`)
 - **interface**: `api.tx.parachainSystem.sudoSendUpwardMessage`
+
+___
+
+
+## parameters
+ 
+### setParameter(key_value: `AssetHubKusamaRuntimeRuntimeParameters`)
+- **interface**: `api.tx.parameters.setParameter`
+- **summary**:    Set the value of a parameter. 
+
+   The dispatch origin of this call must be `AdminOrigin` for the given `key`. Values be  deleted by setting them to `None`. 
 
 ___
 
@@ -2952,6 +4199,45 @@ ___
 ___
 
 
+## preimage
+ 
+### ensureUpdated(hashes: `Vec<H256>`)
+- **interface**: `api.tx.preimage.ensureUpdated`
+- **summary**:    Ensure that the bulk of pre-images is upgraded. 
+
+   The caller pays no fee if at least 90% of pre-images were successfully updated. 
+ 
+### notePreimage(bytes: `Bytes`)
+- **interface**: `api.tx.preimage.notePreimage`
+- **summary**:    Register a preimage on-chain. 
+
+   If the preimage was previously requested, no fees or deposits are taken for providing  the preimage. Otherwise, a deposit is taken proportional to the size of the preimage. 
+ 
+### requestPreimage(hash: `H256`)
+- **interface**: `api.tx.preimage.requestPreimage`
+- **summary**:    Request a preimage be uploaded to the chain without paying any fees or deposits. 
+
+   If the preimage requests has already been provided on-chain, we unreserve any deposit  a user may have paid, and take the control of the preimage out of their hands. 
+ 
+### unnotePreimage(hash: `H256`)
+- **interface**: `api.tx.preimage.unnotePreimage`
+- **summary**:    Clear an unrequested preimage from the runtime storage. 
+
+   If `len` is provided, then it will be a much cheaper operation. 
+
+   - `hash`: The hash of the preimage to be removed from the store. 
+
+  - `len`: The length of the preimage of `hash`.
+ 
+### unrequestPreimage(hash: `H256`)
+- **interface**: `api.tx.preimage.unrequestPreimage`
+- **summary**:    Clear a previously made request for a preimage. 
+
+   NOTE: THIS MUST NOT BE CALLED ON `hash` MORE TIMES THAN `request_preimage`. 
+
+___
+
+
 ## proxy
  
 ### addProxy(delegate: `MultiAddress`, proxy_type: `AssetHubKusamaRuntimeProxyType`, delay: `u32`)
@@ -3008,19 +4294,19 @@ ___
 
    WARNING: **All access to this account will be lost.** Any funds held in it will be  inaccessible. 
 
-   Requires a `Signed` origin, and the sender account must have been created by a call to  `pure` with corresponding parameters. 
+   Requires a `Signed` origin, and the sender account must have been created by a call to  `create_pure` with corresponding parameters. 
 
-   - `spawner`: The account that originally called `pure` to create this account. 
+   - `spawner`: The account that originally called `create_pure` to create this account. 
 
-  - `index`: The disambiguation index originally passed to `pure`. Probably `0`.
+  - `index`: The disambiguation index originally passed to `create_pure`. Probably `0`.
 
-  - `proxy_type`: The proxy type originally passed to `pure`.
+  - `proxy_type`: The proxy type originally passed to `create_pure`.
 
-  - `height`: The height of the chain when the call to `pure` was processed.
+  - `height`: The height of the chain when the call to `create_pure` was processed.
 
-  - `ext_index`: The extrinsic index in which the call to `pure` was processed.
+  - `ext_index`: The extrinsic index in which the call to `create_pure` was processed.
 
-   Fails with `NoPermission` in case the caller is not a previously created pure  account whose `pure` call has corresponding parameters. 
+   Fails with `NoPermission` in case the caller is not a previously created pure  account whose `create_pure` call has corresponding parameters. 
  
 ### pokeDeposit()
 - **interface**: `api.tx.proxy.pokeDeposit`
@@ -3096,7 +4382,7 @@ ___
 
    The dispatch origin for this call must be _Signed_. 
 
-   WARNING: This may be called on accounts created by `pure`, however if done, then  the unreserved fees will be inaccessible. **All access to this account will be lost.** 
+   WARNING: This may be called on accounts created by `create_pure`, however if done, then  the unreserved fees will be inaccessible. **All access to this account will be lost.** 
  
 ### removeProxy(delegate: `MultiAddress`, proxy_type: `AssetHubKusamaRuntimeProxyType`, delay: `u32`)
 - **interface**: `api.tx.proxy.removeProxy`
@@ -3109,6 +4395,246 @@ ___
   - `proxy`: The account that the `caller` would like to remove as a proxy.
 
   - `proxy_type`: The permissions currently enabled for the removed proxy account.
+
+___
+
+
+## recovery
+ 
+### asRecovered(account: `MultiAddress`, call: `Call`)
+- **interface**: `api.tx.recovery.asRecovered`
+- **summary**:    Send a call through a recovered account. 
+
+   The dispatch origin for this call must be _Signed_ and registered to  be able to make calls on behalf of the recovered account. 
+
+   Parameters: 
+
+  - `account`: The recovered account you want to make a call on-behalf-of.
+
+  - `call`: The call you want to make with the recovered account.
+ 
+### cancelRecovered(account: `MultiAddress`)
+- **interface**: `api.tx.recovery.cancelRecovered`
+- **summary**:    Cancel the ability to use `as_recovered` for `account`. 
+
+   The dispatch origin for this call must be _Signed_ and registered to  be able to make calls on behalf of the recovered account. 
+
+   Parameters: 
+
+  - `account`: The recovered account you are able to call on-behalf-of.
+ 
+### claimRecovery(account: `MultiAddress`)
+- **interface**: `api.tx.recovery.claimRecovery`
+- **summary**:    Allow a successful rescuer to claim their recovered account. 
+
+   The dispatch origin for this call must be _Signed_ and must be a "rescuer"  who has successfully completed the account recovery process: collected  `threshold` or more vouches, waited `delay_period` blocks since initiation. 
+
+   Parameters: 
+
+  - `account`: The lost account that you want to claim has been successfully recovered by you. 
+ 
+### closeRecovery(rescuer: `MultiAddress`)
+- **interface**: `api.tx.recovery.closeRecovery`
+- **summary**:    As the controller of a recoverable account, close an active recovery  process for your account. 
+
+   Payment: By calling this function, the recoverable account will receive  the recovery deposit `RecoveryDeposit` placed by the rescuer. 
+
+   The dispatch origin for this call must be _Signed_ and must be a  recoverable account with an active recovery process for it. 
+
+   Parameters: 
+
+  - `rescuer`: The account trying to rescue this recoverable account.
+ 
+### createRecovery(friends: `Vec<AccountId32>`, threshold: `u16`, delay_period: `u32`)
+- **interface**: `api.tx.recovery.createRecovery`
+- **summary**:    Create a recovery configuration for your account. This makes your account recoverable. 
+
+   Payment: `ConfigDepositBase` + `FriendDepositFactor` * #_of_friends balance  will be reserved for storing the recovery configuration. This deposit is returned  in full when the user calls `remove_recovery`. 
+
+   The dispatch origin for this call must be _Signed_. 
+
+   Parameters: 
+
+  - `friends`: A list of friends you trust to vouch for recovery attempts. Should be ordered and contain no duplicate values. 
+
+  - `threshold`: The number of friends that must vouch for a recovery attempt before the account can be recovered. Should be less than or equal to the length of the list of  friends. 
+
+  - `delay_period`: The number of blocks after a recovery attempt is initialized that needs to pass before the account can be recovered. 
+ 
+### initiateRecovery(account: `MultiAddress`)
+- **interface**: `api.tx.recovery.initiateRecovery`
+- **summary**:    Initiate the process for recovering a recoverable account. 
+
+   Payment: `RecoveryDeposit` balance will be reserved for initiating the  recovery process. This deposit will always be repatriated to the account  trying to be recovered. See `close_recovery`. 
+
+   The dispatch origin for this call must be _Signed_. 
+
+   Parameters: 
+
+  - `account`: The lost account that you want to recover. This account needs to be recoverable (i.e. have a recovery configuration). 
+ 
+### pokeDeposit(maybe_account: `Option<MultiAddress>`)
+- **interface**: `api.tx.recovery.pokeDeposit`
+- **summary**:    Poke deposits for recovery configurations and / or active recoveries. 
+
+   This can be used by accounts to possibly lower their locked amount. 
+
+   The dispatch origin for this call must be _Signed_. 
+
+   Parameters: 
+
+  - `maybe_account`: Optional recoverable account for which you have an active recovery and want to adjust the deposit for the active recovery. 
+
+   This function checks both recovery configuration deposit and active recovery deposits  of the caller: 
+
+  - If the caller has created a recovery configuration, checks and adjusts its deposit
+
+  - If the caller has initiated any active recoveries, and provides the account in `maybe_account`, checks and adjusts those deposits 
+
+   If any deposit is updated, the difference will be reserved/unreserved from the caller's  account. 
+
+   The transaction is made free if any deposit is updated and paid otherwise. 
+
+   Emits `DepositPoked` if any deposit is updated.  Multiple events may be emitted in case both types of deposits are updated. 
+ 
+### removeRecovery()
+- **interface**: `api.tx.recovery.removeRecovery`
+- **summary**:    Remove the recovery process for your account. Recovered accounts are still accessible. 
+
+   NOTE: The user must make sure to call `close_recovery` on all active  recovery attempts before calling this function else it will fail. 
+
+   Payment: By calling this function the recoverable account will unreserve  their recovery configuration deposit.  (`ConfigDepositBase` + `FriendDepositFactor` * #_of_friends) 
+
+   The dispatch origin for this call must be _Signed_ and must be a  recoverable account (i.e. has a recovery configuration). 
+ 
+### setRecovered(lost: `MultiAddress`, rescuer: `MultiAddress`)
+- **interface**: `api.tx.recovery.setRecovered`
+- **summary**:    Allow ROOT to bypass the recovery process and set a rescuer account  for a lost account directly. 
+
+   The dispatch origin for this call must be _ROOT_. 
+
+   Parameters: 
+
+  - `lost`: The "lost account" to be recovered.
+
+  - `rescuer`: The "rescuer account" which can call as the lost account.
+ 
+### vouchRecovery(lost: `MultiAddress`, rescuer: `MultiAddress`)
+- **interface**: `api.tx.recovery.vouchRecovery`
+- **summary**:    Allow a "friend" of a recoverable account to vouch for an active recovery  process for that account. 
+
+   The dispatch origin for this call must be _Signed_ and must be a "friend"  for the recoverable account. 
+
+   Parameters: 
+
+  - `lost`: The lost account that you want to recover.
+
+  - `rescuer`: The account trying to rescue the lost account that you want to vouch for.
+
+   The combination of these two parameters must point to an active recovery  process. 
+
+___
+
+
+## referenda
+ 
+### cancel(index: `u32`)
+- **interface**: `api.tx.referenda.cancel`
+- **summary**:    Cancel an ongoing referendum. 
+
+   - `origin`: must be the `CancelOrigin`. 
+
+  - `index`: The index of the referendum to be cancelled.
+
+   Emits `Cancelled`. 
+ 
+### kill(index: `u32`)
+- **interface**: `api.tx.referenda.kill`
+- **summary**:    Cancel an ongoing referendum and slash the deposits. 
+
+   - `origin`: must be the `KillOrigin`. 
+
+  - `index`: The index of the referendum to be cancelled.
+
+   Emits `Killed` and `DepositSlashed`. 
+ 
+### nudgeReferendum(index: `u32`)
+- **interface**: `api.tx.referenda.nudgeReferendum`
+- **summary**:    Advance a referendum onto its next logical state. Only used internally. 
+
+   - `origin`: must be `Root`. 
+
+  - `index`: the referendum to be advanced.
+ 
+### oneFewerDeciding(track: `u16`)
+- **interface**: `api.tx.referenda.oneFewerDeciding`
+- **summary**:    Advance a track onto its next logical state. Only used internally. 
+
+   - `origin`: must be `Root`. 
+
+  - `track`: the track to be advanced.
+
+   Action item for when there is now one fewer referendum in the deciding phase and the  `DecidingCount` is not yet updated. This means that we should either: 
+
+  - begin deciding another referendum (and leave `DecidingCount` alone); or
+
+  - decrement `DecidingCount`.
+ 
+### placeDecisionDeposit(index: `u32`)
+- **interface**: `api.tx.referenda.placeDecisionDeposit`
+- **summary**:    Post the Decision Deposit for a referendum. 
+
+   - `origin`: must be `Signed` and the account must have funds available for the  referendum's track's Decision Deposit. 
+
+  - `index`: The index of the submitted referendum whose Decision Deposit is yet to be posted. 
+
+   Emits `DecisionDepositPlaced`. 
+ 
+### refundDecisionDeposit(index: `u32`)
+- **interface**: `api.tx.referenda.refundDecisionDeposit`
+- **summary**:    Refund the Decision Deposit for a closed referendum back to the depositor. 
+
+   - `origin`: must be `Signed` or `Root`. 
+
+  - `index`: The index of a closed referendum whose Decision Deposit has not yet been refunded. 
+
+   Emits `DecisionDepositRefunded`. 
+ 
+### refundSubmissionDeposit(index: `u32`)
+- **interface**: `api.tx.referenda.refundSubmissionDeposit`
+- **summary**:    Refund the Submission Deposit for a closed referendum back to the depositor. 
+
+   - `origin`: must be `Signed` or `Root`. 
+
+  - `index`: The index of a closed referendum whose Submission Deposit has not yet been refunded. 
+
+   Emits `SubmissionDepositRefunded`. 
+ 
+### setMetadata(index: `u32`, maybe_hash: `Option<H256>`)
+- **interface**: `api.tx.referenda.setMetadata`
+- **summary**:    Set or clear metadata of a referendum. 
+
+   Parameters: 
+
+  - `origin`: Must be `Signed` by a creator of a referendum or by anyone to clear a metadata of a finished referendum. 
+
+  - `index`:  The index of a referendum to set or clear metadata for.
+
+  - `maybe_hash`: The hash of an on-chain stored preimage. `None` to clear a metadata.
+ 
+### submit(proposal_origin: `AssetHubKusamaRuntimeOriginCaller`, proposal: `FrameSupportPreimagesBounded`, enactment_moment: `FrameSupportScheduleDispatchTime`)
+- **interface**: `api.tx.referenda.submit`
+- **summary**:    Propose a referendum on a privileged action. 
+
+   - `origin`: must be `SubmitOrigin` and the account must have `SubmissionDeposit` funds  available. 
+
+  - `proposal_origin`: The origin from which the proposal should be executed.
+
+  - `proposal`: The proposal.
+
+  - `enactment_moment`: The moment that the proposal should be enacted.
+
+   Emits `Submitted`. 
 
 ___
 
@@ -3194,6 +4720,16 @@ ___
 
    Every `AccountId32` can control its corresponding fallback account. The fallback account  is the `AccountId20` with the last 12 bytes set to `0xEE`. This is essentially a  recovery function in case an `AccountId20` was used without creating a mapping first. 
  
+### ethCall(dest: `H160`, value: `U256`, gas_limit: `SpWeightsWeightV2Weight`, storage_deposit_limit: `Compact<u128>`, data: `Bytes`)
+- **interface**: `api.tx.revive.ethCall`
+- **summary**:    Same as [`Self::call`], but intended to be dispatched **only**  by an EVM transaction through the EVM compatibility layer. 
+ 
+### ethInstantiateWithCode(value: `U256`, gas_limit: `SpWeightsWeightV2Weight`, storage_deposit_limit: `Compact<u128>`, code: `Bytes`, data: `Bytes`)
+- **interface**: `api.tx.revive.ethInstantiateWithCode`
+- **summary**:    Same as [`Self::instantiate_with_code`], but intended to be dispatched **only**  by an EVM transaction through the EVM compatibility layer. 
+
+   Calling this dispatchable ensures that the origin's nonce is bumped only once,  via the `CheckNonce` transaction extension. In contrast, [`Self::instantiate_with_code`]  also bumps the nonce after contract instantiation, since it may be invoked multiple  times within a batch call transaction. 
+ 
 ### ethTransact(payload: `Bytes`)
 - **interface**: `api.tx.revive.ethTransact`
 - **summary**:    A raw EVM transaction, typically dispatched by an Ethereum JSON-RPC server. 
@@ -3212,9 +4748,9 @@ ___
  
 ### instantiate(value: `Compact<u128>`, gas_limit: `SpWeightsWeightV2Weight`, storage_deposit_limit: `Compact<u128>`, code_hash: `H256`, data: `Bytes`, salt: `Option<[u8;32]>`)
 - **interface**: `api.tx.revive.instantiate`
-- **summary**:    Instantiates a contract from a previously deployed wasm binary. 
+- **summary**:    Instantiates a contract from a previously deployed vm binary. 
 
-   This function is identical to [`Self::instantiate_with_code`] but without the  code deployment step. Instead, the `code_hash` of an on-chain deployed wasm binary  must be supplied. 
+   This function is identical to [`Self::instantiate_with_code`] but without the  code deployment step. Instead, the `code_hash` of an on-chain deployed vm binary  must be supplied. 
  
 ### instantiateWithCode(value: `Compact<u128>`, gas_limit: `SpWeightsWeightV2Weight`, storage_deposit_limit: `Compact<u128>`, code: `Bytes`, data: `Bytes`, salt: `Option<[u8;32]>`)
 - **interface**: `api.tx.revive.instantiateWithCode`
@@ -3293,6 +4829,59 @@ ___
 ___
 
 
+## scheduler
+ 
+### cancel(when: `u32`, index: `u32`)
+- **interface**: `api.tx.scheduler.cancel`
+- **summary**:    Cancel an anonymously scheduled task. 
+ 
+### cancelNamed(id: `[u8;32]`)
+- **interface**: `api.tx.scheduler.cancelNamed`
+- **summary**:    Cancel a named scheduled task. 
+ 
+### cancelRetry(task: `(u32,u32)`)
+- **interface**: `api.tx.scheduler.cancelRetry`
+- **summary**:    Removes the retry configuration of a task. 
+ 
+### cancelRetryNamed(id: `[u8;32]`)
+- **interface**: `api.tx.scheduler.cancelRetryNamed`
+- **summary**:    Cancel the retry configuration of a named task. 
+ 
+### schedule(when: `u32`, maybe_periodic: `Option<(u32,u32)>`, priority: `u8`, call: `Call`)
+- **interface**: `api.tx.scheduler.schedule`
+- **summary**:    Anonymously schedule a task. 
+ 
+### scheduleAfter(after: `u32`, maybe_periodic: `Option<(u32,u32)>`, priority: `u8`, call: `Call`)
+- **interface**: `api.tx.scheduler.scheduleAfter`
+- **summary**:    Anonymously schedule a task after a delay. 
+ 
+### scheduleNamed(id: `[u8;32]`, when: `u32`, maybe_periodic: `Option<(u32,u32)>`, priority: `u8`, call: `Call`)
+- **interface**: `api.tx.scheduler.scheduleNamed`
+- **summary**:    Schedule a named task. 
+ 
+### scheduleNamedAfter(id: `[u8;32]`, after: `u32`, maybe_periodic: `Option<(u32,u32)>`, priority: `u8`, call: `Call`)
+- **interface**: `api.tx.scheduler.scheduleNamedAfter`
+- **summary**:    Schedule a named task after a delay. 
+ 
+### setRetry(task: `(u32,u32)`, retries: `u8`, period: `u32`)
+- **interface**: `api.tx.scheduler.setRetry`
+- **summary**:    Set a retry configuration for a task so that, in case its scheduled run fails, it will  be retried after `period` blocks, for a total amount of `retries` retries or until it  succeeds. 
+
+   Tasks which need to be scheduled for a retry are still subject to weight metering and  agenda space, same as a regular task. If a periodic task fails, it will be scheduled  normally while the task is retrying. 
+
+   Tasks scheduled as a result of a retry for a periodic task are unnamed, non-periodic  clones of the original task. Their retry configuration will be derived from the  original task's configuration, but will have a lower value for `remaining` than the  original `total_retries`. 
+ 
+### setRetryNamed(id: `[u8;32]`, retries: `u8`, period: `u32`)
+- **interface**: `api.tx.scheduler.setRetryNamed`
+- **summary**:    Set a retry configuration for a named task so that, in case its scheduled run fails, it  will be retried after `period` blocks, for a total amount of `retries` retries or until  it succeeds. 
+
+   Tasks which need to be scheduled for a retry are still subject to weight metering and  agenda space, same as a regular task. If a periodic task fails, it will be scheduled  normally while the task is retrying. 
+
+   Tasks scheduled as a result of a retry for a periodic task are unnamed, non-periodic  clones of the original task. Their retry configuration will be derived from the  original task's configuration, but will have a lower value for `remaining` than the  original `total_retries`. 
+
+___
+
+
 ## session
  
 ### purgeKeys()
@@ -3316,6 +4905,608 @@ ___
    #### Complexity 
 
   - `O(1)`. Actual cost depends on the number of length of `T::Keys::key_ids()` which is fixed. 
+
+___
+
+
+## society
+ 
+### bestowMembership(candidate: `AccountId32`)
+- **interface**: `api.tx.society.bestowMembership`
+- **summary**:    Transform an approved candidate into a member. Callable only by the Signed origin of the  Founder, only after the period for voting has ended and only when the candidate is not  clearly rejected. 
+ 
+### bid(value: `u128`)
+- **interface**: `api.tx.society.bid`
+- **summary**:    A user outside of the society can make a bid for entry. 
+
+   Payment: The group's Candidate Deposit will be reserved for making a bid. It is returned  when the bid becomes a member, or if the bid calls `unbid`. 
+
+   The dispatch origin for this call must be _Signed_. 
+
+   Parameters: 
+
+  - `value`: A one time payment the bid would like to receive when joining the society.
+ 
+### claimMembership()
+- **interface**: `api.tx.society.claimMembership`
+- **summary**:    Transform an approved candidate into a member. Callable only by the  the candidate, and only after the period for voting has ended. 
+ 
+### cleanupCandidacy(candidate: `AccountId32`, max: `u32`)
+- **interface**: `api.tx.society.cleanupCandidacy`
+- **summary**:    Remove up to `max` stale votes for the given `candidate`. 
+
+   May be called by any Signed origin, but only after the candidate's candidacy is ended. 
+ 
+### cleanupChallenge(challenge_round: `u32`, max: `u32`)
+- **interface**: `api.tx.society.cleanupChallenge`
+- **summary**:    Remove up to `max` stale votes for the defender in the given `challenge_round`. 
+
+   May be called by any Signed origin, but only after the challenge round is ended. 
+ 
+### defenderVote(approve: `bool`)
+- **interface**: `api.tx.society.defenderVote`
+- **summary**:    As a member, vote on the defender. 
+
+   The dispatch origin for this call must be _Signed_ and a member. 
+
+   Parameters: 
+
+  - `approve`: A boolean which says if the candidate should be approved (`true`) or rejected (`false`). 
+ 
+### dissolve()
+- **interface**: `api.tx.society.dissolve`
+- **summary**:    Dissolve the society and remove all members. 
+
+   The dispatch origin for this call must be Signed, and the signing account must be both  the `Founder` and the `Head`. This implies that it may only be done when there is one  member. 
+ 
+### dropCandidate(candidate: `AccountId32`)
+- **interface**: `api.tx.society.dropCandidate`
+- **summary**:    Remove a `candidate`'s failed application from the society. Callable by any  signed origin but only at the end of the subsequent round and only for  a candidate with more rejections than approvals. 
+
+   The bid deposit is lost and the voucher is banned. 
+ 
+### foundSociety(founder: `MultiAddress`, max_members: `u32`, max_intake: `u32`, max_strikes: `u32`, candidate_deposit: `u128`, rules: `Bytes`)
+- **interface**: `api.tx.society.foundSociety`
+- **summary**:    Found the society. 
+
+   This is done as a discrete action in order to allow for the  pallet to be included into a running chain and can only be done once. 
+
+   The dispatch origin for this call must be from the _FounderSetOrigin_. 
+
+   Parameters: 
+
+  - `founder` - The first member and head of the newly founded society.
+
+  - `max_members` - The initial max number of members for the society.
+
+  - `max_intake` - The maximum number of candidates per intake period.
+
+  - `max_strikes`: The maximum number of strikes a member may get before they become suspended and may only be reinstated by the founder. 
+
+  - `candidate_deposit`: The deposit required to make a bid for membership of the group.
+
+  - `rules` - The rules of this society concerning membership.
+
+   Complexity: O(1) 
+ 
+### judgeSuspendedMember(who: `MultiAddress`, forgive: `bool`)
+- **interface**: `api.tx.society.judgeSuspendedMember`
+- **summary**:    Allow suspension judgement origin to make judgement on a suspended member. 
+
+   If a suspended member is forgiven, we simply add them back as a member, not affecting  any of the existing storage items for that member. 
+
+   If a suspended member is rejected, remove all associated storage items, including  their payouts, and remove any vouched bids they currently have. 
+
+   The dispatch origin for this call must be Signed from the Founder. 
+
+   Parameters: 
+
+  - `who` - The suspended member to be judged.
+
+  - `forgive` - A boolean representing whether the suspension judgement origin forgives (`true`) or rejects (`false`) a suspended member. 
+ 
+### kickCandidate(candidate: `AccountId32`)
+- **interface**: `api.tx.society.kickCandidate`
+- **summary**:    Remove the candidate's application from the society. Callable only by the Signed origin  of the Founder, only after the period for voting has ended, and only when they do not  have a clear approval. 
+
+   Any bid deposit is lost and voucher is banned. 
+ 
+### payout()
+- **interface**: `api.tx.society.payout`
+- **summary**:    Transfer the first matured payout for the sender and remove it from the records. 
+
+   NOTE: This extrinsic needs to be called multiple times to claim multiple matured  payouts. 
+
+   Payment: The member will receive a payment equal to their first matured  payout to their free balance. 
+
+   The dispatch origin for this call must be _Signed_ and a member with  payouts remaining. 
+ 
+### pokeDeposit()
+- **interface**: `api.tx.society.pokeDeposit`
+- **summary**:    Poke the deposit reserved when bidding. 
+
+   The dispatch origin for this call must be _Signed_ and must be the bidder. 
+
+   The transaction fee is waived if the deposit is changed after poking/reconsideration. 
+
+   Emits `DepositPoked` if successful. 
+ 
+### punishSkeptic()
+- **interface**: `api.tx.society.punishSkeptic`
+- **summary**:    Punish the skeptic with a strike if they did not vote on a candidate. Callable by the  candidate. 
+ 
+### resignCandidacy()
+- **interface**: `api.tx.society.resignCandidacy`
+- **summary**:    Remove the candidate's application from the society. Callable only by the candidate. 
+
+   Any bid deposit is lost and voucher is banned. 
+ 
+### setParameters(max_members: `u32`, max_intake: `u32`, max_strikes: `u32`, candidate_deposit: `u128`)
+- **interface**: `api.tx.society.setParameters`
+- **summary**:    Change the maximum number of members in society and the maximum number of new candidates  in a single intake period. 
+
+   The dispatch origin for this call must be Signed by the Founder. 
+
+   Parameters: 
+
+  - `max_members` - The maximum number of members for the society. This must be no less than the current number of members. 
+
+  - `max_intake` - The maximum number of candidates per intake period.
+
+  - `max_strikes`: The maximum number of strikes a member may get before they become suspended and may only be reinstated by the founder. 
+
+  - `candidate_deposit`: The deposit required to make a bid for membership of the group.
+ 
+### unbid()
+- **interface**: `api.tx.society.unbid`
+- **summary**:    A bidder can remove their bid for entry into society.  By doing so, they will have their candidate deposit returned or  they will unvouch their voucher. 
+
+   Payment: The bid deposit is unreserved if the user made a bid. 
+
+   The dispatch origin for this call must be _Signed_ and a bidder. 
+ 
+### unvouch()
+- **interface**: `api.tx.society.unvouch`
+- **summary**:    As a vouching member, unvouch a bid. This only works while vouched user is  only a bidder (and not a candidate). 
+
+   The dispatch origin for this call must be _Signed_ and a vouching member. 
+
+   Parameters: 
+
+  - `pos`: Position in the `Bids` vector of the bid who should be unvouched.
+ 
+### vote(candidate: `MultiAddress`, approve: `bool`)
+- **interface**: `api.tx.society.vote`
+- **summary**:    As a member, vote on a candidate. 
+
+   The dispatch origin for this call must be _Signed_ and a member. 
+
+   Parameters: 
+
+  - `candidate`: The candidate that the member would like to bid on.
+
+  - `approve`: A boolean which says if the candidate should be approved (`true`) or rejected (`false`). 
+ 
+### vouch(who: `MultiAddress`, value: `u128`, tip: `u128`)
+- **interface**: `api.tx.society.vouch`
+- **summary**:    As a member, vouch for someone to join society by placing a bid on their behalf. 
+
+   There is no deposit required to vouch for a new bid, but a member can only vouch for  one bid at a time. If the bid becomes a suspended candidate and ultimately rejected by  the suspension judgement origin, the member will be banned from vouching again. 
+
+   As a vouching member, you can claim a tip if the candidate is accepted. This tip will  be paid as a portion of the reward the member will receive for joining the society. 
+
+   The dispatch origin for this call must be _Signed_ and a member. 
+
+   Parameters: 
+
+  - `who`: The user who you would like to vouch for.
+
+  - `value`: The total reward to be paid between you and the candidate if they become a member in the society. 
+
+  - `tip`: Your cut of the total `value` payout when the candidate is inducted into the society. Tips larger than `value` will be saturated upon payout. 
+ 
+### waiveRepay(amount: `u128`)
+- **interface**: `api.tx.society.waiveRepay`
+- **summary**:    Repay the payment previously given to the member with the signed origin, remove any  pending payments, and elevate them from rank 0 to rank 1. 
+
+___
+
+
+## staking
+ 
+### applySlash(slash_era: `u32`, slash_key: `(AccountId32,Perbill,u32)`)
+- **interface**: `api.tx.staking.applySlash`
+- **summary**:    Manually and permissionlessly applies a deferred slash for a given era. 
+
+   Normally, slashes are automatically applied shortly after the start of the `slash_era`.  The automatic application of slashes is handled by the pallet's internal logic, and it  tries to apply one slash page per block of the era.  If for some reason, one era is not enough for applying all slash pages, the remaining  slashes need to be manually (permissionlessly) applied. 
+
+   For a given era x, if at era x+1, slashes are still unapplied, all withdrawals get  blocked, and these need to be manually applied by calling this function.  This function exists as a **fallback mechanism** for this extreme situation, but we  never expect to encounter this in normal scenarios. 
+
+   The parameters for this call can be queried by looking at the `UnappliedSlashes` storage  for eras older than the active era. 
+
+   #### Parameters 
+
+  - `slash_era`: The staking era in which the slash was originally scheduled.
+
+  - `slash_key`: A unique identifier for the slash, represented as a tuple:
+
+  - `stash`: The stash account of the validator being slashed.
+
+  - `slash_fraction`: The fraction of the stake that was slashed.
+
+  - `page_index`: The index of the exposure page being processed.
+
+   #### Behavior 
+
+  - The function is **permissionless**—anyone can call it.
+
+  - The `slash_era` **must be the current era or a past era**. If it is in the future, the  call fails with `EraNotStarted`. 
+
+  - The fee is waived if the slash is successfully applied.
+
+   #### Future Improvement 
+
+  - Implement an **off-chain worker (OCW) task** to automatically apply slashes when there is unused block space, improving efficiency. 
+ 
+### bond(value: `Compact<u128>`, payee: `PalletStakingAsyncRewardDestination`)
+- **interface**: `api.tx.staking.bond`
+- **summary**:    Take the origin account as a stash and lock up `value` of its balance. `controller` will  be the account that controls it. 
+
+   `value` must be more than the `minimum_balance` specified by `T::Currency`. 
+
+   The dispatch origin for this call must be _Signed_ by the stash account. 
+
+   Emits `Bonded`. 
+
+   NOTE: Two of the storage writes (`Self::bonded`, `Self::payee`) are _never_ cleaned  unless the `origin` falls below _existential deposit_ (or equal to 0) and gets removed  as dust. 
+ 
+### bondExtra(max_additional: `Compact<u128>`)
+- **interface**: `api.tx.staking.bondExtra`
+- **summary**:    Add some extra amount that have appeared in the stash `free_balance` into the balance up  for staking. 
+
+   The dispatch origin for this call must be _Signed_ by the stash, not the controller. 
+
+   Use this if there are additional funds in your stash account that you wish to bond.  Unlike [`bond`](Self::bond) or [`unbond`](Self::unbond) this function does not impose  any limitation on the amount that can be added. 
+
+   Emits `Bonded`. 
+ 
+### cancelDeferredSlash(era: `u32`, validator_slashes: `Vec<(AccountId32,Perbill)>`)
+- **interface**: `api.tx.staking.cancelDeferredSlash`
+- **summary**:    Cancels scheduled slashes for a given era before they are applied. 
+
+   This function allows `T::AdminOrigin` to cancel pending slashes for specified validators  in a given era. The cancelled slashes are stored and will be checked when applying  slashes. 
+
+   #### Parameters 
+
+  - `era`: The staking era for which slashes should be cancelled. This is the era where the slash would be applied, not the era in which the offence was committed. 
+
+  - `validator_slashes`: A list of validator stash accounts and their slash fractions to be cancelled. 
+ 
+### chill()
+- **interface**: `api.tx.staking.chill`
+- **summary**:    Declare no desire to either validate or nominate. 
+
+   Effects will be felt at the beginning of the next era. 
+
+   The dispatch origin for this call must be _Signed_ by the controller, not the stash. 
+
+   #### Complexity 
+
+  - Independent of the arguments. Insignificant complexity.
+
+  - Contains one read.
+
+  - Writes are limited to the `origin` account key.
+ 
+### chillOther(stash: `AccountId32`)
+- **interface**: `api.tx.staking.chillOther`
+- **summary**:    Declare a `controller` to stop participating as either a validator or nominator. 
+
+   Effects will be felt at the beginning of the next era. 
+
+   The dispatch origin for this call must be _Signed_, but can be called by anyone. 
+
+   If the caller is the same as the controller being targeted, then no further checks are  enforced, and this function behaves just like `chill`. 
+
+   If the caller is different than the controller being targeted, the following conditions  must be met: 
+
+   * `controller` must belong to a nominator who has become non-decodable, 
+
+   Or: 
+
+   * A `ChillThreshold` must be set and checked which defines how close to the max  nominators or validators we must reach before users can start chilling one-another. 
+
+  * A `MaxNominatorCount` and `MaxValidatorCount` must be set which is used to determine how close we are to the threshold. 
+
+  * A `MinNominatorBond` and `MinValidatorBond` must be set and checked, which determines if this is a person that should be chilled because they have not met the threshold  bond required. 
+
+   This can be helpful if bond requirements are updated, and we need to remove old users  who do not satisfy these requirements. 
+ 
+### deprecateControllerBatch(controllers: `Vec<AccountId32>`)
+- **interface**: `api.tx.staking.deprecateControllerBatch`
+- **summary**:    Updates a batch of controller accounts to their corresponding stash account if they are  not the same. Ignores any controller accounts that do not exist, and does not operate if  the stash and controller are already the same. 
+
+   Effects will be felt instantly (as soon as this function is completed successfully). 
+
+   The dispatch origin must be `T::AdminOrigin`. 
+ 
+### forceApplyMinCommission(validator_stash: `AccountId32`)
+- **interface**: `api.tx.staking.forceApplyMinCommission`
+- **summary**:    Force a validator to have at least the minimum commission. This will not affect a  validator who already has a commission greater than or equal to the minimum. Any account  can call this. 
+ 
+### forceNewEra()
+- **interface**: `api.tx.staking.forceNewEra`
+- **summary**:    Force there to be a new era at the end of the next session. After this, it will be  reset to normal (non-forced) behaviour. 
+
+   The dispatch origin must be Root. 
+
+   #### Warning 
+
+   The election process starts multiple blocks before the end of the era.  If this is called just before a new era is triggered, the election process may not  have enough blocks to get a result. 
+ 
+### forceNewEraAlways()
+- **interface**: `api.tx.staking.forceNewEraAlways`
+- **summary**:    Force there to be a new era at the end of sessions indefinitely. 
+
+   The dispatch origin must be Root. 
+
+   #### Warning 
+
+   The election process starts multiple blocks before the end of the era.  If this is called just before a new era is triggered, the election process may not  have enough blocks to get a result. 
+ 
+### forceNoEras()
+- **interface**: `api.tx.staking.forceNoEras`
+- **summary**:    Force there to be no new eras indefinitely. 
+
+   The dispatch origin must be Root. 
+
+   #### Warning 
+
+   The election process starts multiple blocks before the end of the era.  Thus the election process may be ongoing when this is called. In this case the  election will continue until the next era is triggered. 
+ 
+### forceUnstake(stash: `AccountId32`, num_slashing_spans: `u32`)
+- **interface**: `api.tx.staking.forceUnstake`
+- **summary**:    Force a current staker to become completely unstaked, immediately. 
+
+   The dispatch origin must be Root.  #### Parameters 
+
+   - `stash`: The stash account to be unstaked. 
+
+  - `num_slashing_spans`: **Deprecated**. This parameter is retained for backward compatibility. It no longer has any effect. 
+ 
+### increaseValidatorCount(additional: `Compact<u32>`)
+- **interface**: `api.tx.staking.increaseValidatorCount`
+- **summary**:    Increments the ideal number of validators up to maximum of  `T::MaxValidatorSet`. 
+
+   The dispatch origin must be Root. 
+ 
+### kick(who: `Vec<MultiAddress>`)
+- **interface**: `api.tx.staking.kick`
+- **summary**:    Remove the given nominations from the calling validator. 
+
+   Effects will be felt at the beginning of the next era. 
+
+   The dispatch origin for this call must be _Signed_ by the controller, not the stash. 
+
+   - `who`: A list of nominator stash accounts who are nominating this validator which  should no longer be nominating this validator. 
+
+   Note: Making this call only makes sense if you first set the validator preferences to  block any further nominations. 
+ 
+### migrateCurrency(stash: `AccountId32`)
+- **interface**: `api.tx.staking.migrateCurrency`
+- **summary**:    Migrates permissionlessly a stash from locks to holds. 
+
+   This removes the old lock on the stake and creates a hold on it atomically. If all  stake cannot be held, the best effort is made to hold as much as possible. The remaining  stake is removed from the ledger. 
+
+   The fee is waived if the migration is successful. 
+ 
+### nominate(targets: `Vec<MultiAddress>`)
+- **interface**: `api.tx.staking.nominate`
+- **summary**:    Declare the desire to nominate `targets` for the origin controller. 
+
+   Effects will be felt at the beginning of the next era. 
+
+   The dispatch origin for this call must be _Signed_ by the controller, not the stash. 
+ 
+### payoutStakers(validator_stash: `AccountId32`, era: `u32`)
+- **interface**: `api.tx.staking.payoutStakers`
+- **summary**:    Pay out next page of the stakers behind a validator for the given era. 
+
+   - `validator_stash` is the stash account of the validator. 
+
+  - `era` may be any era between `[current_era - history_depth; current_era]`.
+
+   The origin of this call must be _Signed_. Any account can call this function, even if  it is not one of the stakers. 
+
+   The reward payout could be paged in case there are too many nominators backing the  `validator_stash`. This call will payout unpaid pages in an ascending order. To claim a  specific page, use `payout_stakers_by_page`.` 
+
+   If all pages are claimed, it returns an error `InvalidPage`. 
+ 
+### payoutStakersByPage(validator_stash: `AccountId32`, era: `u32`, page: `u32`)
+- **interface**: `api.tx.staking.payoutStakersByPage`
+- **summary**:    Pay out a page of the stakers behind a validator for the given era and page. 
+
+   - `validator_stash` is the stash account of the validator. 
+
+  - `era` may be any era between `[current_era - history_depth; current_era]`.
+
+  - `page` is the page index of nominators to pay out with value between 0 and `num_nominators / T::MaxExposurePageSize`. 
+
+   The origin of this call must be _Signed_. Any account can call this function, even if  it is not one of the stakers. 
+
+   If a validator has more than [`Config::MaxExposurePageSize`] nominators backing  them, then the list of nominators is paged, with each page being capped at  [`Config::MaxExposurePageSize`.] If a validator has more than one page of nominators,  the call needs to be made for each page separately in order for all the nominators  backing a validator to receive the reward. The nominators are not sorted across pages  and so it should not be assumed the highest staker would be on the topmost page and vice  versa. If rewards are not claimed in [`Config::HistoryDepth`] eras, they are lost. 
+ 
+### pruneEraStep(era: `u32`)
+- **interface**: `api.tx.staking.pruneEraStep`
+- **summary**:    Perform one step of era pruning to prevent PoV size exhaustion from unbounded deletions. 
+
+   This extrinsic enables permissionless lazy pruning of era data by performing  incremental deletion of storage items. Each call processes a limited number  of items based on available block weight to avoid exceeding block limits. 
+
+   Returns `Pays::No` when work is performed to incentivize regular maintenance.  Anyone can call this to help maintain the chain's storage health. 
+
+   The era must be eligible for pruning (older than HistoryDepth + 1).  Check `EraPruningState` storage to see if an era needs pruning before calling. 
+ 
+### reapStash(stash: `AccountId32`, num_slashing_spans: `u32`)
+- **interface**: `api.tx.staking.reapStash`
+- **summary**:    Remove all data structures concerning a staker/stash once it is at a state where it can  be considered `dust` in the staking system. The requirements are: 
+
+   1. the `total_balance` of the stash is below `min_chilled_bond` or is zero.  2. or, the `ledger.total` of the stash is below `min_chilled_bond` or is zero. 
+
+   The former can happen in cases like a slash; the latter when a fully unbonded account  is still receiving staking rewards in `RewardDestination::Staked`. 
+
+   It can be called by anyone, as long as `stash` meets the above requirements. 
+
+   Refunds the transaction fees upon successful execution. 
+
+   #### Parameters 
+
+   - `stash`: The stash account to be reaped. 
+
+  - `num_slashing_spans`: **Deprecated**. This parameter is retained for backward compatibility. It no longer has any effect. 
+ 
+### rebond(value: `Compact<u128>`)
+- **interface**: `api.tx.staking.rebond`
+- **summary**:    Rebond a portion of the stash scheduled to be unlocked. 
+
+   The dispatch origin must be signed by the controller. 
+ 
+### restoreLedger(stash: `AccountId32`, maybe_controller: `Option<AccountId32>`, maybe_total: `Option<u128>`, maybe_unlocking: `Option<Vec<PalletStakingAsyncLedgerUnlockChunk>>`)
+- **interface**: `api.tx.staking.restoreLedger`
+- **summary**:    Restores the state of a ledger which is in an inconsistent state. 
+
+   The requirements to restore a ledger are the following: 
+
+  * The stash is bonded; or
+
+  * The stash is not bonded but it has a staking lock left behind; or
+
+  * If the stash has an associated ledger and its state is inconsistent; or
+
+  * If the ledger is not corrupted *but* its staking lock is out of sync.
+
+   The `maybe_*` input parameters will overwrite the corresponding data and metadata of the  ledger associated with the stash. If the input parameters are not set, the ledger will  be reset values from on-chain state. 
+ 
+### scaleValidatorCount(factor: `Percent`)
+- **interface**: `api.tx.staking.scaleValidatorCount`
+- **summary**:    Scale up the ideal number of validators by a factor up to maximum of  `T::MaxValidatorSet`. 
+
+   The dispatch origin must be Root. 
+ 
+### setController()
+- **interface**: `api.tx.staking.setController`
+- **summary**:    (Re-)sets the controller of a stash to the stash itself. This function previously  accepted a `controller` argument to set the controller to an account other than the  stash itself. This functionality has now been removed, now only setting the controller  to the stash, if it is not already. 
+
+   Effects will be felt instantly (as soon as this function is completed successfully). 
+
+   The dispatch origin for this call must be _Signed_ by the stash, not the controller. 
+ 
+### setInvulnerables(invulnerables: `Vec<AccountId32>`)
+- **interface**: `api.tx.staking.setInvulnerables`
+- **summary**:    Set the validators who cannot be slashed (if any). 
+
+   The dispatch origin must be Root. 
+ 
+### setMinCommission(new: `Perbill`)
+- **interface**: `api.tx.staking.setMinCommission`
+- **summary**:    Sets the minimum amount of commission that each validators must maintain. 
+
+   This call has lower privilege requirements than `set_staking_config` and can be called  by the `T::AdminOrigin`. Root can always call this. 
+ 
+### setPayee(payee: `PalletStakingAsyncRewardDestination`)
+- **interface**: `api.tx.staking.setPayee`
+- **summary**:    (Re-)set the payment target for a controller. 
+
+   Effects will be felt instantly (as soon as this function is completed successfully). 
+
+   The dispatch origin for this call must be _Signed_ by the controller, not the stash. 
+ 
+### setStakingConfigs(min_nominator_bond: `PalletStakingAsyncPalletConfigOpU128`, min_validator_bond: `PalletStakingAsyncPalletConfigOpU128`, max_nominator_count: `PalletStakingAsyncPalletConfigOpU32`, max_validator_count: `PalletStakingAsyncPalletConfigOpU32`, chill_threshold: `PalletStakingAsyncPalletConfigOpPercent`, min_commission: `PalletStakingAsyncPalletConfigOpPerbill`, max_staked_rewards: `PalletStakingAsyncPalletConfigOpPercent`)
+- **interface**: `api.tx.staking.setStakingConfigs`
+- **summary**:    Update the various staking configurations . 
+
+   * `min_nominator_bond`: The minimum active bond needed to be a nominator. 
+
+  * `min_validator_bond`: The minimum active bond needed to be a validator.
+
+  * `max_nominator_count`: The max number of users who can be a nominator at once. When set to `None`, no limit is enforced. 
+
+  * `max_validator_count`: The max number of users who can be a validator at once. When set to `None`, no limit is enforced. 
+
+  * `chill_threshold`: The ratio of `max_nominator_count` or `max_validator_count` which should be filled in order for the `chill_other` transaction to work. 
+
+  * `min_commission`: The minimum amount of commission that each validators must maintain. This is checked only upon calling `validate`. Existing validators are not affected. 
+
+   RuntimeOrigin must be Root to call this function. 
+
+   NOTE: Existing nominators and validators will not be affected by this update.  to kick people under the new limits, `chill_other` should be called. 
+ 
+### setValidatorCount(new: `Compact<u32>`)
+- **interface**: `api.tx.staking.setValidatorCount`
+- **summary**:    Sets the ideal number of validators. 
+
+   The dispatch origin must be Root. 
+ 
+### unbond(value: `Compact<u128>`)
+- **interface**: `api.tx.staking.unbond`
+- **summary**:    Schedule a portion of the stash to be unlocked ready for transfer out after the bond  period ends. If this leaves an amount actively bonded less than  [`asset::existential_deposit`], then it is increased to the full amount. 
+
+   The dispatch origin for this call must be _Signed_ by the controller, not the stash. 
+
+   Once the unlock period is done, you can call `withdraw_unbonded` to actually move  the funds out of management ready for transfer. 
+
+   No more than a limited number of unlocking chunks (see `MaxUnlockingChunks`)  can co-exists at the same time. If there are no unlocking chunks slots available  [`Call::withdraw_unbonded`] is called to remove some of the chunks (if possible). 
+
+   If a user encounters the `InsufficientBond` error when calling this extrinsic,  they should call `chill` first in order to free up their bonded funds. 
+
+   Emits `Unbonded`. 
+
+   See also [`Call::withdraw_unbonded`]. 
+ 
+### updatePayee(controller: `AccountId32`)
+- **interface**: `api.tx.staking.updatePayee`
+- **summary**:    Migrates an account's `RewardDestination::Controller` to  `RewardDestination::Account(controller)`. 
+
+   Effects will be felt instantly (as soon as this function is completed successfully). 
+
+   This will waive the transaction fee if the `payee` is successfully migrated. 
+ 
+### validate(prefs: `PalletStakingAsyncValidatorPrefs`)
+- **interface**: `api.tx.staking.validate`
+- **summary**:    Declare the desire to validate for the origin controller. 
+
+   Effects will be felt at the beginning of the next era. 
+
+   The dispatch origin for this call must be _Signed_ by the controller, not the stash. 
+ 
+### withdrawUnbonded(num_slashing_spans: `u32`)
+- **interface**: `api.tx.staking.withdrawUnbonded`
+- **summary**:    Remove any stake that has been fully unbonded and is ready for withdrawal. 
+
+   Stake is considered fully unbonded once [`Config::BondingDuration`] has elapsed since  the unbonding was initiated. In rare cases—such as when offences for the unbonded era  have been reported but not yet processed—withdrawal is restricted to eras for which  all offences have been processed. 
+
+   The unlocked stake will be returned as free balance in the stash account. 
+
+   The dispatch origin for this call must be _Signed_ by the controller. 
+
+   Emits `Withdrawn`. 
+
+   See also [`Call::unbond`]. 
+
+   #### Parameters 
+
+   - `num_slashing_spans`: **Deprecated**. Retained only for backward compatibility; this  parameter has no effect. 
+
+___
+
+
+## stakingRcClient
+ 
+### relayNewOffencePaged(offences: `Vec<(u32,PalletStakingAsyncRcClientOffence)>`)
+- **interface**: `api.tx.stakingRcClient.relayNewOffencePaged`
+ 
+### relaySessionReport(report: `PalletStakingAsyncRcClientSessionReport`)
+- **interface**: `api.tx.stakingRcClient.relaySessionReport`
+- **summary**:    Called to indicate the start of a new session on the relay chain. 
 
 ___
 
@@ -3397,6 +5588,9 @@ ___
 
    This call requires Root origin. 
  
+### doTask(task: `AssetHubKusamaRuntimeRuntimeTask`)
+- **interface**: `api.tx.system.doTask`
+ 
 ### killPrefix(prefix: `Bytes`, subkeys: `u32`)
 - **interface**: `api.tx.system.killPrefix`
 - **summary**:    Kill all storage items with a key that starts with the given prefix. 
@@ -3468,6 +5662,141 @@ ___
 ### reportBridgeStatus(bridge_id: `H256`, is_congested: `bool`)
 - **interface**: `api.tx.toPolkadotXcmRouter.reportBridgeStatus`
 - **summary**:    Notification about congested bridge queue. 
+
+___
+
+
+## treasury
+ 
+### checkStatus(index: `u32`)
+- **interface**: `api.tx.treasury.checkStatus`
+- **summary**:    Check the status of the spend and remove it from the storage if processed. 
+
+   #### Dispatch Origin 
+
+   Must be signed. 
+
+   #### Details 
+
+   The status check is a prerequisite for retrying a failed payout.  If a spend has either succeeded or expired, it is removed from the storage by this  function. In such instances, transaction fees are refunded. 
+
+   #### Parameters 
+
+  - `index`: The spend index.
+
+   #### Events 
+
+   Emits [`Event::PaymentFailed`] if the spend payout has failed.  Emits [`Event::SpendProcessed`] if the spend payout has succeed. 
+ 
+### payout(index: `u32`)
+- **interface**: `api.tx.treasury.payout`
+- **summary**:    Claim a spend. 
+
+   #### Dispatch Origin 
+
+   Must be signed 
+
+   #### Details 
+
+   Spends must be claimed within some temporal bounds. A spend may be claimed within one  [`Config::PayoutPeriod`] from the `valid_from` block.  In case of a payout failure, the spend status must be updated with the `check_status`  dispatchable before retrying with the current function. 
+
+   #### Parameters 
+
+  - `index`: The spend index.
+
+   #### Events 
+
+   Emits [`Event::Paid`] if successful. 
+ 
+### removeApproval(proposal_id: `Compact<u32>`)
+- **interface**: `api.tx.treasury.removeApproval`
+- **summary**:    Force a previously approved proposal to be removed from the approval queue. 
+
+   #### Dispatch Origin 
+
+   Must be [`Config::RejectOrigin`]. 
+
+   #### Details 
+
+   The original deposit will no longer be returned. 
+
+   #### Parameters 
+
+  - `proposal_id`: The index of a proposal
+
+   #### Complexity 
+
+  - O(A) where `A` is the number of approvals
+
+   #### Errors 
+
+  - [`Error::ProposalNotApproved`]: The `proposal_id` supplied was not found in the approval queue, i.e., the proposal has not been approved. This could also mean the  proposal does not exist altogether, thus there is no way it would have been approved  in the first place. 
+ 
+### spend(asset_kind: `PolkadotRuntimeCommonImplsVersionedLocatableAsset`, amount: `Compact<u128>`, beneficiary: `ParachainsCommonPayVersionedLocatableAccount`, valid_from: `Option<u32>`)
+- **interface**: `api.tx.treasury.spend`
+- **summary**:    Propose and approve a spend of treasury funds. 
+
+   #### Dispatch Origin 
+
+   Must be [`Config::SpendOrigin`] with the `Success` value being at least  `amount` of `asset_kind` in the native asset. The amount of `asset_kind` is converted  for assertion using the [`Config::BalanceConverter`]. 
+
+   #### Details 
+
+   Create an approved spend for transferring a specific `amount` of `asset_kind` to a  designated beneficiary. The spend must be claimed using the `payout` dispatchable within  the [`Config::PayoutPeriod`]. 
+
+   #### Parameters 
+
+  - `asset_kind`: An indicator of the specific asset class to be spent.
+
+  - `amount`: The amount to be transferred from the treasury to the `beneficiary`.
+
+  - `beneficiary`: The beneficiary of the spend.
+
+  - `valid_from`: The block number from which the spend can be claimed. It can refer to the past if the resulting spend has not yet expired according to the  [`Config::PayoutPeriod`]. If `None`, the spend can be claimed immediately after  approval. 
+
+   #### Events 
+
+   Emits [`Event::AssetSpendApproved`] if successful. 
+ 
+### spendLocal(amount: `Compact<u128>`, beneficiary: `MultiAddress`)
+- **interface**: `api.tx.treasury.spendLocal`
+- **summary**:    Propose and approve a spend of treasury funds. 
+
+   #### Dispatch Origin 
+
+   Must be [`Config::SpendOrigin`] with the `Success` value being at least `amount`. 
+
+   #### Details  NOTE: For record-keeping purposes, the proposer is deemed to be equivalent to the  beneficiary. 
+
+   #### Parameters 
+
+  - `amount`: The amount to be transferred from the treasury to the `beneficiary`.
+
+  - `beneficiary`: The destination account for the transfer.
+
+   #### Events 
+
+   Emits [`Event::SpendApproved`] if successful. 
+ 
+### voidSpend(index: `u32`)
+- **interface**: `api.tx.treasury.voidSpend`
+- **summary**:    Void previously approved spend. 
+
+   #### Dispatch Origin 
+
+   Must be [`Config::RejectOrigin`]. 
+
+   #### Details 
+
+   A spend void is only possible if the payout has not been attempted yet. 
+
+   #### Parameters 
+
+  - `index`: The spend index.
+
+   #### Events 
+
+   Emits [`Event::AssetSpendVoided`] if successful. 
 
 ___
 
@@ -4127,6 +6456,56 @@ ___
    #### Complexity 
 
   - `O(1)`.
+
+___
+
+
+## voterList
+ 
+### putInFrontOf(lighter: `MultiAddress`)
+- **interface**: `api.tx.voterList.putInFrontOf`
+- **summary**:    Move the caller's Id directly in front of `lighter`. 
+
+   The dispatch origin for this call must be _Signed_ and can only be called by the Id of  the account going in front of `lighter`. Fee is payed by the origin under all  circumstances. 
+
+   Only works if: 
+
+   - both nodes are within the same bag, 
+
+  - and `origin` has a greater `Score` than `lighter`.
+ 
+### putInFrontOfOther(heavier: `MultiAddress`, lighter: `MultiAddress`)
+- **interface**: `api.tx.voterList.putInFrontOfOther`
+- **summary**:    Same as [`Pallet::put_in_front_of`], but it can be called by anyone. 
+
+   Fee is paid by the origin under all circumstances. 
+ 
+### rebag(dislocated: `MultiAddress`)
+- **interface**: `api.tx.voterList.rebag`
+- **summary**:    Declare that some `dislocated` account has, through rewards or penalties, sufficiently  changed its score that it should properly fall into a different bag than its current  one. 
+
+   Anyone can call this function about any potentially dislocated account. 
+
+   Will always update the stored score of `dislocated` to the correct score, based on  `ScoreProvider`. 
+
+   If `dislocated` does not exists, it returns an error. 
+
+___
+
+
+## whitelist
+ 
+### dispatchWhitelistedCall(call_hash: `H256`, call_encoded_len: `u32`, call_weight_witness: `SpWeightsWeightV2Weight`)
+- **interface**: `api.tx.whitelist.dispatchWhitelistedCall`
+ 
+### dispatchWhitelistedCallWithPreimage(call: `Call`)
+- **interface**: `api.tx.whitelist.dispatchWhitelistedCallWithPreimage`
+ 
+### removeWhitelistedCall(call_hash: `H256`)
+- **interface**: `api.tx.whitelist.removeWhitelistedCall`
+ 
+### whitelistCall(call_hash: `H256`)
+- **interface**: `api.tx.whitelist.whitelistCall`
 
 ___
 

--- a/docs/asset-hub-kusama/rpc.md
+++ b/docs/asset-hub-kusama/rpc.md
@@ -12,8 +12,6 @@ The following sections contain known RPC methods that may be available on specif
 
 - **[dev](#dev)**
 
-- **[engine](#engine)**
-
 - **[offchain](#offchain)**
 
 - **[payment](#payment)**
@@ -160,21 +158,6 @@ ___
 - **jsonrpc**: `dev_getBlockStats`
 - **summary**: Reexecute the specified `block_hash` and gather statistics while doing so
 - **unsafe**: This method is only active with appropriate flags
-
-___
-
-
-## engine
- 
-### createBlock(createEmpty: `bool`, finalize: `bool`, parentHash?: `BlockHash`): `CreatedBlock`
-- **interface**: `api.rpc.engine.createBlock`
-- **jsonrpc**: `engine_createBlock`
-- **summary**: Instructs the manual-seal authorship task to create a new block
- 
-### finalizeBlock(hash: `BlockHash`, justification?: `Justification`): `bool`
-- **interface**: `api.rpc.engine.finalizeBlock`
-- **jsonrpc**: `engine_finalizeBlock`
-- **summary**: Instructs the manual-seal authorship task to finalize a block
 
 ___
 

--- a/docs/asset-hub-kusama/runtime.md
+++ b/docs/asset-hub-kusama/runtime.md
@@ -12,6 +12,8 @@ The following section contains known runtime calls that may be available on spec
 
 - **[auraUnincludedSegmentApi](#auraunincludedsegmentapi)**
 
+- **[authorizedAliasersApi](#authorizedaliasersapi)**
+
 - **[blockBuilder](#blockbuilder)**
 
 - **[collectCollationInfo](#collectcollationinfo)**
@@ -24,21 +26,33 @@ The following section contains known runtime calls that may be available on spec
 
 - **[genesisBuilder](#genesisbuilder)**
 
+- **[getParachainInfo](#getparachaininfo)**
+
 - **[locationToAccountApi](#locationtoaccountapi)**
 
 - **[metadata](#metadata)**
 
+- **[nominationPoolsApi](#nominationpoolsapi)**
+
 - **[offchainWorkerApi](#offchainworkerapi)**
+
+- **[relayParentOffsetApi](#relayparentoffsetapi)**
 
 - **[reviveApi](#reviveapi)**
 
+- **[runtimeViewFunction](#runtimeviewfunction)**
+
 - **[sessionKeys](#sessionkeys)**
+
+- **[stakingApi](#stakingapi)**
 
 - **[taggedTransactionQueue](#taggedtransactionqueue)**
 
 - **[transactionPaymentApi](#transactionpaymentapi)**
 
 - **[transactionPaymentCallApi](#transactionpaymentcallapi)**
+
+- **[trustedQueryApi](#trustedqueryapi)**
 
 - **[xcmPaymentApi](#xcmpaymentapi)**
 
@@ -58,17 +72,17 @@ ___
 
 ## assetConversionApi
  
-### getReserves(asset1: `StagingXcmV4Location`, asset2: `StagingXcmV4Location`): `Option<(u128,u128)>`
+### getReserves(asset1: `StagingXcmV5Location`, asset2: `StagingXcmV5Location`): `Option<(u128,u128)>`
 - **interface**: `api.call.assetConversionApi.getReserves`
 - **runtime**: `assetConversionApi_get_reserves`
 - **summary**:  Returns the size of the liquidity pool for the given asset pair.
  
-### quotePriceExactTokensForTokens(asset1: `StagingXcmV4Location`, asset2: `StagingXcmV4Location`, amount: `u128`, include_fee: `bool`): `Option<u128>`
+### quotePriceExactTokensForTokens(asset1: `StagingXcmV5Location`, asset2: `StagingXcmV5Location`, amount: `u128`, include_fee: `bool`): `Option<u128>`
 - **interface**: `api.call.assetConversionApi.quotePriceExactTokensForTokens`
 - **runtime**: `assetConversionApi_quote_price_exact_tokens_for_tokens`
 - **summary**:  Provides a quote for [`Pallet::swap_exact_tokens_for_tokens`].,, Note that the price may have changed by the time the transaction is executed., (Use `amount_out_min` to control slippage.)
  
-### quotePriceTokensForExactTokens(asset1: `StagingXcmV4Location`, asset2: `StagingXcmV4Location`, amount: `u128`, include_fee: `bool`): `Option<u128>`
+### quotePriceTokensForExactTokens(asset1: `StagingXcmV5Location`, asset2: `StagingXcmV5Location`, amount: `u128`, include_fee: `bool`): `Option<u128>`
 - **interface**: `api.call.assetConversionApi.quotePriceTokensForExactTokens`
 - **runtime**: `assetConversionApi_quote_price_tokens_for_exact_tokens`
 - **summary**:  Provides a quote for [`Pallet::swap_tokens_for_exact_tokens`].,, Note that the price may have changed by the time the transaction is executed., (Use `amount_in_max` to control slippage.)
@@ -97,6 +111,21 @@ ___
 - **interface**: `api.call.auraUnincludedSegmentApi.canBuildUpon`
 - **runtime**: `auraUnincludedSegmentApi_can_build_upon`
 - **summary**:  Whether it is legal to extend the chain, assuming the given block is the most, recently included one as-of the relay parent that will be built against, and, the given relay chain slot.,, This should be consistent with the logic the runtime uses when validating blocks to, avoid issues.,, When the unincluded segment is empty, i.e. `included_hash == at`, where at is the block, whose state we are querying against, this must always return `true` as long as the slot, is more recent than the included block itself.
+
+___
+
+
+## authorizedAliasersApi
+ 
+### authorizedAliasers(target: `XcmVersionedLocation`): `Result<Vec<XcmRuntimeApisAuthorizedAliasesOriginAliaser>, XcmRuntimeApisAuthorizedAliasesError>`
+- **interface**: `api.call.authorizedAliasersApi.authorizedAliasers`
+- **runtime**: `authorizedAliasersApi_authorized_aliasers`
+- **summary**:  Returns locations allowed to alias into and act as `target`.
+ 
+### isAuthorizedAlias(origin: `XcmVersionedLocation`, target: `XcmVersionedLocation`): `Result<bool, XcmRuntimeApisAuthorizedAliasesError>`
+- **interface**: `api.call.authorizedAliasersApi.isAuthorizedAlias`
+- **runtime**: `authorizedAliasersApi_is_authorized_alias`
+- **summary**:  Returns whether `origin` is allowed to alias into and act as `target`.
 
 ___
 
@@ -201,6 +230,16 @@ ___
 ___
 
 
+## getParachainInfo
+ 
+### parachainId(): `PolkadotParachainPrimitivesPrimitivesId`
+- **interface**: `api.call.getParachainInfo.parachainId`
+- **runtime**: `getParachainInfo_parachain_id`
+- **summary**:  Retrieve the parachain id used for runtime.
+
+___
+
+
 ## locationToAccountApi
  
 ### convertLocation(location: `XcmVersionedLocation`): `Result<AccountId32, XcmRuntimeApisConversionsError>`
@@ -231,6 +270,61 @@ ___
 ___
 
 
+## nominationPoolsApi
+ 
+### balanceToPoints(pool_id: `u32`, new_funds: `u128`): `u128`
+- **interface**: `api.call.nominationPoolsApi.balanceToPoints`
+- **runtime**: `nominationPoolsApi_balance_to_points`
+- **summary**:  Returns the equivalent points of `new_funds` for a given pool.
+ 
+### memberNeedsDelegateMigration(member: `SpCoreCryptoAccountId32`): `bool`
+- **interface**: `api.call.nominationPoolsApi.memberNeedsDelegateMigration`
+- **runtime**: `nominationPoolsApi_member_needs_delegate_migration`
+- **summary**:  Returns true if the delegated funds of the pool `member` needs migration.,, Once a pool has successfully migrated to the strategy, [`DelegateStake`](pallet_nomination_pools::adapter::DelegateStake), the funds of the, member can be migrated from pool account to the member's account. Use, [`migrate_delegation`](pallet_nomination_pools::Call::migrate_delegation), to migrate the funds of the pool member.
+ 
+### memberPendingSlash(member: `SpCoreCryptoAccountId32`): `u128`
+- **interface**: `api.call.nominationPoolsApi.memberPendingSlash`
+- **runtime**: `nominationPoolsApi_member_pending_slash`
+- **summary**:  Returns the pending slash for a given pool member.,, If pending slash of the member exceeds `ExistentialDeposit`, it can be reported on, chain.
+ 
+### memberTotalBalance(who: `SpCoreCryptoAccountId32`): `u128`
+- **interface**: `api.call.nominationPoolsApi.memberTotalBalance`
+- **runtime**: `nominationPoolsApi_member_total_balance`
+- **summary**:  Returns the total contribution of a pool member including any balance that is unbonding.
+ 
+### pendingRewards(who: `SpCoreCryptoAccountId32`): `u128`
+- **interface**: `api.call.nominationPoolsApi.pendingRewards`
+- **runtime**: `nominationPoolsApi_pending_rewards`
+- **summary**:  Returns the pending rewards for the member that the AccountId was given for.
+ 
+### pointsToBalance(pool_id: `u32`, points: `u128`): `u128`
+- **interface**: `api.call.nominationPoolsApi.pointsToBalance`
+- **runtime**: `nominationPoolsApi_points_to_balance`
+- **summary**:  Returns the equivalent balance of `points` for a given pool.
+ 
+### poolAccounts(pool_id: `u32`): `(AccountId32,AccountId32)`
+- **interface**: `api.call.nominationPoolsApi.poolAccounts`
+- **runtime**: `nominationPoolsApi_pool_accounts`
+- **summary**:  Returns the bonded account and reward account associated with the pool_id.
+ 
+### poolBalance(pool_id: `u32`): `u128`
+- **interface**: `api.call.nominationPoolsApi.poolBalance`
+- **runtime**: `nominationPoolsApi_pool_balance`
+- **summary**:  Total balance contributed to the pool.
+ 
+### poolNeedsDelegateMigration(pool_id: `u32`): `bool`
+- **interface**: `api.call.nominationPoolsApi.poolNeedsDelegateMigration`
+- **runtime**: `nominationPoolsApi_pool_needs_delegate_migration`
+- **summary**:  Returns true if the pool with `pool_id` needs migration.,, This can happen when the `pallet-nomination-pools` has switched to using strategy, [`DelegateStake`](pallet_nomination_pools::adapter::DelegateStake) but the pool, still has funds that were staked using the older strategy, [TransferStake](pallet_nomination_pools::adapter::TransferStake). Use, [`migrate_pool_to_delegate_stake`](pallet_nomination_pools::Call::migrate_pool_to_delegate_stake), to migrate the pool.
+ 
+### poolPendingSlash(pool_id: `u32`): `u128`
+- **interface**: `api.call.nominationPoolsApi.poolPendingSlash`
+- **runtime**: `nominationPoolsApi_pool_pending_slash`
+- **summary**:  Returns the pending slash for a given pool.
+
+___
+
+
 ## offchainWorkerApi
  
 ### offchainWorker(header: `SpRuntimeHeader`): `Null`
@@ -241,12 +335,32 @@ ___
 ___
 
 
+## relayParentOffsetApi
+ 
+### relayParentOffset(): `u32`
+- **interface**: `api.call.relayParentOffsetApi.relayParentOffset`
+- **runtime**: `relayParentOffsetApi_relay_parent_offset`
+- **summary**:  Fetch the slot offset that is expected from the relay chain.
+
+___
+
+
 ## reviveApi
+ 
+### address(account_id: `SpCoreCryptoAccountId32`): `PrimitiveTypesH160`
+- **interface**: `api.call.reviveApi.address`
+- **runtime**: `reviveApi_address`
+- **summary**:  Get the H160 address associated to this account id
  
 ### balance(address: `PrimitiveTypesH160`): `PrimitiveTypesU256`
 - **interface**: `api.call.reviveApi.balance`
 - **runtime**: `reviveApi_balance`
 - **summary**:  Returns the free balance of the given `[H160]` address, using EVM decimals.
+ 
+### blockAuthor(): `Option<H160>`
+- **interface**: `api.call.reviveApi.blockAuthor`
+- **runtime**: `reviveApi_block_author`
+- **summary**:  The address of the validator that produced the current block.
  
 ### blockGasLimit(): `PrimitiveTypesU256`
 - **interface**: `api.call.reviveApi.blockGasLimit`
@@ -258,10 +372,15 @@ ___
 - **runtime**: `reviveApi_call`
 - **summary**:  Perform a call from a specified account to a given contract.,, See [`crate::Pallet::bare_call`].
  
+### code(address: `PrimitiveTypesH160`): `Bytes`
+- **interface**: `api.call.reviveApi.code`
+- **runtime**: `reviveApi_code`
+- **summary**:  The code at the specified address taking pre-compiles into account.
+ 
 ### ethTransact(tx: `PalletReviveEvmApiRpcTypesGenGenericTransaction`): `Result<PalletRevivePrimitivesEthTransactInfo, PalletRevivePrimitivesEthTransactError>`
 - **interface**: `api.call.reviveApi.ethTransact`
 - **runtime**: `reviveApi_eth_transact`
-- **summary**:  Perform an Ethereum call.,, See [`crate::Pallet::bare_eth_transact`]
+- **summary**:  Perform an Ethereum call.,, See [`crate::Pallet::dry_run_eth_transact`]
  
 ### gasPrice(): `PrimitiveTypesU256`
 - **interface**: `api.call.reviveApi.gasPrice`
@@ -273,6 +392,11 @@ ___
 - **runtime**: `reviveApi_get_storage`
 - **summary**:  Query a given storage key in a given contract.,, Returns `Ok(Some(Vec<u8>))` if the storage value exists under the given key in the, specified account and `Ok(None)` if it doesn't. If the account specified by the address, doesn't exist, or doesn't have a contract then `Err` is returned.
  
+### getStorageVarKey(address: `PrimitiveTypesH160`, key: `Bytes`): `Result<Option<Bytes>, PalletRevivePrimitivesContractAccessError>`
+- **interface**: `api.call.reviveApi.getStorageVarKey`
+- **runtime**: `reviveApi_get_storage_var_key`
+- **summary**:  Query a given variable-sized storage key in a given contract.,, Returns `Ok(Some(Vec<u8>))` if the storage value exists under the given key in the, specified account and `Ok(None)` if it doesn't. If the account specified by the address, doesn't exist, or doesn't have a contract then `Err` is returned.
+ 
 ### instantiate(origin: `SpCoreCryptoAccountId32`, value: `u128`, gas_limit: `Option<SpWeightsWeightV2Weight>`, storage_deposit_limit: `Option<u128>`, code: `PalletRevivePrimitivesCode`, data: `Bytes`, salt: `Option<[u8;32]>`): `PalletRevivePrimitivesContractResultInstantiateReturnValue`
 - **interface**: `api.call.reviveApi.instantiate`
 - **runtime**: `reviveApi_instantiate`
@@ -282,6 +406,11 @@ ___
 - **interface**: `api.call.reviveApi.nonce`
 - **runtime**: `reviveApi_nonce`
 - **summary**:  Returns the nonce of the given `[H160]` address.
+ 
+### runtimePalletsAddress(): `PrimitiveTypesH160`
+- **interface**: `api.call.reviveApi.runtimePalletsAddress`
+- **runtime**: `reviveApi_runtime_pallets_address`
+- **summary**:  The address used to call the runtime's pallets dispatchables
  
 ### traceBlock(block: `SpRuntimeBlock`, config: `PalletReviveEvmApiDebugRpcTypesTracerType`): `Vec<(u32,PalletReviveEvmApiDebugRpcTypesTrace)>`
 - **interface**: `api.call.reviveApi.traceBlock`
@@ -306,6 +435,16 @@ ___
 ___
 
 
+## runtimeViewFunction
+ 
+### executeViewFunction(query_id: `FrameSupportViewFunctionsViewFunctionId`, input: `Bytes`): `Result<Bytes, FrameSupportViewFunctionsViewFunctionDispatchError>`
+- **interface**: `api.call.runtimeViewFunction.executeViewFunction`
+- **runtime**: `runtimeViewFunction_execute_view_function`
+- **summary**:  Execute a view function query.
+
+___
+
+
 ## sessionKeys
  
 ### decodeSessionKeys(encoded: `Bytes`): `Option<Vec<(Bytes,SpCoreCryptoKeyTypeId)>>`
@@ -317,6 +456,26 @@ ___
 - **interface**: `api.call.sessionKeys.generateSessionKeys`
 - **runtime**: `sessionKeys_generate_session_keys`
 - **summary**:  Generate a set of session keys with optionally using the given seed., The keys should be stored within the keystore exposed via runtime, externalities.,, The seed needs to be a valid `utf8` string.,, Returns the concatenated SCALE encoded public keys.
+
+___
+
+
+## stakingApi
+ 
+### erasStakersPageCount(era: `u32`, account: `SpCoreCryptoAccountId32`): `u32`
+- **interface**: `api.call.stakingApi.erasStakersPageCount`
+- **runtime**: `stakingApi_eras_stakers_page_count`
+- **summary**:  Returns the page count of exposures for a validator `account` in a given era.
+ 
+### nominationsQuota(balance: `u128`): `u32`
+- **interface**: `api.call.stakingApi.nominationsQuota`
+- **runtime**: `stakingApi_nominations_quota`
+- **summary**:  Returns the nominations quota for a nominator with a given balance.
+ 
+### pendingRewards(era: `u32`, account: `SpCoreCryptoAccountId32`): `bool`
+- **interface**: `api.call.stakingApi.pendingRewards`
+- **runtime**: `stakingApi_pending_rewards`
+- **summary**:  Returns true if validator `account` has pages to be claimed for the given era.
 
 ___
 
@@ -377,6 +536,21 @@ ___
 - **interface**: `api.call.transactionPaymentCallApi.queryWeightToFee`
 - **runtime**: `transactionPaymentCallApi_query_weight_to_fee`
 - **summary**:  Query the output of the current `WeightToFee` given some input.
+
+___
+
+
+## trustedQueryApi
+ 
+### isTrustedReserve(asset: `XcmVersionedAsset`, location: `XcmVersionedLocation`): `Result<bool, XcmRuntimeApisTrustedQueryError>`
+- **interface**: `api.call.trustedQueryApi.isTrustedReserve`
+- **runtime**: `trustedQueryApi_is_trusted_reserve`
+- **summary**:  Returns if the location is a trusted reserve for the asset.,, # Arguments, * `asset`: `VersionedAsset`., * `location`: `VersionedLocation`.
+ 
+### isTrustedTeleporter(asset: `XcmVersionedAsset`, location: `XcmVersionedLocation`): `Result<bool, XcmRuntimeApisTrustedQueryError>`
+- **interface**: `api.call.trustedQueryApi.isTrustedTeleporter`
+- **runtime**: `trustedQueryApi_is_trusted_teleporter`
+- **summary**:  Returns if the asset can be teleported to the location.,, # Arguments, * `asset`: `VersionedAsset`., * `location`: `VersionedLocation`.
 
 ___
 

--- a/docs/asset-hub-kusama/storage.md
+++ b/docs/asset-hub-kusama/storage.md
@@ -6,7 +6,13 @@ The following sections contain Storage methods are part of the default asset-hub
 
 (NOTE: These were generated from a static/snapshot view of a recent default asset-hub-kusama runtime. Some items may not be available in older nodes, or in any customized implementations.)
 
+- **[ahMigrator](#ahmigrator)**
+
+- **[ahOps](#ahops)**
+
 - **[assetConversion](#assetconversion)**
+
+- **[assetRate](#assetrate)**
 
 - **[assets](#assets)**
 
@@ -18,11 +24,31 @@ The following sections contain Storage methods are part of the default asset-hub
 
 - **[balances](#balances)**
 
+- **[bounties](#bounties)**
+
+- **[childBounties](#childbounties)**
+
+- **[claims](#claims)**
+
 - **[collatorSelection](#collatorselection)**
+
+- **[convictionVoting](#convictionvoting)**
+
+- **[delegatedStaking](#delegatedstaking)**
 
 - **[foreignAssets](#foreignassets)**
 
+- **[indices](#indices)**
+
 - **[messageQueue](#messagequeue)**
+
+- **[multiBlockElection](#multiblockelection)**
+
+- **[multiBlockElectionSigned](#multiblockelectionsigned)**
+
+- **[multiBlockElectionVerifier](#multiblockelectionverifier)**
+
+- **[multiBlockMigrations](#multiblockmigrations)**
 
 - **[multisig](#multisig)**
 
@@ -30,21 +56,39 @@ The following sections contain Storage methods are part of the default asset-hub
 
 - **[nfts](#nfts)**
 
+- **[nominationPools](#nominationpools)**
+
 - **[parachainInfo](#parachaininfo)**
 
 - **[parachainSystem](#parachainsystem)**
+
+- **[parameters](#parameters)**
 
 - **[polkadotXcm](#polkadotxcm)**
 
 - **[poolAssets](#poolassets)**
 
+- **[preimage](#preimage)**
+
 - **[proxy](#proxy)**
+
+- **[recovery](#recovery)**
+
+- **[referenda](#referenda)**
 
 - **[remoteProxyRelayChain](#remoteproxyrelaychain)**
 
 - **[revive](#revive)**
 
+- **[scheduler](#scheduler)**
+
 - **[session](#session)**
+
+- **[society](#society)**
+
+- **[staking](#staking)**
+
+- **[stakingRcClient](#stakingrcclient)**
 
 - **[stateTrieMigration](#statetriemigration)**
 
@@ -58,12 +102,114 @@ The following sections contain Storage methods are part of the default asset-hub
 
 - **[transactionPayment](#transactionpayment)**
 
+- **[treasury](#treasury)**
+
 - **[uniques](#uniques)**
 
 - **[vesting](#vesting)**
 
+- **[voterList](#voterlist)**
+
+- **[whitelist](#whitelist)**
+
 - **[xcmpQueue](#xcmpqueue)**
 
+
+___
+
+
+## ahMigrator
+ 
+### ahBalancesBefore(): `PalletAhMigratorBalancesBefore`
+- **interface**: `api.query.ahMigrator.ahBalancesBefore`
+- **summary**:    Helper storage item to store the total balance / total issuance of native token at the start  of the migration. Since teleports are disabled during migration, the total issuance will not  change for other reason than the migration itself. 
+ 
+### ahMigrationStage(): `PalletAhMigratorMigrationStage`
+- **interface**: `api.query.ahMigrator.ahMigrationStage`
+- **summary**:    The Asset Hub migration state. 
+ 
+### dmpQueuePriorityConfig(): `PalletRcMigratorQueuePriority`
+- **interface**: `api.query.ahMigrator.dmpQueuePriorityConfig`
+- **summary**:    The priority of the DMP queue during migration. 
+
+   Controls how the DMP (Downward Message Passing) queue is processed relative to other queues  during the migration process. This helps ensure timely processing of migration messages.  The default priority pattern is defined in the pallet configuration, but can be overridden  by a storage value of this type. 
+ 
+### manager(): `Option<AccountId32>`
+- **interface**: `api.query.ahMigrator.manager`
+- **summary**:    An optional account id of a manager. 
+
+   This account id has similar privileges to [`Config::AdminOrigin`] except that it  can not set the manager account id via `set_manager` call. 
+ 
+### migrationEndBlock(): `Option<u32>`
+- **interface**: `api.query.ahMigrator.migrationEndBlock`
+- **summary**:    Block number when migration finished and extrinsics were unlocked. 
+
+   This is set when entering the `MigrationDone` stage hence when  `RcMigrationStage::is_finished()` becomes `true`. 
+ 
+### migrationStartBlock(): `Option<u32>`
+- **interface**: `api.query.ahMigrator.migrationStartBlock`
+- **summary**:    The block number at which the migration began and the pallet's extrinsics were locked. 
+
+   This value is set when entering the `WaitingForAh` stage, i.e., when  `RcMigrationStage::is_ongoing()` becomes `true`. 
+ 
+### rcAccounts(`AccountId32`): `Option<PalletRcMigratorAccountsAccount>`
+- **interface**: `api.query.ahMigrator.rcAccounts`
+- **summary**:    RC accounts that failed to migrate when were received on the Asset Hub. 
+
+   This is unlikely to happen, since we dry run the migration, but we keep it for completeness. 
+
+___
+
+
+## ahOps
+ 
+### rcCrowdloanContribution(`u32, u32, AccountId32`): `Option<(AccountId32,u128)>`
+- **interface**: `api.query.ahOps.rcCrowdloanContribution`
+- **summary**:    Amount of balance that a contributor made towards a crowdloan. 
+
+   `withdraw_crowdloan_contribution` can be permissionlessly called once the block number  passed to unlock the balance for a specific account. 
+
+   The keys are as follows: 
+
+  - Block number after which the balance can be unlocked.
+
+  - The para_id of the crowdloan.
+
+  - The account that made the contribution.
+
+   The value is (fund_pot, balance). The contribution pot is the second key in the  `RcCrowdloanContribution` storage. 
+ 
+### rcCrowdloanReserve(`u32, u32, AccountId32`): `Option<u128>`
+- **interface**: `api.query.ahOps.rcCrowdloanReserve`
+- **summary**:    The reserve that was taken to create a crowdloan. 
+
+   This is normally 500 DOT and can be refunded as last step after all  `RcCrowdloanContribution`s of this loan have been withdrawn. 
+
+   Keys: 
+
+  - Block number after which this can be unreserved
+
+  - The para_id of the crowdloan
+
+  - The account that will have the balance unreserved
+ 
+### rcLeaseReserve(`u32, u32, AccountId32`): `Option<u128>`
+- **interface**: `api.query.ahOps.rcLeaseReserve`
+- **summary**:    Amount of balance that was reserved for winning a lease auction. 
+
+   `unreserve_lease_deposit` can be permissionlessly called once the block number passed to  unreserve the deposit. It is implicitly called by `withdraw_crowdloan_contribution`. 
+
+   The account here can either be a crowdloan account or a solo bidder. If it is a crowdloan  account, then the summed up contributions for it in the contributions map will equate the  reserved balance here. 
+
+   The keys are as follows: 
+
+  - Block number after which the deposit can be unreserved.
+
+  - The para_id of the lease slot.
+
+  - The account that will have the balance unreserved.
+
+  - The balance to be unreserved.
 
 ___
 
@@ -74,9 +220,20 @@ ___
 - **interface**: `api.query.assetConversion.nextPoolAssetId`
 - **summary**:    Stores the `PoolAssetId` that is going to be used for the next lp token.  This gets incremented whenever a new lp pool is created. 
  
-### pools(`(StagingXcmV4Location,StagingXcmV4Location)`): `Option<PalletAssetConversionPoolInfo>`
+### pools(`(StagingXcmV5Location,StagingXcmV5Location)`): `Option<PalletAssetConversionPoolInfo>`
 - **interface**: `api.query.assetConversion.pools`
 - **summary**:    Map from `PoolAssetId` to `PoolInfo`. This establishes whether a pool has been officially  created rather than people sending tokens directly to a pool's public account. 
+
+___
+
+
+## assetRate
+ 
+### conversionRateToNative(`PolkadotRuntimeCommonImplsVersionedLocatableAsset`): `Option<u128>`
+- **interface**: `api.query.assetRate.conversionRateToNative`
+- **summary**:    Maps an asset to its fixed point representation in the native balance. 
+
+   E.g. `native_amount = asset_amount * ConversionRateToNative::<T>::get(asset_kind)` 
 
 ___
 
@@ -169,11 +326,11 @@ ___
 
    But this comes with tradeoffs, storing account balances in the system pallet stores  `frame_system` data alongside the account data contrary to storing account balances in the  `Balances` pallet, which uses a `StorageMap` to store balances data only.  NOTE: This is only used in the case that this pallet is used to store balances. 
  
-### freezes(`AccountId32`): `Vec<FrameSupportTokensMiscIdAmount>`
+### freezes(`AccountId32`): `Vec<FrameSupportTokensMiscIdAmountRuntimeFreezeReason>`
 - **interface**: `api.query.balances.freezes`
 - **summary**:    Freeze locks on account balances. 
  
-### holds(`AccountId32`): `Vec<{"id":"AssetHubKusamaRuntimeRuntimeHoldReason","amount":"u128"}>`
+### holds(`AccountId32`): `Vec<FrameSupportTokensMiscIdAmountRuntimeHoldReason>`
 - **interface**: `api.query.balances.holds`
 - **summary**:    Holds on account balances. 
  
@@ -196,6 +353,87 @@ ___
 ### totalIssuance(): `u128`
 - **interface**: `api.query.balances.totalIssuance`
 - **summary**:    The total units issued in the system. 
+
+___
+
+
+## bounties
+ 
+### bounties(`u32`): `Option<PalletBountiesBounty>`
+- **interface**: `api.query.bounties.bounties`
+- **summary**:    Bounties that have been made. 
+ 
+### bountyApprovals(): `Vec<u32>`
+- **interface**: `api.query.bounties.bountyApprovals`
+- **summary**:    Bounty indices that have been approved but not yet funded. 
+ 
+### bountyCount(): `u32`
+- **interface**: `api.query.bounties.bountyCount`
+- **summary**:    Number of bounty proposals that have been made. 
+ 
+### bountyDescriptions(`u32`): `Option<Bytes>`
+- **interface**: `api.query.bounties.bountyDescriptions`
+- **summary**:    The description of each bounty. 
+
+___
+
+
+## childBounties
+ 
+### childBounties(`u32, u32`): `Option<PalletChildBountiesChildBounty>`
+- **interface**: `api.query.childBounties.childBounties`
+- **summary**:    Child bounties that have been added. 
+ 
+### childBountyCount(): `u32`
+- **interface**: `api.query.childBounties.childBountyCount`
+- **summary**:    DEPRECATED: Replaced with `ParentTotalChildBounties` storage item keeping dedicated counts  for each parent bounty. Number of total child bounties. Will be removed in May 2025. 
+ 
+### childBountyDescriptionsV1(`u32, u32`): `Option<Bytes>`
+- **interface**: `api.query.childBounties.childBountyDescriptionsV1`
+- **summary**:    The description of each child-bounty. Indexed by `(parent_id, child_id)`. 
+
+   This item replaces the `ChildBountyDescriptions` storage item from the V0 storage version. 
+ 
+### childrenCuratorFees(`u32`): `u128`
+- **interface**: `api.query.childBounties.childrenCuratorFees`
+- **summary**:    The cumulative child-bounty curator fee for each parent bounty. 
+ 
+### parentChildBounties(`u32`): `u32`
+- **interface**: `api.query.childBounties.parentChildBounties`
+- **summary**:    Number of active child bounties per parent bounty.  Map of parent bounty index to number of child bounties. 
+ 
+### parentTotalChildBounties(`u32`): `u32`
+- **interface**: `api.query.childBounties.parentTotalChildBounties`
+- **summary**:    Number of total child bounties per parent bounty, including completed bounties. 
+ 
+### v0ToV1ChildBountyIds(`u32`): `Option<(u32,u32)>`
+- **interface**: `api.query.childBounties.v0ToV1ChildBountyIds`
+- **summary**:    The mapping of the child bounty ids from storage version `V0` to the new `V1` version. 
+
+   The `V0` ids based on total child bounty count [`ChildBountyCount`]`. The `V1` version ids  based on the child bounty count per parent bounty [`ParentTotalChildBounties`].  The item intended solely for client convenience and not used in the pallet's core logic. 
+
+___
+
+
+## claims
+ 
+### claims(`EthereumAddress`): `Option<u128>`
+- **interface**: `api.query.claims.claims`
+ 
+### preclaims(`AccountId32`): `Option<EthereumAddress>`
+- **interface**: `api.query.claims.preclaims`
+- **summary**:    Pre-claimed Ethereum accounts, by the Account ID that they are claimed to. 
+ 
+### signing(`EthereumAddress`): `Option<PolkadotRuntimeCommonClaimsStatementKind>`
+- **interface**: `api.query.claims.signing`
+- **summary**:    The statement kind that must be signed, if any. 
+ 
+### total(): `u128`
+- **interface**: `api.query.claims.total`
+ 
+### vesting(`EthereumAddress`): `Option<(u128,u128,u32)>`
+- **interface**: `api.query.claims.vesting`
+- **summary**:    Vesting schedule for a claim.  First balance is the total amount that should be held for vesting.  Second balance is how much should be unlocked per block.  The block number is when the vesting should start. 
 
 ___
 
@@ -231,31 +469,76 @@ ___
 ___
 
 
+## convictionVoting
+ 
+### classLocksFor(`AccountId32`): `Vec<(u16,u128)>`
+- **interface**: `api.query.convictionVoting.classLocksFor`
+- **summary**:    The voting classes which have a non-zero lock requirement and the lock amounts which they  require. The actual amount locked on behalf of this pallet should always be the maximum of  this list. 
+ 
+### votingFor(`AccountId32, u16`): `PalletConvictionVotingVoteVoting`
+- **interface**: `api.query.convictionVoting.votingFor`
+- **summary**:    All voting for a particular voter in a particular voting class. We store the balance for the  number of votes that we have recorded. 
+
+___
+
+
+## delegatedStaking
+ 
+### agents(`AccountId32`): `Option<PalletDelegatedStakingAgentLedger>`
+- **interface**: `api.query.delegatedStaking.agents`
+- **summary**:    Map of `Agent` to their `Ledger`. 
+ 
+### counterForAgents(): `u32`
+- **interface**: `api.query.delegatedStaking.counterForAgents`
+- **summary**:    Counter for the related counted storage map 
+ 
+### counterForDelegators(): `u32`
+- **interface**: `api.query.delegatedStaking.counterForDelegators`
+- **summary**:    Counter for the related counted storage map 
+ 
+### delegators(`AccountId32`): `Option<PalletDelegatedStakingDelegation>`
+- **interface**: `api.query.delegatedStaking.delegators`
+- **summary**:    Map of Delegators to their `Delegation`. 
+
+   Implementation note: We are not using a double map with `delegator` and `agent` account  as keys since we want to restrict delegators to delegate only to one account at a time. 
+
+___
+
+
 ## foreignAssets
  
-### account(`StagingXcmV4Location, AccountId32`): `Option<PalletAssetsAssetAccount>`
+### account(`StagingXcmV5Location, AccountId32`): `Option<PalletAssetsAssetAccount>`
 - **interface**: `api.query.foreignAssets.account`
 - **summary**:    The holdings of a specific account for a specific asset. 
  
-### approvals(`StagingXcmV4Location, AccountId32, AccountId32`): `Option<PalletAssetsApproval>`
+### approvals(`StagingXcmV5Location, AccountId32, AccountId32`): `Option<PalletAssetsApproval>`
 - **interface**: `api.query.foreignAssets.approvals`
 - **summary**:    Approved balance transfers. First balance is the amount approved for transfer. Second  is the amount of `T::Currency` reserved for storing this.  First key is the asset ID, second key is the owner and third key is the delegate. 
  
-### asset(`StagingXcmV4Location`): `Option<PalletAssetsAssetDetails>`
+### asset(`StagingXcmV5Location`): `Option<PalletAssetsAssetDetails>`
 - **interface**: `api.query.foreignAssets.asset`
 - **summary**:    Details of an asset. 
  
-### metadata(`StagingXcmV4Location`): `{"deposit":"u128","name":"Bytes","symbol":"Bytes","decimals":"u8","isFrozen":"bool"}`
+### metadata(`StagingXcmV5Location`): `{"deposit":"u128","name":"Bytes","symbol":"Bytes","decimals":"u8","isFrozen":"bool"}`
 - **interface**: `api.query.foreignAssets.metadata`
 - **summary**:    Metadata of an asset. 
  
-### nextAssetId(): `Option<StagingXcmV4Location>`
+### nextAssetId(): `Option<StagingXcmV5Location>`
 - **interface**: `api.query.foreignAssets.nextAssetId`
 - **summary**:    The asset ID enforced for the next asset creation, if any present. Otherwise, this storage  item has no effect. 
 
    This can be useful for setting up constraints for IDs of the new assets. For example, by  providing an initial [`NextAssetId`] and using the [`crate::AutoIncAssetId`] callback, an  auto-increment model can be applied to all new asset IDs. 
 
    The initial next asset ID can be set using the [`GenesisConfig`] or the  [SetNextAssetId](`migration::next_asset_id::SetNextAssetId`) migration. 
+
+___
+
+
+## indices
+ 
+### accounts(`u32`): `Option<(AccountId32,u128,bool)>`
+- **interface**: `api.query.indices.accounts`
+- **summary**:    The lookup from index to account. 
 
 ___
 
@@ -273,6 +556,137 @@ ___
 ### serviceHead(): `Option<CumulusPrimitivesCoreAggregateMessageOrigin>`
 - **interface**: `api.query.messageQueue.serviceHead`
 - **summary**:    The origin at which we should begin servicing. 
+
+___
+
+
+## multiBlockElection
+ 
+### currentPhase(): `PalletElectionProviderMultiBlockPhase`
+- **interface**: `api.query.multiBlockElection.currentPhase`
+- **summary**:    Current phase. 
+ 
+### desiredTargets(`u32`): `Option<u32>`
+- **interface**: `api.query.multiBlockElection.desiredTargets`
+- **summary**:    Desired number of targets to elect for this round. 
+ 
+### pagedTargetSnapshot(`u32, u32`): `Option<Vec<AccountId32>>`
+- **interface**: `api.query.multiBlockElection.pagedTargetSnapshot`
+- **summary**:    Paginated target snapshot. 
+
+   For the time being, since we assume one pages of targets, at most ONE key will exist. 
+ 
+### pagedTargetSnapshotHash(`u32, u32`): `Option<H256>`
+- **interface**: `api.query.multiBlockElection.pagedTargetSnapshotHash`
+- **summary**:    Same as [`PagedTargetSnapshot`], but it will store the hash of the snapshot. 
+
+   The hash is generated using [`frame_system::Config::Hashing`]. 
+ 
+### pagedVoterSnapshot(`u32, u32`): `Option<Vec<(AccountId32,u64,Vec<AccountId32>)>>`
+- **interface**: `api.query.multiBlockElection.pagedVoterSnapshot`
+- **summary**:    Paginated voter snapshot. At most [`T::Pages`] keys will exist. 
+ 
+### pagedVoterSnapshotHash(`u32, u32`): `Option<H256>`
+- **interface**: `api.query.multiBlockElection.pagedVoterSnapshotHash`
+- **summary**:    Same as [`PagedVoterSnapshot`], but it will store the hash of the snapshot. 
+
+   The hash is generated using [`frame_system::Config::Hashing`]. 
+ 
+### round(): `u32`
+- **interface**: `api.query.multiBlockElection.round`
+- **summary**:    Internal counter for the number of rounds. 
+
+   This is useful for de-duplication of transactions submitted to the pool, and general  diagnostics of the pallet. 
+
+   This is merely incremented once per every time that an upstream `elect` is called. 
+
+___
+
+
+## multiBlockElectionSigned
+ 
+### invulnerables(): `Vec<AccountId32>`
+- **interface**: `api.query.multiBlockElectionSigned.invulnerables`
+- **summary**:    Accounts whitelisted by governance to always submit their solutions. 
+
+   They are different in that: 
+
+   * They always pay a fixed deposit for submission, specified by  [`Config::InvulnerableDeposit`]. They pay no page deposit. 
+
+  * If _ejected_ by better solution from [`SortedScores`], they will get their full deposit back. 
+
+  * They always get their tx-fee back even if they are _discarded_.
+ 
+### sortedScores(`u32`): `Vec<(AccountId32,SpNposElectionsElectionScore)>`
+- **interface**: `api.query.multiBlockElectionSigned.sortedScores`
+ 
+### submissionMetadataStorage(`u32, AccountId32`): `Option<PalletElectionProviderMultiBlockSignedSubmissionMetadata>`
+- **interface**: `api.query.multiBlockElectionSigned.submissionMetadataStorage`
+- **summary**:    Map from account to the metadata of their submission. 
+
+   invariant: for any Key1 of type `AccountId` in [`Submissions`], this storage map also has a  value. 
+ 
+### submissionStorage(`u32, AccountId32, u32`): `Option<AssetHubKusamaRuntimeStakingNposCompactSolution24>`
+- **interface**: `api.query.multiBlockElectionSigned.submissionStorage`
+- **summary**:    Triple map from (round, account, page) to a solution page. 
+
+___
+
+
+## multiBlockElectionVerifier
+ 
+### minimumScore(): `Option<SpNposElectionsElectionScore>`
+- **interface**: `api.query.multiBlockElectionVerifier.minimumScore`
+- **summary**:    The minimum score that each solution must attain in order to be considered feasible. 
+ 
+### queuedSolutionBackings(`u32, u32`): `Option<Vec<(AccountId32,PalletElectionProviderMultiBlockVerifierImplsPartialBackings)>>`
+- **interface**: `api.query.multiBlockElectionVerifier.queuedSolutionBackings`
+- **summary**:    The `(amount, count)` of backings, divided per page. 
+
+   This is stored because in the last block of verification we need them to compute the score,  and check `MaxBackersPerWinnerFinal`. 
+
+   This can only ever live for the invalid variant of the solution. Once it is valid, we don't  need this information anymore; the score is already computed once in  [`QueuedSolutionScore`], and the backing counts are checked. 
+ 
+### queuedSolutionScore(`u32`): `Option<SpNposElectionsElectionScore>`
+- **interface**: `api.query.multiBlockElectionVerifier.queuedSolutionScore`
+- **summary**:    The score of the valid variant of [`QueuedSolution`]. 
+
+   This only ever lives for the `valid` variant. 
+ 
+### queuedSolutionX(`u32, u32`): `Option<FrameElectionProviderSupportBoundedSupports>`
+- **interface**: `api.query.multiBlockElectionVerifier.queuedSolutionX`
+- **summary**:    The `X` variant of the current queued solution. Might be the valid one or not. 
+
+   The two variants of this storage item is to avoid the need of copying. Recall that once a  `VerifyingSolution` is being processed, it needs to write its partial supports *somewhere*.  Writing theses supports on top of a *good* queued supports is wrong, since we might bail.  Writing them to a bugger and copying at the ned is slightly better, but expensive. This flag  system is best of both worlds. 
+ 
+### queuedSolutionY(`u32, u32`): `Option<FrameElectionProviderSupportBoundedSupports>`
+- **interface**: `api.query.multiBlockElectionVerifier.queuedSolutionY`
+- **summary**:    The `Y` variant of the current queued solution. Might be the valid one or not. 
+ 
+### queuedValidVariant(`u32`): `PalletElectionProviderMultiBlockVerifierImplsValidSolution`
+- **interface**: `api.query.multiBlockElectionVerifier.queuedValidVariant`
+- **summary**:    Pointer to the variant of [`QueuedSolutionX`] or [`QueuedSolutionY`] that is currently  valid. 
+ 
+### statusStorage(): `PalletElectionProviderMultiBlockVerifierImplsStatus`
+- **interface**: `api.query.multiBlockElectionVerifier.statusStorage`
+- **summary**:    Storage item for [`Status`]. 
+
+___
+
+
+## multiBlockMigrations
+ 
+### cursor(): `Option<PalletMigrationsMigrationCursor>`
+- **interface**: `api.query.multiBlockMigrations.cursor`
+- **summary**:    The currently active migration to run and its cursor. 
+
+   `None` indicates that no migration is running. 
+ 
+### historic(`Bytes`): `Option<Null>`
+- **interface**: `api.query.multiBlockMigrations.historic`
+- **summary**:    Set of all successfully executed migrations. 
+
+   This is used as blacklist, to not re-execute migrations that have not been removed from the  codebase yet. Governance can regularly clear this out via `clear_historic`. 
 
 ___
 
@@ -360,6 +774,105 @@ ___
 ___
 
 
+## nominationPools
+ 
+### bondedPools(`u32`): `Option<PalletNominationPoolsBondedPoolInner>`
+- **interface**: `api.query.nominationPools.bondedPools`
+- **summary**:    Storage for bonded pools. 
+ 
+### claimPermissions(`AccountId32`): `PalletNominationPoolsClaimPermission`
+- **interface**: `api.query.nominationPools.claimPermissions`
+- **summary**:    Map from a pool member account to their opted claim permission. 
+ 
+### counterForBondedPools(): `u32`
+- **interface**: `api.query.nominationPools.counterForBondedPools`
+- **summary**:    Counter for the related counted storage map 
+ 
+### counterForMetadata(): `u32`
+- **interface**: `api.query.nominationPools.counterForMetadata`
+- **summary**:    Counter for the related counted storage map 
+ 
+### counterForPoolMembers(): `u32`
+- **interface**: `api.query.nominationPools.counterForPoolMembers`
+- **summary**:    Counter for the related counted storage map 
+ 
+### counterForReversePoolIdLookup(): `u32`
+- **interface**: `api.query.nominationPools.counterForReversePoolIdLookup`
+- **summary**:    Counter for the related counted storage map 
+ 
+### counterForRewardPools(): `u32`
+- **interface**: `api.query.nominationPools.counterForRewardPools`
+- **summary**:    Counter for the related counted storage map 
+ 
+### counterForSubPoolsStorage(): `u32`
+- **interface**: `api.query.nominationPools.counterForSubPoolsStorage`
+- **summary**:    Counter for the related counted storage map 
+ 
+### globalMaxCommission(): `Option<Perbill>`
+- **interface**: `api.query.nominationPools.globalMaxCommission`
+- **summary**:    The maximum commission that can be charged by a pool. Used on commission payouts to bound  pool commissions that are > `GlobalMaxCommission`, necessary if a future  `GlobalMaxCommission` is lower than some current pool commissions. 
+ 
+### lastPoolId(): `u32`
+- **interface**: `api.query.nominationPools.lastPoolId`
+- **summary**:    Ever increasing number of all pools created so far. 
+ 
+### maxPoolMembers(): `Option<u32>`
+- **interface**: `api.query.nominationPools.maxPoolMembers`
+- **summary**:    Maximum number of members that can exist in the system. If `None`, then the count  members are not bound on a system wide basis. 
+ 
+### maxPoolMembersPerPool(): `Option<u32>`
+- **interface**: `api.query.nominationPools.maxPoolMembersPerPool`
+- **summary**:    Maximum number of members that may belong to pool. If `None`, then the count of  members is not bound on a per pool basis. 
+ 
+### maxPools(): `Option<u32>`
+- **interface**: `api.query.nominationPools.maxPools`
+- **summary**:    Maximum number of nomination pools that can exist. If `None`, then an unbounded number of  pools can exist. 
+ 
+### metadata(`u32`): `Bytes`
+- **interface**: `api.query.nominationPools.metadata`
+- **summary**:    Metadata for the pool. 
+ 
+### minCreateBond(): `u128`
+- **interface**: `api.query.nominationPools.minCreateBond`
+- **summary**:    Minimum bond required to create a pool. 
+
+   This is the amount that the depositor must put as their initial stake in the pool, as an  indication of "skin in the game". 
+
+   This is the value that will always exist in the staking ledger of the pool bonded account  while all other accounts leave. 
+ 
+### minJoinBond(): `u128`
+- **interface**: `api.query.nominationPools.minJoinBond`
+- **summary**:    Minimum amount to bond to join a pool. 
+ 
+### poolMembers(`AccountId32`): `Option<PalletNominationPoolsPoolMember>`
+- **interface**: `api.query.nominationPools.poolMembers`
+- **summary**:    Active members. 
+
+   TWOX-NOTE: SAFE since `AccountId` is a secure hash. 
+ 
+### reversePoolIdLookup(`AccountId32`): `Option<u32>`
+- **interface**: `api.query.nominationPools.reversePoolIdLookup`
+- **summary**:    A reverse lookup from the pool's account id to its id. 
+
+   This is only used for slashing and on automatic withdraw update. In all other instances, the  pool id is used, and the accounts are deterministically derived from it. 
+ 
+### rewardPools(`u32`): `Option<PalletNominationPoolsRewardPool>`
+- **interface**: `api.query.nominationPools.rewardPools`
+- **summary**:    Reward pools. This is where there rewards for each pool accumulate. When a members payout is  claimed, the balance comes out of the reward pool. Keyed by the bonded pools account. 
+ 
+### subPoolsStorage(`u32`): `Option<PalletNominationPoolsSubPools>`
+- **interface**: `api.query.nominationPools.subPoolsStorage`
+- **summary**:    Groups of unbonding pools. Each group of unbonding pools belongs to a  bonded pool, hence the name sub-pools. Keyed by the bonded pools account. 
+ 
+### totalValueLocked(): `u128`
+- **interface**: `api.query.nominationPools.totalValueLocked`
+- **summary**:    The sum of funds across all pools. 
+
+   This might be lower but never higher than the sum of `total_balance` of all [`PoolMembers`]  because calling `pool_withdraw_unbonded` might decrease the total stake of the pool's  `bonded_account` without adjusting the pallet-internal `UnbondingPool`'s. 
+
+___
+
+
 ## parachainInfo
  
 ### parachainId(): `u32`
@@ -405,8 +918,6 @@ ___
 ### hrmpWatermark(): `u32`
 - **interface**: `api.query.parachainSystem.hrmpWatermark`
 - **summary**:    HRMP watermark that was set in a block. 
-
-   This will be cleared in `on_initialize` of each new block. 
  
 ### lastDmqMqcHead(): `H256`
 - **interface**: `api.query.parachainSystem.lastDmqMqcHead`
@@ -419,6 +930,18 @@ ___
 - **summary**:    The message queue chain heads we have observed per each channel incoming channel. 
 
    This value is loaded before and saved after processing inbound downward messages carried  by the system inherent. 
+ 
+### lastProcessedDownwardMessage(): `Option<CumulusPalletParachainSystemParachainInherentInboundMessageId>`
+- **interface**: `api.query.parachainSystem.lastProcessedDownwardMessage`
+- **summary**:    The last processed downward message. 
+
+   We need to keep track of this to filter the messages that have been already processed. 
+ 
+### lastProcessedHrmpMessage(): `Option<CumulusPalletParachainSystemParachainInherentInboundMessageId>`
+- **interface**: `api.query.parachainSystem.lastProcessedHrmpMessage`
+- **summary**:    The last processed HRMP message. 
+
+   We need to keep track of this to filter the messages that have been already processed. 
  
 ### lastRelayChainBlockNumber(): `u32`
 - **interface**: `api.query.parachainSystem.lastRelayChainBlockNumber`
@@ -503,6 +1026,15 @@ ___
 ### validationData(): `Option<PolkadotPrimitivesV8PersistedValidationData>`
 - **interface**: `api.query.parachainSystem.validationData`
 - **summary**:    The [`PersistedValidationData`] set for this block.  This value is expected to be set only once per block and it's never stored  in the trie. 
+
+___
+
+
+## parameters
+ 
+### parameters(`AssetHubKusamaRuntimeRuntimeParametersKey`): `Option<AssetHubKusamaRuntimeRuntimeParametersValue>`
+- **interface**: `api.query.parameters.parameters`
+- **summary**:    Stored parameters. 
 
 ___
 
@@ -607,15 +1139,81 @@ ___
 ___
 
 
+## preimage
+ 
+### preimageFor(`(H256,u32)`): `Option<Bytes>`
+- **interface**: `api.query.preimage.preimageFor`
+ 
+### requestStatusFor(`H256`): `Option<PalletPreimageRequestStatus>`
+- **interface**: `api.query.preimage.requestStatusFor`
+- **summary**:    The request status of a given hash. 
+ 
+### statusFor(`H256`): `Option<PalletPreimageOldRequestStatus>`
+- **interface**: `api.query.preimage.statusFor`
+- **summary**:    The request status of a given hash. 
+
+___
+
+
 ## proxy
  
 ### announcements(`AccountId32`): `(Vec<PalletProxyAnnouncement>,u128)`
 - **interface**: `api.query.proxy.announcements`
 - **summary**:    The announcements made by the proxy (key). 
  
-### proxies(`AccountId32`): `(Vec<PalletProxyProxyDefinition>,u128)`
+### proxies(`AccountId32`): `(Vec<PalletProxyProxyDefinitionAssetHubKusamaRuntimeProxyType>,u128)`
 - **interface**: `api.query.proxy.proxies`
 - **summary**:    The set of account proxies. Maps the account which has delegated to the accounts  which are being delegated to, together with the amount held on deposit. 
+
+___
+
+
+## recovery
+ 
+### activeRecoveries(`AccountId32, AccountId32`): `Option<PalletRecoveryActiveRecovery>`
+- **interface**: `api.query.recovery.activeRecoveries`
+- **summary**:    Active recovery attempts. 
+
+   First account is the account to be recovered, and the second account  is the user trying to recover the account. 
+ 
+### proxy(`AccountId32`): `Option<AccountId32>`
+- **interface**: `api.query.recovery.proxy`
+- **summary**:    The list of allowed proxy accounts. 
+
+   Map from the user who can access it to the recovered account. 
+ 
+### recoverable(`AccountId32`): `Option<PalletRecoveryRecoveryConfig>`
+- **interface**: `api.query.recovery.recoverable`
+- **summary**:    The set of recoverable accounts and their recovery configuration. 
+
+___
+
+
+## referenda
+ 
+### decidingCount(`u16`): `u32`
+- **interface**: `api.query.referenda.decidingCount`
+- **summary**:    The number of referenda being decided currently. 
+ 
+### metadataOf(`u32`): `Option<H256>`
+- **interface**: `api.query.referenda.metadataOf`
+- **summary**:    The metadata is a general information concerning the referendum.  The `Hash` refers to the preimage of the `Preimages` provider which can be a JSON  dump or IPFS hash of a JSON file. 
+
+   Consider a garbage collection for a metadata of finished referendums to `unrequest` (remove)  large preimages. 
+ 
+### referendumCount(): `u32`
+- **interface**: `api.query.referenda.referendumCount`
+- **summary**:    The next free referendum index, aka the number of referenda started so far. 
+ 
+### referendumInfoFor(`u32`): `Option<PalletReferendaReferendumInfoOriginCaller>`
+- **interface**: `api.query.referenda.referendumInfoFor`
+- **summary**:    Information concerning any given referendum. 
+ 
+### trackQueue(`u16`): `Vec<(u32,u128)>`
+- **interface**: `api.query.referenda.trackQueue`
+- **summary**:    The sorted list of referenda ready to be decided but not yet being decided, ordered by  conviction-weighted approvals. 
+
+   This should be empty if `DecidingCount` is less than `TrackInfo::max_deciding`. 
 
 ___
 
@@ -631,13 +1229,13 @@ ___
 
 ## revive
  
-### codeInfoOf(`H256`): `Option<PalletReviveWasmCodeInfo>`
+### accountInfoOf(`H160`): `Option<PalletReviveStorageAccountInfo>`
+- **interface**: `api.query.revive.accountInfoOf`
+- **summary**:    The data associated to a contract or externally owned account. 
+ 
+### codeInfoOf(`H256`): `Option<PalletReviveVmCodeInfo>`
 - **interface**: `api.query.revive.codeInfoOf`
 - **summary**:    A mapping from a contract's code hash to its code info. 
- 
-### contractInfoOf(`H160`): `Option<PalletReviveStorageContractInfo>`
-- **interface**: `api.query.revive.contractInfoOf`
-- **summary**:    The code associated with a given account. 
  
 ### deletionQueue(`u32`): `Option<Bytes>`
 - **interface**: `api.query.revive.deletionQueue`
@@ -662,6 +1260,29 @@ ___
 ### pristineCode(`H256`): `Option<Bytes>`
 - **interface**: `api.query.revive.pristineCode`
 - **summary**:    A mapping from a contract's code hash to its code. 
+
+___
+
+
+## scheduler
+ 
+### agenda(`u32`): `Vec<Option<PalletSchedulerScheduled>>`
+- **interface**: `api.query.scheduler.agenda`
+- **summary**:    Items to be executed, indexed by the block number that they should be executed on. 
+ 
+### incompleteSince(): `Option<u32>`
+- **interface**: `api.query.scheduler.incompleteSince`
+- **summary**:    Block number at which the agenda began incomplete execution. 
+ 
+### lookup(`[u8;32]`): `Option<(u32,u32)>`
+- **interface**: `api.query.scheduler.lookup`
+- **summary**:    Lookup from a name to the block number and index of the task. 
+
+   For v3 -> v4 the previously unbounded identities are Blake2-256 hashed to form the v4  identities. 
+ 
+### retries(`(u32,u32)`): `Option<PalletSchedulerRetryConfig>`
+- **interface**: `api.query.scheduler.retries`
+- **summary**:    Retry configurations for items to be executed, indexed by task address. 
 
 ___
 
@@ -697,6 +1318,378 @@ ___
 ### validators(): `Vec<AccountId32>`
 - **interface**: `api.query.session.validators`
 - **summary**:    The current set of validators. 
+
+___
+
+
+## society
+ 
+### bids(): `Vec<PalletSocietyBid>`
+- **interface**: `api.query.society.bids`
+- **summary**:    The current bids, stored ordered by the value of the bid. 
+ 
+### candidates(`AccountId32`): `Option<PalletSocietyCandidacy>`
+- **interface**: `api.query.society.candidates`
+ 
+### challengeRoundCount(): `u32`
+- **interface**: `api.query.society.challengeRoundCount`
+- **summary**:    The number of challenge rounds there have been. Used to identify stale DefenderVotes. 
+ 
+### defenderVotes(`u32, AccountId32`): `Option<PalletSocietyVote>`
+- **interface**: `api.query.society.defenderVotes`
+- **summary**:    Votes for the defender, keyed by challenge round. 
+ 
+### defending(): `Option<(AccountId32,AccountId32,PalletSocietyTally)>`
+- **interface**: `api.query.society.defending`
+- **summary**:    The defending member currently being challenged, along with a running tally of votes. 
+ 
+### founder(): `Option<AccountId32>`
+- **interface**: `api.query.society.founder`
+- **summary**:    The first member. 
+ 
+### head(): `Option<AccountId32>`
+- **interface**: `api.query.society.head`
+- **summary**:    The most primary from the most recently approved rank 0 members in the society. 
+ 
+### memberByIndex(`u32`): `Option<AccountId32>`
+- **interface**: `api.query.society.memberByIndex`
+- **summary**:    The current items in `Members` keyed by their unique index. Keys are densely populated  `0..MemberCount` (does not include `MemberCount`). 
+ 
+### memberCount(): `u32`
+- **interface**: `api.query.society.memberCount`
+- **summary**:    The number of items in `Members` currently. (Doesn't include `SuspendedMembers`.) 
+ 
+### members(`AccountId32`): `Option<PalletSocietyMemberRecord>`
+- **interface**: `api.query.society.members`
+- **summary**:    The current members and their rank. Doesn't include `SuspendedMembers`. 
+ 
+### nextChallengeAt(): `Option<u32>`
+- **interface**: `api.query.society.nextChallengeAt`
+- **summary**:    Next challenge rotation scheduled with [Config::BlockNumberProvider]. 
+ 
+### nextHead(): `Option<PalletSocietyIntakeRecord>`
+- **interface**: `api.query.society.nextHead`
+- **summary**:    At the end of the claim period, this contains the most recently approved members (along with  their bid and round ID) who is from the most recent round with the lowest bid. They will  become the new `Head`. 
+ 
+### nextIntakeAt(): `Option<u32>`
+- **interface**: `api.query.society.nextIntakeAt`
+- **summary**:    Next intake rotation scheduled with [Config::BlockNumberProvider]. 
+ 
+### parameters(): `Option<PalletSocietyGroupParams>`
+- **interface**: `api.query.society.parameters`
+- **summary**:    The max number of members for the society at one time. 
+ 
+### payouts(`AccountId32`): `PalletSocietyPayoutRecord`
+- **interface**: `api.query.society.payouts`
+- **summary**:    Information regarding rank-0 payouts, past and future. 
+ 
+### pot(): `u128`
+- **interface**: `api.query.society.pot`
+- **summary**:    Amount of our account balance that is specifically for the next round's bid(s). 
+ 
+### roundCount(): `u32`
+- **interface**: `api.query.society.roundCount`
+- **summary**:    The number of rounds which have passed. 
+ 
+### rules(): `Option<H256>`
+- **interface**: `api.query.society.rules`
+- **summary**:    A hash of the rules of this society concerning membership. Can only be set once and  only by the founder. 
+ 
+### skeptic(): `Option<AccountId32>`
+- **interface**: `api.query.society.skeptic`
+- **summary**:    The current skeptic. 
+ 
+### suspendedMembers(`AccountId32`): `Option<PalletSocietyMemberRecord>`
+- **interface**: `api.query.society.suspendedMembers`
+- **summary**:    The set of suspended members, with their old membership record. 
+ 
+### voteClearCursor(`AccountId32`): `Option<Bytes>`
+- **interface**: `api.query.society.voteClearCursor`
+- **summary**:    Clear-cursor for Vote, map from Candidate -> (Maybe) Cursor. 
+ 
+### votes(`AccountId32, AccountId32`): `Option<PalletSocietyVote>`
+- **interface**: `api.query.society.votes`
+- **summary**:    Double map from Candidate -> Voter -> (Maybe) Vote. 
+
+___
+
+
+## staking
+ 
+### activeEra(): `Option<PalletStakingAsyncActiveEraInfo>`
+- **interface**: `api.query.staking.activeEra`
+- **summary**:    The active era information, it holds index and start. 
+
+   The active era is the era being currently rewarded. Validator set of this era must be  equal to what is RC's session pallet. 
+ 
+### bonded(`AccountId32`): `Option<AccountId32>`
+- **interface**: `api.query.staking.bonded`
+- **summary**:    Map from all locked "stash" accounts to the controller account. 
+
+   TWOX-NOTE: SAFE since `AccountId` is a secure hash. 
+ 
+### bondedEras(): `Vec<(u32,u32)>`
+- **interface**: `api.query.staking.bondedEras`
+- **summary**:    A mapping from still-bonded eras to the first session index of that era. 
+
+   Must contains information for eras for the range:  `[active_era - bounding_duration; active_era]` 
+ 
+### canceledSlashPayout(): `u128`
+- **interface**: `api.query.staking.canceledSlashPayout`
+- **summary**:    The amount of currency given to reporters of a slash event which was  canceled by extraordinary circumstances (e.g. governance). 
+ 
+### cancelledSlashes(`u32`): `Vec<(AccountId32,Perbill)>`
+- **interface**: `api.query.staking.cancelledSlashes`
+- **summary**:    Cancelled slashes by era and validator with maximum slash fraction to be cancelled. 
+
+   When slashes are cancelled by governance, this stores the era and the validators  whose slashes should be cancelled, along with the maximum slash fraction that should  be cancelled for each validator. 
+ 
+### chillThreshold(): `Option<Percent>`
+- **interface**: `api.query.staking.chillThreshold`
+- **summary**:    The threshold for when users can start calling `chill_other` for other validators /  nominators. The threshold is compared to the actual number of validators / nominators  (`CountFor*`) in the system compared to the configured max (`Max*Count`). 
+ 
+### claimedRewards(`u32, AccountId32`): `Vec<u32>`
+- **interface**: `api.query.staking.claimedRewards`
+- **summary**:    History of claimed paged rewards by era and validator. 
+
+   This is keyed by era and validator stash which maps to the set of page indexes which have  been claimed. 
+
+   It is removed after [`Config::HistoryDepth`] eras. 
+ 
+### counterForNominators(): `u32`
+- **interface**: `api.query.staking.counterForNominators`
+- **summary**:    Counter for the related counted storage map 
+ 
+### counterForValidators(): `u32`
+- **interface**: `api.query.staking.counterForValidators`
+- **summary**:    Counter for the related counted storage map 
+ 
+### counterForVirtualStakers(): `u32`
+- **interface**: `api.query.staking.counterForVirtualStakers`
+- **summary**:    Counter for the related counted storage map 
+ 
+### currentEra(): `Option<u32>`
+- **interface**: `api.query.staking.currentEra`
+- **summary**:    The current planned era index. 
+
+   This is the latest planned era, depending on how the Session pallet queues the validator  set, it might be active or not. 
+ 
+### electableStashes(): `BTreeSet<AccountId32>`
+- **interface**: `api.query.staking.electableStashes`
+- **summary**:    A bounded list of the "electable" stashes that resulted from a successful election. 
+ 
+### eraPruningState(`u32`): `Option<PalletStakingAsyncPalletPruningStep>`
+- **interface**: `api.query.staking.eraPruningState`
+- **summary**:    Tracks the current step of era pruning process for each era being lazily pruned. 
+ 
+### erasRewardPoints(`u32`): `PalletStakingAsyncEraRewardPoints`
+- **interface**: `api.query.staking.erasRewardPoints`
+- **summary**:    Rewards for the last [`Config::HistoryDepth`] eras.  If reward hasn't been set or has been removed then 0 reward is returned. 
+ 
+### erasStakersOverview(`u32, AccountId32`): `Option<SpStakingPagedExposureMetadata>`
+- **interface**: `api.query.staking.erasStakersOverview`
+- **summary**:    Summary of validator exposure at a given era. 
+
+   This contains the total stake in support of the validator and their own stake. In addition,  it can also be used to get the number of nominators backing this validator and the number of  exposure pages they are divided into. The page count is useful to determine the number of  pages of rewards that needs to be claimed. 
+
+   This is keyed first by the era index to allow bulk deletion and then the stash account.  Should only be accessed through `Eras`. 
+
+   Is it removed after [`Config::HistoryDepth`] eras.  If stakers hasn't been set or has been removed then empty overview is returned. 
+ 
+### erasStakersPaged(`u32, AccountId32, u32`): `Option<PalletStakingAsyncPalletBoundedExposurePage>`
+- **interface**: `api.query.staking.erasStakersPaged`
+- **summary**:    Paginated exposure of a validator at given era. 
+
+   This is keyed first by the era index to allow bulk deletion, then stash account and finally  the page. Should only be accessed through `Eras`. 
+
+   This is cleared after [`Config::HistoryDepth`] eras. 
+ 
+### erasTotalStake(`u32`): `u128`
+- **interface**: `api.query.staking.erasTotalStake`
+- **summary**:    The total amount staked for the last [`Config::HistoryDepth`] eras.  If total hasn't been set or has been removed then 0 stake is returned. 
+ 
+### erasValidatorPrefs(`u32, AccountId32`): `PalletStakingAsyncValidatorPrefs`
+- **interface**: `api.query.staking.erasValidatorPrefs`
+- **summary**:    Exposure of validator at era with the preferences of validators. 
+
+   This is keyed first by the era index to allow bulk deletion and then the stash account. 
+
+   Is it removed after [`Config::HistoryDepth`] eras. 
+ 
+### erasValidatorReward(`u32`): `Option<u128>`
+- **interface**: `api.query.staking.erasValidatorReward`
+- **summary**:    The total validator era payout for the last [`Config::HistoryDepth`] eras. 
+
+   Eras that haven't finished yet or has been removed doesn't have reward. 
+ 
+### forceEra(): `PalletStakingAsyncForcing`
+- **interface**: `api.query.staking.forceEra`
+- **summary**:    Mode of era forcing. 
+ 
+### invulnerables(): `Vec<AccountId32>`
+- **interface**: `api.query.staking.invulnerables`
+- **summary**:    Any validators that may never be slashed or forcibly kicked. It's a Vec since they're  easy to initialize and the performance hit is minimal (we expect no more than four  invulnerables) and restricted to testnets. 
+ 
+### ledger(`AccountId32`): `Option<PalletStakingAsyncLedgerStakingLedger>`
+- **interface**: `api.query.staking.ledger`
+- **summary**:    Map from all (unlocked) "controller" accounts to the info regarding the staking. 
+
+   Note: All the reads and mutations to this storage *MUST* be done through the methods exposed  by [`StakingLedger`] to ensure data and lock consistency. 
+ 
+### maxNominatorsCount(): `Option<u32>`
+- **interface**: `api.query.staking.maxNominatorsCount`
+- **summary**:    The maximum nominator count before we stop allowing new validators to join. 
+
+   When this value is not set, no limits are enforced. 
+ 
+### maxStakedRewards(): `Option<Percent>`
+- **interface**: `api.query.staking.maxStakedRewards`
+- **summary**:    Maximum staked rewards, i.e. the percentage of the era inflation that  is used for stake rewards.  See [Era payout](./index.html#era-payout). 
+ 
+### maxValidatorsCount(): `Option<u32>`
+- **interface**: `api.query.staking.maxValidatorsCount`
+- **summary**:    The maximum validator count before we stop allowing new validators to join. 
+
+   When this value is not set, no limits are enforced. 
+ 
+### minCommission(): `Perbill`
+- **interface**: `api.query.staking.minCommission`
+- **summary**:    The minimum amount of commission that validators can set. 
+
+   If set to `0`, no limit exists. 
+ 
+### minimumActiveStake(): `u128`
+- **interface**: `api.query.staking.minimumActiveStake`
+- **summary**:    The minimum active nominator stake of the last successful election. 
+ 
+### minNominatorBond(): `u128`
+- **interface**: `api.query.staking.minNominatorBond`
+- **summary**:    The minimum active bond to become and maintain the role of a nominator. 
+ 
+### minValidatorBond(): `u128`
+- **interface**: `api.query.staking.minValidatorBond`
+- **summary**:    The minimum active bond to become and maintain the role of a validator. 
+ 
+### nextElectionPage(): `Option<u32>`
+- **interface**: `api.query.staking.nextElectionPage`
+- **summary**:    Keeps track of an ongoing multi-page election solution request. 
+
+   If `Some(_)``, it is the next page that we intend to elect. If `None`, we are not in the  election process. 
+
+   This is only set in multi-block elections. Should always be `None` otherwise. 
+ 
+### nominators(`AccountId32`): `Option<PalletStakingAsyncNominations>`
+- **interface**: `api.query.staking.nominators`
+- **summary**:    The map from nominator stash key to their nomination preferences, namely the validators that  they wish to support. 
+
+   Note that the keys of this storage map might become non-decodable in case the  account's [`NominationsQuota::MaxNominations`] configuration is decreased.  In this rare case, these nominators  are still existent in storage, their key is correct and retrievable (i.e. `contains_key`  indicates that they exist), but their value cannot be decoded. Therefore, the non-decodable  nominators will effectively not-exist, until they re-submit their preferences such that it  is within the bounds of the newly set `Config::MaxNominations`. 
+
+   This implies that `::iter_keys().count()` and `::iter().count()` might return different  values for this map. Moreover, the main `::count()` is aligned with the former, namely the  number of keys that exist. 
+
+   Lastly, if any of the nominators become non-decodable, they can be chilled immediately via  [`Call::chill_other`] dispatchable by anyone. 
+
+   TWOX-NOTE: SAFE since `AccountId` is a secure hash. 
+ 
+### offenceQueue(`u32, AccountId32`): `Option<PalletStakingAsyncSlashingOffenceRecord>`
+- **interface**: `api.query.staking.offenceQueue`
+- **summary**:    Stores reported offences in a queue until they are processed in subsequent blocks. 
+
+   Each offence is recorded under the corresponding era index and the offending validator's  account. If an offence spans multiple pages, only one page is processed at a time. Offences  are handled sequentially, with their associated slashes computed and stored in  `UnappliedSlashes`. These slashes are then applied in a future era as determined by  `SlashDeferDuration`. 
+
+   Any offences tied to an era older than `BondingDuration` are automatically dropped.  Processing always prioritizes the oldest era first. 
+ 
+### offenceQueueEras(): `Option<Vec<u32>>`
+- **interface**: `api.query.staking.offenceQueueEras`
+- **summary**:    Tracks the eras that contain offences in `OffenceQueue`, sorted from **earliest to latest**. 
+
+   - This ensures efficient retrieval of the oldest offence without iterating through  `OffenceQueue`. 
+
+  - When a new offence is added to `OffenceQueue`, its era is **inserted in sorted order** if not already present. 
+
+  - When all offences for an era are processed, it is **removed** from this list.
+
+  - The maximum length of this vector is bounded by `BondingDuration`.
+
+   This eliminates the need for expensive iteration and sorting when fetching the next offence  to process. 
+ 
+### payee(`AccountId32`): `Option<PalletStakingAsyncRewardDestination>`
+- **interface**: `api.query.staking.payee`
+- **summary**:    Where the reward payment should be made. Keyed by stash. 
+
+   TWOX-NOTE: SAFE since `AccountId` is a secure hash. 
+ 
+### processingOffence(): `Option<(u32,AccountId32,PalletStakingAsyncSlashingOffenceRecord)>`
+- **interface**: `api.query.staking.processingOffence`
+- **summary**:    Tracks the currently processed offence record from the `OffenceQueue`. 
+
+   - When processing offences, an offence record is **popped** from the oldest era in  `OffenceQueue` and stored here. 
+
+  - The function `process_offence` reads from this storage, processing one page of exposure at a time. 
+
+  - After processing a page, the `exposure_page` count is **decremented** until it reaches zero. 
+
+  - Once fully processed, the offence record is removed from this storage.
+
+   This ensures that offences are processed incrementally, preventing excessive computation  in a single block while maintaining correct slashing behavior. 
+ 
+### slashRewardFraction(): `Perbill`
+- **interface**: `api.query.staking.slashRewardFraction`
+- **summary**:    The percentage of the slash that is distributed to reporters. 
+
+   The rest of the slashed value is handled by the `Slash`. 
+ 
+### unappliedSlashes(`u32, (AccountId32,Perbill,u32)`): `Option<PalletStakingAsyncUnappliedSlash>`
+- **interface**: `api.query.staking.unappliedSlashes`
+- **summary**:    All unapplied slashes that are queued for later. 
+ 
+### validatorCount(): `u32`
+- **interface**: `api.query.staking.validatorCount`
+- **summary**:    The ideal number of active validators. 
+ 
+### validators(`AccountId32`): `PalletStakingAsyncValidatorPrefs`
+- **interface**: `api.query.staking.validators`
+- **summary**:    The map from (wannabe) validator stash key to the preferences of that validator. 
+
+   TWOX-NOTE: SAFE since `AccountId` is a secure hash. 
+ 
+### validatorSlashInEra(`u32, AccountId32`): `Option<(Perbill,u128)>`
+- **interface**: `api.query.staking.validatorSlashInEra`
+- **summary**:    All slashing events on validators, mapped by era to the highest slash proportion  and slash value of the era. 
+ 
+### virtualStakers(`AccountId32`): `Option<Null>`
+- **interface**: `api.query.staking.virtualStakers`
+- **summary**:    Stakers whose funds are managed by other pallets. 
+
+   This pallet does not apply any locks on them, therefore they are only virtually bonded. They  are expected to be keyless accounts and hence should not be allowed to mutate their ledger  directly via this pallet. Instead, these accounts are managed by other pallets and accessed  via low level apis. We keep track of them to do minimal integrity checks. 
+ 
+### voterSnapshotStatus(): `PalletStakingAsyncSnapshotStatus`
+- **interface**: `api.query.staking.voterSnapshotStatus`
+- **summary**:    Voter snapshot progress status. 
+
+   If the status is `Ongoing`, it keeps a cursor of the last voter retrieved to proceed when  creating the next snapshot page. 
+
+___
+
+
+## stakingRcClient
+ 
+### incompleteSessionReport(): `Option<PalletStakingAsyncRcClientSessionReport>`
+- **interface**: `api.query.stakingRcClient.incompleteSessionReport`
+- **summary**:    An incomplete incoming session report that we have not acted upon yet. 
+ 
+### lastSessionReportEndingIndex(): `Option<u32>`
+- **interface**: `api.query.stakingRcClient.lastSessionReportEndingIndex`
+- **summary**:    The last session report's `end_index` that we have acted upon. 
+
+   This allows this pallet to ensure a sequentially increasing sequence of session reports  passed to staking. 
+
+   Note that with the XCM being the backbone of communication, we have a guarantee on the  ordering of messages. As long as the RC sends session reports in order, we _eventually_  receive them in the same correct order as well. 
+ 
+### outgoingValidatorSet(): `Option<(PalletStakingAsyncRcClientValidatorSetReport,u32)>`
+- **interface**: `api.query.stakingRcClient.outgoingValidatorSet`
+- **summary**:    A validator set that is outgoing, and should be sent. 
+
+   This will be attempted to be sent, possibly on every `on_initialize` call, until it is sent,  or the second value reaches zero, at which point we drop it. 
 
 ___
 
@@ -897,6 +1890,45 @@ ___
 ___
 
 
+## treasury
+ 
+### approvals(): `Vec<u32>`
+- **interface**: `api.query.treasury.approvals`
+- **summary**:    DEPRECATED: associated with `spend_local` call and will be removed in May 2025.  Refer to <https://github.com/paritytech/polkadot-sdk/pull/5961> for migration to `spend`. 
+
+   Proposal indices that have been approved but not yet awarded. 
+ 
+### deactivated(): `u128`
+- **interface**: `api.query.treasury.deactivated`
+- **summary**:    The amount which has been reported as inactive to Currency. 
+ 
+### lastSpendPeriod(): `Option<u32>`
+- **interface**: `api.query.treasury.lastSpendPeriod`
+- **summary**:    The blocknumber for the last triggered spend period. 
+ 
+### proposalCount(): `u32`
+- **interface**: `api.query.treasury.proposalCount`
+- **summary**:    DEPRECATED: associated with `spend_local` call and will be removed in May 2025.  Refer to <https://github.com/paritytech/polkadot-sdk/pull/5961> for migration to `spend`. 
+
+   Number of proposals that have been made. 
+ 
+### proposals(`u32`): `Option<PalletTreasuryProposal>`
+- **interface**: `api.query.treasury.proposals`
+- **summary**:    DEPRECATED: associated with `spend_local` call and will be removed in May 2025.  Refer to <https://github.com/paritytech/polkadot-sdk/pull/5961> for migration to `spend`. 
+
+   Proposals that have been made. 
+ 
+### spendCount(): `u32`
+- **interface**: `api.query.treasury.spendCount`
+- **summary**:    The count of spends that have been made. 
+ 
+### spends(`u32`): `Option<PalletTreasurySpendStatus>`
+- **interface**: `api.query.treasury.spends`
+- **summary**:    Spends that have been approved and being processed. 
+
+___
+
+
 ## uniques
  
 ### account(`AccountId32, u32, u32`): `Option<Null>`
@@ -953,6 +1985,45 @@ ___
 ### vesting(`AccountId32`): `Option<Vec<PalletVestingVestingInfo>>`
 - **interface**: `api.query.vesting.vesting`
 - **summary**:    Information regarding the vesting of a given account. 
+
+___
+
+
+## voterList
+ 
+### counterForListNodes(): `u32`
+- **interface**: `api.query.voterList.counterForListNodes`
+- **summary**:    Counter for the related counted storage map 
+ 
+### listBags(`u64`): `Option<PalletBagsListListBag>`
+- **interface**: `api.query.voterList.listBags`
+- **summary**:    A bag stored in storage. 
+
+   Stores a `Bag` struct, which stores head and tail pointers to itself. 
+ 
+### listNodes(`AccountId32`): `Option<PalletBagsListListNode>`
+- **interface**: `api.query.voterList.listNodes`
+- **summary**:    A single node, within some bag. 
+
+   Nodes store links forward and back within their respective bags. 
+ 
+### lock(): `Option<Null>`
+- **interface**: `api.query.voterList.lock`
+- **summary**:    Lock all updates to this pallet. 
+
+   If any nodes needs updating, removal or addition due to a temporary lock, the  [`Call::rebag`] can be used. 
+ 
+### nextNodeAutoRebagged(): `Option<AccountId32>`
+- **interface**: `api.query.voterList.nextNodeAutoRebagged`
+- **summary**:    Pointer that remembers the next node that will be auto-rebagged.  When `None`, the next scan will start from the list head again. 
+
+___
+
+
+## whitelist
+ 
+### whitelistedCall(`H256`): `Option<Null>`
+- **interface**: `api.query.whitelist.whitelistedCall`
 
 ___
 

--- a/docs/asset-hub-polkadot/constants.md
+++ b/docs/asset-hub-polkadot/constants.md
@@ -14,15 +14,33 @@ The following sections contain the module constants, also known as parameter typ
 
 - **[balances](#balances)**
 
+- **[bounties](#bounties)**
+
+- **[childBounties](#childbounties)**
+
+- **[claims](#claims)**
+
 - **[collatorSelection](#collatorselection)**
+
+- **[convictionVoting](#convictionvoting)**
+
+- **[delegatedStaking](#delegatedstaking)**
 
 - **[foreignAssets](#foreignassets)**
 
+- **[indices](#indices)**
+
 - **[messageQueue](#messagequeue)**
+
+- **[multiBlockElection](#multiblockelection)**
+
+- **[multiBlockElectionVerifier](#multiblockelectionverifier)**
 
 - **[multisig](#multisig)**
 
 - **[nfts](#nfts)**
+
+- **[nominationPools](#nominationpools)**
 
 - **[parachainSystem](#parachainsystem)**
 
@@ -32,6 +50,14 @@ The following sections contain the module constants, also known as parameter typ
 
 - **[proxy](#proxy)**
 
+- **[referenda](#referenda)**
+
+- **[scheduler](#scheduler)**
+
+- **[session](#session)**
+
+- **[staking](#staking)**
+
 - **[stateTrieMigration](#statetriemigration)**
 
 - **[system](#system)**
@@ -40,11 +66,15 @@ The following sections contain the module constants, also known as parameter typ
 
 - **[transactionPayment](#transactionpayment)**
 
+- **[treasury](#treasury)**
+
 - **[uniques](#uniques)**
 
 - **[utility](#utility)**
 
 - **[vesting](#vesting)**
+
+- **[voterList](#voterlist)**
 
 - **[xcmpQueue](#xcmpqueue)**
 
@@ -78,7 +108,7 @@ ___
 - **interface**: `api.consts.assetConversion.poolSetupFee`
 - **summary**:    A one-time fee to setup the pool. 
  
-### poolSetupFeeAsset: `StagingXcmV4Location`
+### poolSetupFeeAsset: `StagingXcmV5Location`
 - **interface**: `api.consts.assetConversion.poolSetupFeeAsset`
 - **summary**:    Asset class from [`Config::Assets`] used to pay the [`Config::PoolSetupFee`]. 
 
@@ -160,6 +190,74 @@ ___
 ___
 
 
+## bounties
+ 
+### bountyDepositBase: `u128`
+- **interface**: `api.consts.bounties.bountyDepositBase`
+- **summary**:    The amount held on deposit for placing a bounty proposal. 
+ 
+### bountyDepositPayoutDelay: `u32`
+- **interface**: `api.consts.bounties.bountyDepositPayoutDelay`
+- **summary**:    The delay period for which a bounty beneficiary need to wait before claim the payout. 
+ 
+### bountyUpdatePeriod: `u32`
+- **interface**: `api.consts.bounties.bountyUpdatePeriod`
+- **summary**:    The time limit for a curator to act before a bounty expires. 
+
+   The period that starts when a curator is approved, during which they must execute or  update the bounty via `extend_bounty_expiry`. If missed, the bounty expires, and the  curator may be slashed. If `BlockNumberFor::MAX`, bounties stay active indefinitely,  removing the need for `extend_bounty_expiry`. 
+ 
+### bountyValueMinimum: `u128`
+- **interface**: `api.consts.bounties.bountyValueMinimum`
+- **summary**:    Minimum value for a bounty. 
+ 
+### curatorDepositMax: `Option<u128>`
+- **interface**: `api.consts.bounties.curatorDepositMax`
+- **summary**:    Maximum amount of funds that should be placed in a deposit for making a proposal. 
+ 
+### curatorDepositMin: `Option<u128>`
+- **interface**: `api.consts.bounties.curatorDepositMin`
+- **summary**:    Minimum amount of funds that should be placed in a deposit for making a proposal. 
+ 
+### curatorDepositMultiplier: `Permill`
+- **interface**: `api.consts.bounties.curatorDepositMultiplier`
+- **summary**:    The curator deposit is calculated as a percentage of the curator fee. 
+
+   This deposit has optional upper and lower bounds with `CuratorDepositMax` and  `CuratorDepositMin`. 
+ 
+### dataDepositPerByte: `u128`
+- **interface**: `api.consts.bounties.dataDepositPerByte`
+- **summary**:    The amount held on deposit per byte within the tip report reason or bounty description. 
+ 
+### maximumReasonLength: `u32`
+- **interface**: `api.consts.bounties.maximumReasonLength`
+- **summary**:    Maximum acceptable reason length. 
+
+   Benchmarks depend on this value, be sure to update weights file when changing this value 
+
+___
+
+
+## childBounties
+ 
+### childBountyValueMinimum: `u128`
+- **interface**: `api.consts.childBounties.childBountyValueMinimum`
+- **summary**:    Minimum value for a child-bounty. 
+ 
+### maxActiveChildBountyCount: `u32`
+- **interface**: `api.consts.childBounties.maxActiveChildBountyCount`
+- **summary**:    Maximum number of child bounties that can be added to a parent bounty. 
+
+___
+
+
+## claims
+ 
+### prefix: `Bytes`
+- **interface**: `api.consts.claims.prefix`
+
+___
+
+
 ## collatorSelection
  
 ### kickThreshold: `u32`
@@ -186,6 +284,36 @@ ___
 ### potId: `FrameSupportPalletId`
 - **interface**: `api.consts.collatorSelection.potId`
 - **summary**:    Account Identifier from which the internal Pot is generated. 
+
+___
+
+
+## convictionVoting
+ 
+### maxVotes: `u32`
+- **interface**: `api.consts.convictionVoting.maxVotes`
+- **summary**:    The maximum number of concurrent votes an account may have. 
+
+   Also used to compute weight, an overly large value can lead to extrinsics with large  weight estimation: see `delegate` for instance. 
+ 
+### voteLockingPeriod: `u32`
+- **interface**: `api.consts.convictionVoting.voteLockingPeriod`
+- **summary**:    The minimum period of vote locking. 
+
+   It should be no shorter than enactment period to ensure that in the case of an approval,  those successful voters are locked into the consequences that their votes entail. 
+
+___
+
+
+## delegatedStaking
+ 
+### palletId: `FrameSupportPalletId`
+- **interface**: `api.consts.delegatedStaking.palletId`
+- **summary**:    Injected identifier for the pallet. 
+ 
+### slashRewardFraction: `Perbill`
+- **interface**: `api.consts.delegatedStaking.slashRewardFraction`
+- **summary**:    Fraction of the slash that is rewarded to the caller of pending slash to the agent. 
 
 ___
 
@@ -225,6 +353,15 @@ ___
 ___
 
 
+## indices
+ 
+### deposit: `u128`
+- **interface**: `api.consts.indices.deposit`
+- **summary**:    The deposit needed for reserving an index. 
+
+___
+
+
 ## messageQueue
  
 ### heapSize: `u32`
@@ -248,6 +385,66 @@ ___
 - **summary**:    The amount of weight (if any) which should be provided to the message queue for  servicing enqueued items `on_initialize`. 
 
    This may be legitimately `None` in the case that you will call  `ServiceQueues::service_queues` manually or set [`Self::IdleMaxServiceWeight`] to have  it run in `on_idle`. 
+
+___
+
+
+## multiBlockElection
+ 
+### pages: `u32`
+- **interface**: `api.consts.multiBlockElection.pages`
+- **summary**:    The number of pages. 
+
+   The snapshot is created with this many keys in the storage map. 
+
+   The solutions may contain at MOST this many pages, but less pages are acceptable as  well. 
+ 
+### signedPhase: `u32`
+- **interface**: `api.consts.multiBlockElection.signedPhase`
+- **summary**:    Duration of the signed phase. 
+ 
+### signedValidationPhase: `u32`
+- **interface**: `api.consts.multiBlockElection.signedValidationPhase`
+- **summary**:    Duration of the singed validation phase. 
+
+   The duration of this should not be less than `T::Pages`, and there is no point in it  being more than `SignedPhase::MaxSubmission::get() * T::Pages`. TODO: integrity test for  it. 
+ 
+### targetSnapshotPerBlock: `u32`
+- **interface**: `api.consts.multiBlockElection.targetSnapshotPerBlock`
+- **summary**:    The number of snapshot targets to fetch per block. 
+ 
+### unsignedPhase: `u32`
+- **interface**: `api.consts.multiBlockElection.unsignedPhase`
+- **summary**:    Duration of the unsigned phase. 
+ 
+### voterSnapshotPerBlock: `u32`
+- **interface**: `api.consts.multiBlockElection.voterSnapshotPerBlock`
+- **summary**:    The number of snapshot voters to fetch per block. 
+
+___
+
+
+## multiBlockElectionVerifier
+ 
+### maxBackersPerWinner: `u32`
+- **interface**: `api.consts.multiBlockElectionVerifier.maxBackersPerWinner`
+- **summary**:    Maximum number of backers, per winner, per page. 
+ 
+### maxBackersPerWinnerFinal: `u32`
+- **interface**: `api.consts.multiBlockElectionVerifier.maxBackersPerWinnerFinal`
+- **summary**:    Maximum number of backers, per winner, among all pages of an election. 
+
+   This can only be checked at the very final step of verification. 
+
+   NOTE: at the moment, we don't check this, and it is in place for future compatibility. 
+ 
+### maxWinnersPerPage: `u32`
+- **interface**: `api.consts.multiBlockElectionVerifier.maxWinnersPerPage`
+- **summary**:    Maximum number of supports (aka. winners/validators/targets) that can be represented in  a page of results. 
+ 
+### solutionImprovementThreshold: `Perbill`
+- **interface**: `api.consts.multiBlockElectionVerifier.solutionImprovementThreshold`
+- **summary**:    The minimum amount of improvement to the solution score that defines a solution as  "better". 
 
 ___
 
@@ -334,6 +531,29 @@ ___
 ___
 
 
+## nominationPools
+ 
+### maxPointsToBalance: `u8`
+- **interface**: `api.consts.nominationPools.maxPointsToBalance`
+- **summary**:    The maximum pool points-to-balance ratio that an `open` pool can have. 
+
+   This is important in the event slashing takes place and the pool's points-to-balance  ratio becomes disproportional. 
+
+   Moreover, this relates to the `RewardCounter` type as well, as the arithmetic operations  are a function of number of points, and by setting this value to e.g. 10, you ensure  that the total number of points in the system are at most 10 times the total_issuance of  the chain, in the absolute worse case. 
+
+   For a value of 10, the threshold would be a pool points-to-balance ratio of 10:1.  Such a scenario would also be the equivalent of the pool being 90% slashed. 
+ 
+### maxUnbonding: `u32`
+- **interface**: `api.consts.nominationPools.maxUnbonding`
+- **summary**:    The maximum number of simultaneous unbonding chunks that can exist per member. 
+ 
+### palletId: `FrameSupportPalletId`
+- **interface**: `api.consts.nominationPools.palletId`
+- **summary**:    The nomination pool's pallet id. 
+
+___
+
+
 ## parachainSystem
  
 ### selfParaId: `u32`
@@ -348,6 +568,18 @@ ___
 ### advertisedXcmVersion: `u32`
 - **interface**: `api.consts.polkadotXcm.advertisedXcmVersion`
 - **summary**:    The latest supported version that we advertise. Generally just set it to  `pallet_xcm::CurrentXcmVersion`. 
+ 
+### maxLockers: `u32`
+- **interface**: `api.consts.polkadotXcm.maxLockers`
+- **summary**:    The maximum number of local XCM locks that a single account may have. 
+ 
+### maxRemoteLockConsumers: `u32`
+- **interface**: `api.consts.polkadotXcm.maxRemoteLockConsumers`
+- **summary**:    The maximum number of consumers a single remote lock may have. 
+ 
+### universalLocation: `StagingXcmV5Junctions`
+- **interface**: `api.consts.polkadotXcm.universalLocation`
+- **summary**:    This chain's Universal Location. 
 
 ___
 
@@ -420,6 +652,140 @@ ___
 - **summary**:    The amount of currency needed per proxy added. 
 
    This is held for adding 32 bytes plus an instance of `ProxyType` more into a  pre-existing storage value. Thus, when configuring `ProxyDepositFactor` one should take  into account `32 + proxy_type.encode().len()` bytes of data. 
+
+___
+
+
+## referenda
+ 
+### alarmInterval: `u32`
+- **interface**: `api.consts.referenda.alarmInterval`
+- **summary**:    Quantization level for the referendum wakeup scheduler. A higher number will result in  fewer storage reads/writes needed for smaller voters, but also result in delays to the  automatic referendum status changes. Explicit servicing instructions are unaffected. 
+ 
+### maxQueued: `u32`
+- **interface**: `api.consts.referenda.maxQueued`
+- **summary**:    Maximum size of the referendum queue for a single track. 
+ 
+### submissionDeposit: `u128`
+- **interface**: `api.consts.referenda.submissionDeposit`
+- **summary**:    The minimum amount to be used as a deposit for a public referendum proposal. 
+ 
+### tracks: `Vec<(u16,PalletReferendaTrackDetails)>`
+- **interface**: `api.consts.referenda.tracks`
+- **summary**:    A list of tracks. 
+
+   Note: if the tracks are dynamic, the value in the static metadata might be inaccurate. 
+ 
+### undecidingTimeout: `u32`
+- **interface**: `api.consts.referenda.undecidingTimeout`
+- **summary**:    The number of blocks after submission that a referendum must begin being decided by.  Once this passes, then anyone may cancel the referendum. 
+
+___
+
+
+## scheduler
+ 
+### maximumWeight: `SpWeightsWeightV2Weight`
+- **interface**: `api.consts.scheduler.maximumWeight`
+- **summary**:    The maximum weight that may be scheduled per block for any dispatchables. 
+ 
+### maxScheduledPerBlock: `u32`
+- **interface**: `api.consts.scheduler.maxScheduledPerBlock`
+- **summary**:    The maximum number of scheduled calls in the queue for a single block. 
+
+   NOTE:  + Dependent pallets' benchmarks might require a higher limit for the setting. Set a  higher limit under `runtime-benchmarks` feature. 
+
+___
+
+
+## session
+ 
+### keyDeposit: `u128`
+- **interface**: `api.consts.session.keyDeposit`
+- **summary**:    The amount to be held when setting keys. 
+
+___
+
+
+## staking
+ 
+### bondingDuration: `u32`
+- **interface**: `api.consts.staking.bondingDuration`
+- **summary**:    Number of eras that staked funds must remain bonded for. 
+ 
+### historyDepth: `u32`
+- **interface**: `api.consts.staking.historyDepth`
+- **summary**:    Number of eras to keep in history. 
+
+   Following information is kept for eras in `[current_era -  HistoryDepth, current_era]`: `ErasValidatorPrefs`, `ErasValidatorReward`,  `ErasRewardPoints`, `ErasTotalStake`, `ClaimedRewards`,  `ErasStakersPaged`, `ErasStakersOverview`. 
+
+   Must be more than the number of eras delayed by session.  I.e. active era must always be in history. I.e. `active_era >  current_era - history_depth` must be guaranteed. 
+
+   If migrating an existing pallet from storage value to config value,  this should be set to same value or greater as in storage. 
+ 
+### maxEraDuration: `u64`
+- **interface**: `api.consts.staking.maxEraDuration`
+- **summary**:    Maximum allowed era duration in milliseconds. 
+
+   This provides a defensive upper bound to cap the effective era duration, preventing  excessively long eras from causing runaway inflation (e.g., due to bugs). If the actual  era duration exceeds this value, it will be clamped to this maximum. 
+
+   Example: For an ideal era duration of 24 hours (86,400,000 ms),  this can be set to 604,800,000 ms (7 days). 
+ 
+### maxExposurePageSize: `u32`
+- **interface**: `api.consts.staking.maxExposurePageSize`
+- **summary**:    The maximum size of each `T::ExposurePage`. 
+
+   An `ExposurePage` is weakly bounded to a maximum of `MaxExposurePageSize`  nominators. 
+
+   For older non-paged exposure, a reward payout was restricted to the top  `MaxExposurePageSize` nominators. This is to limit the i/o cost for the  nominator payout. 
+
+   Note: `MaxExposurePageSize` is used to bound `ClaimedRewards` and is unsafe to  reduce without handling it in a migration. 
+ 
+### maxInvulnerables: `u32`
+- **interface**: `api.consts.staking.maxInvulnerables`
+- **summary**:    Maximum number of invulnerable validators. 
+ 
+### maxPruningItems: `u32`
+- **interface**: `api.consts.staking.maxPruningItems`
+- **summary**:    Maximum number of storage items that can be pruned in a single call. 
+
+   This controls how many storage items can be deleted in each call to `prune_era_step`.  This should be set to a conservative value (e.g., 100-500 items) to ensure pruning  doesn't consume too much block space. The actual weight is determined by benchmarks. 
+ 
+### maxUnlockingChunks: `u32`
+- **interface**: `api.consts.staking.maxUnlockingChunks`
+- **summary**:    The maximum number of `unlocking` chunks a [`StakingLedger`] can  have. Effectively determines how many unique eras a staker may be  unbonding in. 
+
+   Note: `MaxUnlockingChunks` is used as the upper bound for the  `BoundedVec` item `StakingLedger.unlocking`. Setting this value  lower than the existing value can lead to inconsistencies in the  `StakingLedger` and will need to be handled properly in a runtime  migration. The test `reducing_max_unlocking_chunks_abrupt` shows  this effect. 
+ 
+### maxValidatorSet: `u32`
+- **interface**: `api.consts.staking.maxValidatorSet`
+- **summary**:    The absolute maximum of winner validators this pallet should return. 
+
+   As this pallet supports multi-block election, the set of winner validators *per  election* is bounded by this type. 
+ 
+### planningEraOffset: `u32`
+- **interface**: `api.consts.staking.planningEraOffset`
+- **summary**:    Number of sessions before the end of an era when the election for the next era will  start. 
+
+   - This determines how many sessions **before** the last session of the era the staking  election process should begin. 
+
+  - The value is bounded between **1** (election starts at the beginning of the last session) and `SessionsPerEra` (election starts at the beginning of the first session  of the era). 
+
+   #### Example: 
+
+  - If `SessionsPerEra = 6` and `PlanningEraOffset = 1`, the election starts at the beginning of session `6 - 1 = 5`. 
+
+  - If `PlanningEraOffset = 6`, the election starts at the beginning of session `6 - 6 = 0`, meaning it starts at the very beginning of the era. 
+ 
+### sessionsPerEra: `u32`
+- **interface**: `api.consts.staking.sessionsPerEra`
+- **summary**:    Number of sessions per era, as per the preferences of the **relay chain**. 
+ 
+### slashDeferDuration: `u32`
+- **interface**: `api.consts.staking.slashDeferDuration`
+- **summary**:    Number of eras that slashes are deferred by, after computation. 
+
+   This should be less than the bonding duration. Set to 0 if slashes  should be applied immediately, without opportunity for intervention. 
 
 ___
 
@@ -508,6 +874,39 @@ ___
 ___
 
 
+## treasury
+ 
+### burn: `Permill`
+- **interface**: `api.consts.treasury.burn`
+- **summary**:    Percentage of spare funds (if any) that are burnt per spend period. 
+ 
+### maxApprovals: `u32`
+- **interface**: `api.consts.treasury.maxApprovals`
+- **summary**:    DEPRECATED: associated with `spend_local` call and will be removed in May 2025.  Refer to <https://github.com/paritytech/polkadot-sdk/pull/5961> for migration to `spend`. 
+
+   The maximum number of approvals that can wait in the spending queue. 
+
+   NOTE: This parameter is also used within the Bounties Pallet extension if enabled. 
+ 
+### palletId: `FrameSupportPalletId`
+- **interface**: `api.consts.treasury.palletId`
+- **summary**:    The treasury's pallet id, used for deriving its sovereign account ID. 
+ 
+### payoutPeriod: `u32`
+- **interface**: `api.consts.treasury.payoutPeriod`
+- **summary**:    The period during which an approved treasury spend has to be claimed. 
+ 
+### potAccount: `AccountId32`
+- **interface**: `api.consts.treasury.potAccount`
+- **summary**:    Gets this pallet's derived pot account. 
+ 
+### spendPeriod: `u32`
+- **interface**: `api.consts.treasury.spendPeriod`
+- **summary**:    Period between successive spends. 
+
+___
+
+
 ## uniques
  
 ### attributeDepositBase: `u128`
@@ -562,6 +961,51 @@ ___
 ### minVestedTransfer: `u128`
 - **interface**: `api.consts.vesting.minVestedTransfer`
 - **summary**:    The minimum amount transferred to call `vested_transfer`. 
+
+___
+
+
+## voterList
+ 
+### bagThresholds: `Vec<u64>`
+- **interface**: `api.consts.voterList.bagThresholds`
+- **summary**:    The list of thresholds separating the various bags. 
+
+   Ids are separated into unsorted bags according to their score. This specifies the  thresholds separating the bags. An id's bag is the largest bag for which the id's score  is less than or equal to its upper threshold. 
+
+   When ids are iterated, higher bags are iterated completely before lower bags. This means  that iteration is _semi-sorted_: ids of higher score tend to come before ids of lower  score, but peer ids within a particular bag are sorted in insertion order. 
+
+   #### Expressing the constant 
+
+   This constant must be sorted in strictly increasing order. Duplicate items are not  permitted. 
+
+   There is an implied upper limit of `Score::MAX`; that value does not need to be  specified within the bag. For any two threshold lists, if one ends with  `Score::MAX`, the other one does not, and they are otherwise equal, the two  lists will behave identically. 
+
+   #### Calculation 
+
+   It is recommended to generate the set of thresholds in a geometric series, such that  there exists some constant ratio such that `threshold[k + 1] == (threshold[k] *  constant_ratio).max(threshold[k] + 1)` for all `k`. 
+
+   The helpers in the `/utils/frame/generate-bags` module can simplify this calculation. 
+
+   #### Examples 
+
+   - If `BagThresholds::get().is_empty()`, then all ids are put into the same bag, and  iteration is strictly in insertion order. 
+
+  - If `BagThresholds::get().len() == 64`, and the thresholds are determined according to the procedure given above, then the constant ratio is equal to 2. 
+
+  - If `BagThresholds::get().len() == 200`, and the thresholds are determined according to the procedure given above, then the constant ratio is approximately equal to 1.248. 
+
+  - If the threshold list begins `[1, 2, 3, ...]`, then an id with score 0 or 1 will fall into bag 0, an id with score 2 will fall into bag 1, etc. 
+
+   #### Migration 
+
+   In the event that this list ever changes, a copy of the old bags list must be retained.  With that `List::migrate` can be called, which will perform the appropriate migration. 
+ 
+### maxAutoRebagPerBlock: `u32`
+- **interface**: `api.consts.voterList.maxAutoRebagPerBlock`
+- **summary**:    Maximum number of accounts that may be re-bagged automatically in `on_idle`. 
+
+   A value of `0` (obtained by configuring `type MaxAutoRebagPerBlock = ();`) disables  the feature. 
 
 ___
 

--- a/docs/asset-hub-polkadot/errors.md
+++ b/docs/asset-hub-polkadot/errors.md
@@ -6,21 +6,45 @@ This page lists the errors that can be encountered in the different modules.
 
 (NOTE: These were generated from a static/snapshot view of a recent default asset-hub-polkadot runtime. Some items may not be available in older nodes, or in any customized implementations.)
 
+- **[ahMigrator](#ahmigrator)**
+
+- **[ahOps](#ahops)**
+
 - **[assetConversion](#assetconversion)**
+
+- **[assetRate](#assetrate)**
 
 - **[assets](#assets)**
 
 - **[balances](#balances)**
 
+- **[bounties](#bounties)**
+
+- **[childBounties](#childbounties)**
+
+- **[claims](#claims)**
+
 - **[collatorSelection](#collatorselection)**
+
+- **[convictionVoting](#convictionvoting)**
+
+- **[delegatedStaking](#delegatedstaking)**
 
 - **[foreignAssets](#foreignassets)**
 
+- **[indices](#indices)**
+
 - **[messageQueue](#messagequeue)**
+
+- **[multiBlockElection](#multiblockelection)**
+
+- **[multiBlockElectionSigned](#multiblockelectionsigned)**
 
 - **[multisig](#multisig)**
 
 - **[nfts](#nfts)**
+
+- **[nominationPools](#nominationpools)**
 
 - **[parachainSystem](#parachainsystem)**
 
@@ -28,13 +52,25 @@ This page lists the errors that can be encountered in the different modules.
 
 - **[poolAssets](#poolassets)**
 
+- **[preimage](#preimage)**
+
 - **[proxy](#proxy)**
 
+- **[referenda](#referenda)**
+
+- **[scheduler](#scheduler)**
+
 - **[session](#session)**
+
+- **[snowbridgeSystemFrontend](#snowbridgesystemfrontend)**
+
+- **[staking](#staking)**
 
 - **[stateTrieMigration](#statetriemigration)**
 
 - **[system](#system)**
+
+- **[treasury](#treasury)**
 
 - **[uniques](#uniques)**
 
@@ -42,8 +78,142 @@ This page lists the errors that can be encountered in the different modules.
 
 - **[vesting](#vesting)**
 
+- **[voterList](#voterlist)**
+
+- **[whitelist](#whitelist)**
+
 - **[xcmpQueue](#xcmpqueue)**
 
+
+___
+
+
+## ahMigrator
+ 
+### BadXcmVersion
+- **interface**: `api.errors.ahMigrator.BadXcmVersion.is`
+- **summary**:    The XCM version is invalid. 
+ 
+### DmpQueuePriorityAlreadySet
+- **interface**: `api.errors.ahMigrator.DmpQueuePriorityAlreadySet.is`
+- **summary**:    The DMP queue priority is already set to the same value. 
+ 
+### FailedToBoundCall
+- **interface**: `api.errors.ahMigrator.FailedToBoundCall.is`
+- **summary**:    Failed to bound a call. 
+ 
+### FailedToBoundVector
+- **interface**: `api.errors.ahMigrator.FailedToBoundVector.is`
+- **summary**:    Vector did not fit into its compile-time bound. 
+ 
+### FailedToCalculateCheckingAccount
+- **interface**: `api.errors.ahMigrator.FailedToCalculateCheckingAccount.is`
+- **summary**:    Checking account overflow or underflow. 
+ 
+### FailedToConvertCall
+- **interface**: `api.errors.ahMigrator.FailedToConvertCall.is`
+- **summary**:    Failed to convert RC call to AH call. 
+ 
+### FailedToConvertType
+- **interface**: `api.errors.ahMigrator.FailedToConvertType.is`
+- **summary**:    Failed to convert RC type to AH type. 
+ 
+### FailedToIntegrateVestingSchedule
+- **interface**: `api.errors.ahMigrator.FailedToIntegrateVestingSchedule.is`
+- **summary**:    Failed to integrate a vesting schedule. 
+ 
+### FailedToProcessAccount
+- **interface**: `api.errors.ahMigrator.FailedToProcessAccount.is`
+- **summary**:    Failed to process an account data from RC. 
+ 
+### FailedToUnreserveDeposit
+- **interface**: `api.errors.ahMigrator.FailedToUnreserveDeposit.is`
+- **summary**:    Failed to unreserve deposit. 
+ 
+### InsertConflict
+- **interface**: `api.errors.ahMigrator.InsertConflict.is`
+- **summary**:    Some item could not be inserted because it already exists. 
+ 
+### InvalidOrigin
+- **interface**: `api.errors.ahMigrator.InvalidOrigin.is`
+- **summary**:    The origin is invalid. 
+ 
+### InvalidParameter
+- **interface**: `api.errors.ahMigrator.InvalidParameter.is`
+- **summary**:    Invalid parameter. 
+ 
+### PreimageChunkMissing
+- **interface**: `api.errors.ahMigrator.PreimageChunkMissing.is`
+- **summary**:    Preimage chunk missing. 
+ 
+### PreimageMissing
+- **interface**: `api.errors.ahMigrator.PreimageMissing.is`
+- **summary**:    Preimage missing. 
+ 
+### PreimageNotFound
+- **interface**: `api.errors.ahMigrator.PreimageNotFound.is`
+- **summary**:    Failed to fetch preimage. 
+ 
+### PreimageStatusInvalid
+- **interface**: `api.errors.ahMigrator.PreimageStatusInvalid.is`
+- **summary**:    Preimage status invalid. 
+ 
+### PreimageTooBig
+- **interface**: `api.errors.ahMigrator.PreimageTooBig.is`
+- **summary**:    Preimage too big. 
+ 
+### XcmError
+- **interface**: `api.errors.ahMigrator.XcmError.is`
+- **summary**:    Failed to send XCM message. 
+
+___
+
+
+## ahOps
+ 
+### ContributionsRemaining
+- **interface**: `api.errors.ahOps.ContributionsRemaining.is`
+- **summary**:    Not all contributions are withdrawn. 
+ 
+### FailedToWithdrawCrowdloanContribution
+- **interface**: `api.errors.ahOps.FailedToWithdrawCrowdloanContribution.is`
+- **summary**:    Failed to withdraw crowdloan contribution. 
+ 
+### InternalError
+- **interface**: `api.errors.ahOps.InternalError.is`
+- **summary**:    Internal error, please bug report. 
+ 
+### MigrationNotCompleted
+- **interface**: `api.errors.ahOps.MigrationNotCompleted.is`
+- **summary**:    The Asset Hub migration is not completed. 
+ 
+### NoCrowdloanContribution
+- **interface**: `api.errors.ahOps.NoCrowdloanContribution.is`
+- **summary**:    Either no crowdloan contribution or already withdrawn. 
+ 
+### NoCrowdloanReserve
+- **interface**: `api.errors.ahOps.NoCrowdloanReserve.is`
+- **summary**:    Either no crowdloan reserve or already unreserved. 
+ 
+### NoLeaseReserve
+- **interface**: `api.errors.ahOps.NoLeaseReserve.is`
+- **summary**:    Either no lease deposit or already unreserved. 
+ 
+### NotSovereign
+- **interface**: `api.errors.ahOps.NotSovereign.is`
+- **summary**:    Account cannot be migrated since it is not a sovereign parachain account. 
+ 
+### NotYet
+- **interface**: `api.errors.ahOps.NotYet.is`
+- **summary**:    Block number is not yet reached. 
+ 
+### WrongDerivedTranslation
+- **interface**: `api.errors.ahOps.WrongDerivedTranslation.is`
+- **summary**:    The account is not a derived account. 
+ 
+### ZeroBalance
+- **interface**: `api.errors.ahOps.ZeroBalance.is`
+- **summary**:    The balance is zero. 
 
 ___
 
@@ -141,6 +311,23 @@ ___
 ### ZeroLiquidity
 - **interface**: `api.errors.assetConversion.ZeroLiquidity.is`
 - **summary**:    Requested liquidity can't be zero. 
+
+___
+
+
+## assetRate
+ 
+### AlreadyExists
+- **interface**: `api.errors.assetRate.AlreadyExists.is`
+- **summary**:    The given asset ID already has an assigned conversion rate and cannot be re-created. 
+ 
+### Overflow
+- **interface**: `api.errors.assetRate.Overflow.is`
+- **summary**:    Overflow ocurred when calculating the inverse rate. 
+ 
+### UnknownAssetKind
+- **interface**: `api.errors.assetRate.UnknownAssetKind.is`
+- **summary**:    The given asset ID is unknown. 
 
 ___
 
@@ -295,6 +482,105 @@ ___
 ___
 
 
+## bounties
+ 
+### HasActiveChildBounty
+- **interface**: `api.errors.bounties.HasActiveChildBounty.is`
+- **summary**:    The bounty cannot be closed because it has active child bounties. 
+ 
+### InsufficientProposersBalance
+- **interface**: `api.errors.bounties.InsufficientProposersBalance.is`
+- **summary**:    Proposer's balance is too low. 
+ 
+### InvalidFee
+- **interface**: `api.errors.bounties.InvalidFee.is`
+- **summary**:    Invalid bounty fee. 
+ 
+### InvalidIndex
+- **interface**: `api.errors.bounties.InvalidIndex.is`
+- **summary**:    No proposal or bounty at that index. 
+ 
+### InvalidValue
+- **interface**: `api.errors.bounties.InvalidValue.is`
+- **summary**:    Invalid bounty value. 
+ 
+### NotProposer
+- **interface**: `api.errors.bounties.NotProposer.is`
+- **summary**:    User is not the proposer of the bounty. 
+ 
+### PendingPayout
+- **interface**: `api.errors.bounties.PendingPayout.is`
+- **summary**:    A bounty payout is pending.  To cancel the bounty, you must unassign and slash the curator. 
+ 
+### Premature
+- **interface**: `api.errors.bounties.Premature.is`
+- **summary**:    The bounties cannot be claimed/closed because it's still in the countdown period. 
+ 
+### ReasonTooBig
+- **interface**: `api.errors.bounties.ReasonTooBig.is`
+- **summary**:    The reason given is just too big. 
+ 
+### RequireCurator
+- **interface**: `api.errors.bounties.RequireCurator.is`
+- **summary**:    Require bounty curator. 
+ 
+### TooManyQueued
+- **interface**: `api.errors.bounties.TooManyQueued.is`
+- **summary**:    Too many approvals are already queued. 
+ 
+### UnexpectedStatus
+- **interface**: `api.errors.bounties.UnexpectedStatus.is`
+- **summary**:    The bounty status is unexpected. 
+
+___
+
+
+## childBounties
+ 
+### InsufficientBountyBalance
+- **interface**: `api.errors.childBounties.InsufficientBountyBalance.is`
+- **summary**:    The bounty balance is not enough to add new child-bounty. 
+ 
+### ParentBountyNotActive
+- **interface**: `api.errors.childBounties.ParentBountyNotActive.is`
+- **summary**:    The parent bounty is not in active state. 
+ 
+### TooManyChildBounties
+- **interface**: `api.errors.childBounties.TooManyChildBounties.is`
+- **summary**:    Number of child bounties exceeds limit `MaxActiveChildBountyCount`. 
+
+___
+
+
+## claims
+ 
+### InvalidEthereumSignature
+- **interface**: `api.errors.claims.InvalidEthereumSignature.is`
+- **summary**:    Invalid Ethereum signature. 
+ 
+### InvalidStatement
+- **interface**: `api.errors.claims.InvalidStatement.is`
+- **summary**:    A needed statement was not included. 
+ 
+### PotUnderflow
+- **interface**: `api.errors.claims.PotUnderflow.is`
+- **summary**:    There's not enough in the pot to pay out some unvested amount. Generally implies a  logic error. 
+ 
+### SenderHasNoClaim
+- **interface**: `api.errors.claims.SenderHasNoClaim.is`
+- **summary**:    Account ID sending transaction has no claim. 
+ 
+### SignerHasNoClaim
+- **interface**: `api.errors.claims.SignerHasNoClaim.is`
+- **summary**:    Ethereum address has no claim. 
+ 
+### VestedBalanceExists
+- **interface**: `api.errors.claims.VestedBalanceExists.is`
+- **summary**:    The account already has a vested balance. 
+
+___
+
+
 ## collatorSelection
  
 ### AlreadyCandidate
@@ -364,6 +650,114 @@ ___
 ### ValidatorNotRegistered
 - **interface**: `api.errors.collatorSelection.ValidatorNotRegistered.is`
 - **summary**:    Validator ID is not yet registered. 
+
+___
+
+
+## convictionVoting
+ 
+### AlreadyDelegating
+- **interface**: `api.errors.convictionVoting.AlreadyDelegating.is`
+- **summary**:    The account is already delegating. 
+ 
+### AlreadyVoting
+- **interface**: `api.errors.convictionVoting.AlreadyVoting.is`
+- **summary**:    The account currently has votes attached to it and the operation cannot succeed until  these are removed through `remove_vote`. 
+ 
+### BadClass
+- **interface**: `api.errors.convictionVoting.BadClass.is`
+- **summary**:    The class ID supplied is invalid. 
+ 
+### ClassNeeded
+- **interface**: `api.errors.convictionVoting.ClassNeeded.is`
+- **summary**:    The class must be supplied since it is not easily determinable from the state. 
+ 
+### InsufficientFunds
+- **interface**: `api.errors.convictionVoting.InsufficientFunds.is`
+- **summary**:    Too high a balance was provided that the account cannot afford. 
+ 
+### MaxVotesReached
+- **interface**: `api.errors.convictionVoting.MaxVotesReached.is`
+- **summary**:    Maximum number of votes reached. 
+ 
+### Nonsense
+- **interface**: `api.errors.convictionVoting.Nonsense.is`
+- **summary**:    Delegation to oneself makes no sense. 
+ 
+### NoPermission
+- **interface**: `api.errors.convictionVoting.NoPermission.is`
+- **summary**:    The actor has no permission to conduct the action. 
+ 
+### NoPermissionYet
+- **interface**: `api.errors.convictionVoting.NoPermissionYet.is`
+- **summary**:    The actor has no permission to conduct the action right now but will do in the future. 
+ 
+### NotDelegating
+- **interface**: `api.errors.convictionVoting.NotDelegating.is`
+- **summary**:    The account is not currently delegating. 
+ 
+### NotOngoing
+- **interface**: `api.errors.convictionVoting.NotOngoing.is`
+- **summary**:    Poll is not ongoing. 
+ 
+### NotVoter
+- **interface**: `api.errors.convictionVoting.NotVoter.is`
+- **summary**:    The given account did not vote on the poll. 
+
+___
+
+
+## delegatedStaking
+ 
+### AlreadyStaking
+- **interface**: `api.errors.delegatedStaking.AlreadyStaking.is`
+- **summary**:    An existing staker cannot perform this action. 
+ 
+### BadState
+- **interface**: `api.errors.delegatedStaking.BadState.is`
+- **summary**:    Some corruption in internal state. 
+ 
+### InvalidDelegation
+- **interface**: `api.errors.delegatedStaking.InvalidDelegation.is`
+- **summary**:    Delegation conditions are not met. 
+
+   Possible issues are  1) Cannot delegate to self,  2) Cannot delegate to multiple delegates. 
+ 
+### InvalidRewardDestination
+- **interface**: `api.errors.delegatedStaking.InvalidRewardDestination.is`
+- **summary**:    Reward Destination cannot be same as `Agent` account. 
+ 
+### NotAgent
+- **interface**: `api.errors.delegatedStaking.NotAgent.is`
+- **summary**:    Not an existing `Agent` account. 
+ 
+### NotAllowed
+- **interface**: `api.errors.delegatedStaking.NotAllowed.is`
+- **summary**:    The account cannot perform this operation. 
+ 
+### NotDelegator
+- **interface**: `api.errors.delegatedStaking.NotDelegator.is`
+- **summary**:    Not a Delegator account. 
+ 
+### NotEnoughFunds
+- **interface**: `api.errors.delegatedStaking.NotEnoughFunds.is`
+- **summary**:    The account does not have enough funds to perform the operation. 
+ 
+### NothingToSlash
+- **interface**: `api.errors.delegatedStaking.NothingToSlash.is`
+- **summary**:    `Agent` has no pending slash to be applied. 
+ 
+### NotSupported
+- **interface**: `api.errors.delegatedStaking.NotSupported.is`
+- **summary**:    Operation not supported by this pallet. 
+ 
+### UnappliedSlash
+- **interface**: `api.errors.delegatedStaking.UnappliedSlash.is`
+- **summary**:    Unapplied pending slash restricts operation on `Agent`. 
+ 
+### WithdrawFailed
+- **interface**: `api.errors.delegatedStaking.WithdrawFailed.is`
+- **summary**:    Failed to withdraw amount from Core Staking. 
 
 ___
 
@@ -465,6 +859,31 @@ ___
 ___
 
 
+## indices
+ 
+### InUse
+- **interface**: `api.errors.indices.InUse.is`
+- **summary**:    The index was not available. 
+ 
+### NotAssigned
+- **interface**: `api.errors.indices.NotAssigned.is`
+- **summary**:    The index was not already assigned. 
+ 
+### NotOwner
+- **interface**: `api.errors.indices.NotOwner.is`
+- **summary**:    The index is assigned to another account. 
+ 
+### NotTransfer
+- **interface**: `api.errors.indices.NotTransfer.is`
+- **summary**:    The source and destination accounts are identical. 
+ 
+### Permanent
+- **interface**: `api.errors.indices.Permanent.is`
+- **summary**:    The index is permanent and may not be freed/changed. 
+
+___
+
+
 ## messageQueue
  
 ### AlreadyProcessed
@@ -506,6 +925,64 @@ ___
 - **summary**:    This message is temporarily unprocessable. 
 
    Such errors are expected, but not guaranteed, to resolve themselves eventually through  retrying. 
+
+___
+
+
+## multiBlockElection
+ 
+### Fallback
+- **interface**: `api.errors.multiBlockElection.Fallback.is`
+- **summary**:    Triggering the `Fallback` failed. 
+ 
+### Snapshot
+- **interface**: `api.errors.multiBlockElection.Snapshot.is`
+- **summary**:    Snapshot was unavailable. 
+ 
+### UnexpectedPhase
+- **interface**: `api.errors.multiBlockElection.UnexpectedPhase.is`
+- **summary**:    Unexpected phase 
+
+___
+
+
+## multiBlockElectionSigned
+ 
+### BadPageIndex
+- **interface**: `api.errors.multiBlockElectionSigned.BadPageIndex.is`
+- **summary**:    The page index is out of bounds. 
+ 
+### BadWitnessData
+- **interface**: `api.errors.multiBlockElectionSigned.BadWitnessData.is`
+- **summary**:    Bad witness data provided. 
+ 
+### Duplicate
+- **interface**: `api.errors.multiBlockElectionSigned.Duplicate.is`
+- **summary**:    The submission is a duplicate. 
+ 
+### NoSubmission
+- **interface**: `api.errors.multiBlockElectionSigned.NoSubmission.is`
+- **summary**:    No submission found. 
+ 
+### NotRegistered
+- **interface**: `api.errors.multiBlockElectionSigned.NotRegistered.is`
+- **summary**:    The account is not registered. 
+ 
+### PhaseNotSigned
+- **interface**: `api.errors.multiBlockElectionSigned.PhaseNotSigned.is`
+- **summary**:    The phase is not signed. 
+ 
+### QueueFull
+- **interface**: `api.errors.multiBlockElectionSigned.QueueFull.is`
+- **summary**:    The queue is full. 
+ 
+### RoundNotOver
+- **interface**: `api.errors.multiBlockElectionSigned.RoundNotOver.is`
+- **summary**:    Round is not yet over. 
+ 
+### TooManyInvulnerables
+- **interface**: `api.errors.multiBlockElectionSigned.TooManyInvulnerables.is`
+- **summary**:    Too many invulnerable accounts are provided, 
 
 ___
 
@@ -756,6 +1233,165 @@ ___
 ___
 
 
+## nominationPools
+ 
+### AccountBelongsToOtherPool
+- **interface**: `api.errors.nominationPools.AccountBelongsToOtherPool.is`
+- **summary**:    An account is already delegating in another pool. An account may only belong to one  pool at a time. 
+ 
+### AlreadyMigrated
+- **interface**: `api.errors.nominationPools.AlreadyMigrated.is`
+- **summary**:    The pool or member delegation has already migrated to delegate stake. 
+ 
+### BondExtraRestricted
+- **interface**: `api.errors.nominationPools.BondExtraRestricted.is`
+- **summary**:    Bonding extra is restricted to the exact pending reward amount. 
+ 
+### CanNotChangeState
+- **interface**: `api.errors.nominationPools.CanNotChangeState.is`
+- **summary**:    The pools state cannot be changed. 
+ 
+### CannotWithdrawAny
+- **interface**: `api.errors.nominationPools.CannotWithdrawAny.is`
+- **summary**:    None of the funds can be withdrawn yet because the bonding duration has not passed. 
+ 
+### CommissionChangeRateNotAllowed
+- **interface**: `api.errors.nominationPools.CommissionChangeRateNotAllowed.is`
+- **summary**:    The submitted changes to commission change rate are not allowed. 
+ 
+### CommissionChangeThrottled
+- **interface**: `api.errors.nominationPools.CommissionChangeThrottled.is`
+- **summary**:    Not enough blocks have surpassed since the last commission update. 
+ 
+### CommissionExceedsGlobalMaximum
+- **interface**: `api.errors.nominationPools.CommissionExceedsGlobalMaximum.is`
+- **summary**:    The supplied commission exceeds global maximum commission. 
+ 
+### CommissionExceedsMaximum
+- **interface**: `api.errors.nominationPools.CommissionExceedsMaximum.is`
+- **summary**:    The supplied commission exceeds the max allowed commission. 
+ 
+### Defensive
+- **interface**: `api.errors.nominationPools.Defensive.is`
+- **summary**:    Some error occurred that should never happen. This should be reported to the  maintainers. 
+ 
+### DoesNotHavePermission
+- **interface**: `api.errors.nominationPools.DoesNotHavePermission.is`
+- **summary**:    The caller does not have adequate permissions. 
+ 
+### FullyUnbonding
+- **interface**: `api.errors.nominationPools.FullyUnbonding.is`
+- **summary**:    The member is fully unbonded (and thus cannot access the bonded and reward pool  anymore to, for example, collect rewards). 
+ 
+### InvalidPoolId
+- **interface**: `api.errors.nominationPools.InvalidPoolId.is`
+- **summary**:    Pool id provided is not correct/usable. 
+ 
+### MaxCommissionRestricted
+- **interface**: `api.errors.nominationPools.MaxCommissionRestricted.is`
+- **summary**:    The pool's max commission cannot be set higher than the existing value. 
+ 
+### MaxPoolMembers
+- **interface**: `api.errors.nominationPools.MaxPoolMembers.is`
+- **summary**:    Too many members in the pool or system. 
+ 
+### MaxPools
+- **interface**: `api.errors.nominationPools.MaxPools.is`
+- **summary**:    The system is maxed out on pools. 
+ 
+### MaxUnbondingLimit
+- **interface**: `api.errors.nominationPools.MaxUnbondingLimit.is`
+- **summary**:    The member cannot unbond further chunks due to reaching the limit. 
+ 
+### MetadataExceedsMaxLen
+- **interface**: `api.errors.nominationPools.MetadataExceedsMaxLen.is`
+- **summary**:    Metadata exceeds [`Config::MaxMetadataLen`] 
+ 
+### MinimumBondNotMet
+- **interface**: `api.errors.nominationPools.MinimumBondNotMet.is`
+- **summary**:    The amount does not meet the minimum bond to either join or create a pool. 
+
+   The depositor can never unbond to a value less than `Pallet::depositor_min_bond`. The  caller does not have nominating permissions for the pool. Members can never unbond to a  value below `MinJoinBond`. 
+ 
+### NoCommissionCurrentSet
+- **interface**: `api.errors.nominationPools.NoCommissionCurrentSet.is`
+- **summary**:    No commission current has been set. 
+ 
+### NoPendingCommission
+- **interface**: `api.errors.nominationPools.NoPendingCommission.is`
+- **summary**:    There is no pending commission to claim. 
+ 
+### NotDestroying
+- **interface**: `api.errors.nominationPools.NotDestroying.is`
+- **summary**:    A pool must be in [`PoolState::Destroying`] in order for the depositor to unbond or for  other members to be permissionlessly unbonded. 
+ 
+### NothingToAdjust
+- **interface**: `api.errors.nominationPools.NothingToAdjust.is`
+- **summary**:    No imbalance in the ED deposit for the pool. 
+ 
+### NothingToSlash
+- **interface**: `api.errors.nominationPools.NothingToSlash.is`
+- **summary**:    No slash pending that can be applied to the member. 
+ 
+### NotKickerOrDestroying
+- **interface**: `api.errors.nominationPools.NotKickerOrDestroying.is`
+- **summary**:    Either a) the caller cannot make a valid kick or b) the pool is not destroying. 
+ 
+### NotMigrated
+- **interface**: `api.errors.nominationPools.NotMigrated.is`
+- **summary**:    The pool or member delegation has not migrated yet to delegate stake. 
+ 
+### NotNominator
+- **interface**: `api.errors.nominationPools.NotNominator.is`
+- **summary**:    The caller does not have nominating permissions for the pool. 
+ 
+### NotOpen
+- **interface**: `api.errors.nominationPools.NotOpen.is`
+- **summary**:    The pool is not open to join 
+ 
+### NotSupported
+- **interface**: `api.errors.nominationPools.NotSupported.is`
+- **summary**:    This call is not allowed in the current state of the pallet. 
+ 
+### OverflowRisk
+- **interface**: `api.errors.nominationPools.OverflowRisk.is`
+- **summary**:    The transaction could not be executed due to overflow risk for the pool. 
+ 
+### PartialUnbondNotAllowedPermissionlessly
+- **interface**: `api.errors.nominationPools.PartialUnbondNotAllowedPermissionlessly.is`
+- **summary**:    Partial unbonding now allowed permissionlessly. 
+ 
+### PoolIdInUse
+- **interface**: `api.errors.nominationPools.PoolIdInUse.is`
+- **summary**:    Pool id currently in use. 
+ 
+### PoolMemberNotFound
+- **interface**: `api.errors.nominationPools.PoolMemberNotFound.is`
+- **summary**:    An account is not a member. 
+ 
+### PoolNotFound
+- **interface**: `api.errors.nominationPools.PoolNotFound.is`
+- **summary**:    A (bonded) pool id does not exist. 
+ 
+### Restricted
+- **interface**: `api.errors.nominationPools.Restricted.is`
+- **summary**:    Account is restricted from participation in pools. This may happen if the account is  staking in another way already. 
+ 
+### RewardPoolNotFound
+- **interface**: `api.errors.nominationPools.RewardPoolNotFound.is`
+- **summary**:    A reward pool does not exist. In all cases this is a system logic error. 
+ 
+### SlashTooLow
+- **interface**: `api.errors.nominationPools.SlashTooLow.is`
+- **summary**:    The slash amount is too low to be applied. 
+ 
+### SubPoolsNotFound
+- **interface**: `api.errors.nominationPools.SubPoolsNotFound.is`
+- **summary**:    A sub pool does not exist. 
+
+___
+
+
 ## parachainSystem
  
 ### HostConfigurationNotAvailable
@@ -854,6 +1490,10 @@ ___
 ### LocalExecutionIncomplete
 - **interface**: `api.errors.polkadotXcm.LocalExecutionIncomplete.is`
 - **summary**:    Local XCM execution incomplete. 
+ 
+### LocalExecutionIncompleteWithError
+- **interface**: `api.errors.polkadotXcm.LocalExecutionIncompleteWithError.is`
+- **summary**:    Local XCM execution incomplete with the actual XCM error and the index of the  instruction that caused the error. 
  
 ### LockNotFound
 - **interface**: `api.errors.polkadotXcm.LockNotFound.is`
@@ -995,6 +1635,43 @@ ___
 ___
 
 
+## preimage
+ 
+### AlreadyNoted
+- **interface**: `api.errors.preimage.AlreadyNoted.is`
+- **summary**:    Preimage has already been noted on-chain. 
+ 
+### NotAuthorized
+- **interface**: `api.errors.preimage.NotAuthorized.is`
+- **summary**:    The user is not authorized to perform this action. 
+ 
+### NotNoted
+- **interface**: `api.errors.preimage.NotNoted.is`
+- **summary**:    The preimage cannot be removed since it has not yet been noted. 
+ 
+### NotRequested
+- **interface**: `api.errors.preimage.NotRequested.is`
+- **summary**:    The preimage request cannot be removed since no outstanding requests exist. 
+ 
+### Requested
+- **interface**: `api.errors.preimage.Requested.is`
+- **summary**:    A preimage may not be removed when there are outstanding requests. 
+ 
+### TooBig
+- **interface**: `api.errors.preimage.TooBig.is`
+- **summary**:    Preimage is too large to store on-chain. 
+ 
+### TooFew
+- **interface**: `api.errors.preimage.TooFew.is`
+- **summary**:    Too few hashes were requested to be upgraded (i.e. zero). 
+ 
+### TooMany
+- **interface**: `api.errors.preimage.TooMany.is`
+- **summary**:    More than `MAX_HASH_UPGRADE_BULK_COUNT` hashes were requested to be upgraded at once. 
+
+___
+
+
 ## proxy
  
 ### Duplicate
@@ -1032,6 +1709,92 @@ ___
 ___
 
 
+## referenda
+ 
+### BadReferendum
+- **interface**: `api.errors.referenda.BadReferendum.is`
+- **summary**:    The referendum index provided is invalid in this context. 
+ 
+### BadStatus
+- **interface**: `api.errors.referenda.BadStatus.is`
+- **summary**:    The referendum status is invalid for this operation. 
+ 
+### BadTrack
+- **interface**: `api.errors.referenda.BadTrack.is`
+- **summary**:    The track identifier given was invalid. 
+ 
+### Full
+- **interface**: `api.errors.referenda.Full.is`
+- **summary**:    There are already a full complement of referenda in progress for this track. 
+ 
+### HasDeposit
+- **interface**: `api.errors.referenda.HasDeposit.is`
+- **summary**:    Referendum's decision deposit is already paid. 
+ 
+### NoDeposit
+- **interface**: `api.errors.referenda.NoDeposit.is`
+- **summary**:    The deposit cannot be refunded since none was made. 
+ 
+### NoPermission
+- **interface**: `api.errors.referenda.NoPermission.is`
+- **summary**:    The deposit refunder is not the depositor. 
+ 
+### NothingToDo
+- **interface**: `api.errors.referenda.NothingToDo.is`
+- **summary**:    There was nothing to do in the advancement. 
+ 
+### NotOngoing
+- **interface**: `api.errors.referenda.NotOngoing.is`
+- **summary**:    Referendum is not ongoing. 
+ 
+### NoTrack
+- **interface**: `api.errors.referenda.NoTrack.is`
+- **summary**:    No track exists for the proposal origin. 
+ 
+### PreimageNotExist
+- **interface**: `api.errors.referenda.PreimageNotExist.is`
+- **summary**:    The preimage does not exist. 
+ 
+### PreimageStoredWithDifferentLength
+- **interface**: `api.errors.referenda.PreimageStoredWithDifferentLength.is`
+- **summary**:    The preimage is stored with a different length than the one provided. 
+ 
+### QueueEmpty
+- **interface**: `api.errors.referenda.QueueEmpty.is`
+- **summary**:    The queue of the track is empty. 
+ 
+### Unfinished
+- **interface**: `api.errors.referenda.Unfinished.is`
+- **summary**:    Any deposit cannot be refunded until after the decision is over. 
+
+___
+
+
+## scheduler
+ 
+### FailedToSchedule
+- **interface**: `api.errors.scheduler.FailedToSchedule.is`
+- **summary**:    Failed to schedule a call 
+ 
+### Named
+- **interface**: `api.errors.scheduler.Named.is`
+- **summary**:    Attempt to use a non-named function on a named task. 
+ 
+### NotFound
+- **interface**: `api.errors.scheduler.NotFound.is`
+- **summary**:    Cannot find the scheduled call. 
+ 
+### RescheduleNoChange
+- **interface**: `api.errors.scheduler.RescheduleNoChange.is`
+- **summary**:    Reschedule failed because it does not change scheduled time. 
+ 
+### TargetBlockNumberInPast
+- **interface**: `api.errors.scheduler.TargetBlockNumberInPast.is`
+- **summary**:    Given target block number is in the past. 
+
+___
+
+
 ## session
  
 ### DuplicatedKey
@@ -1053,6 +1816,212 @@ ___
 ### NoKeys
 - **interface**: `api.errors.session.NoKeys.is`
 - **summary**:    No keys are associated with this account. 
+
+___
+
+
+## snowbridgeSystemFrontend
+ 
+### BurnError
+- **interface**: `api.errors.snowbridgeSystemFrontend.BurnError.is`
+- **summary**:    Ether could not be burned. 
+ 
+### FeesNotMet
+- **interface**: `api.errors.snowbridgeSystemFrontend.FeesNotMet.is`
+- **summary**:    Withdraw fee asset failure 
+ 
+### Halted
+- **interface**: `api.errors.snowbridgeSystemFrontend.Halted.is`
+- **summary**:    Message export is halted 
+ 
+### InvalidAccount
+- **interface**: `api.errors.snowbridgeSystemFrontend.InvalidAccount.is`
+- **summary**:    Account could not be converted to a location. 
+ 
+### InvalidAssetOwner
+- **interface**: `api.errors.snowbridgeSystemFrontend.InvalidAssetOwner.is`
+- **summary**:    Check location failure, should start from the dispatch origin as owner 
+ 
+### LocationConversionFailed
+- **interface**: `api.errors.snowbridgeSystemFrontend.LocationConversionFailed.is`
+- **summary**:    Convert to reanchored location failure 
+ 
+### SendFailure
+- **interface**: `api.errors.snowbridgeSystemFrontend.SendFailure.is`
+- **summary**:    Send xcm message failure 
+ 
+### SwapError
+- **interface**: `api.errors.snowbridgeSystemFrontend.SwapError.is`
+- **summary**:    Provided tip asset could not be swapped for ether. 
+ 
+### TipAmountZero
+- **interface**: `api.errors.snowbridgeSystemFrontend.TipAmountZero.is`
+- **summary**:    The tip provided is zero. 
+ 
+### Unreachable
+- **interface**: `api.errors.snowbridgeSystemFrontend.Unreachable.is`
+- **summary**:    The desired destination was unreachable, generally because there is a no way of routing  to it. 
+ 
+### UnsupportedAsset
+- **interface**: `api.errors.snowbridgeSystemFrontend.UnsupportedAsset.is`
+- **summary**:    The asset provided for the tip is unsupported. 
+ 
+### UnsupportedLocationVersion
+- **interface**: `api.errors.snowbridgeSystemFrontend.UnsupportedLocationVersion.is`
+- **summary**:    Convert versioned location failure 
+ 
+### WithdrawError
+- **interface**: `api.errors.snowbridgeSystemFrontend.WithdrawError.is`
+- **summary**:    Unable to withdraw asset. 
+
+___
+
+
+## staking
+ 
+### AlreadyBonded
+- **interface**: `api.errors.staking.AlreadyBonded.is`
+- **summary**:    Stash is already bonded. 
+ 
+### AlreadyClaimed
+- **interface**: `api.errors.staking.AlreadyClaimed.is`
+- **summary**:    Rewards for this era have already been claimed for this validator. 
+ 
+### AlreadyMigrated
+- **interface**: `api.errors.staking.AlreadyMigrated.is`
+- **summary**:    The stake of this account is already migrated to `Fungible` holds. 
+ 
+### AlreadyPaired
+- **interface**: `api.errors.staking.AlreadyPaired.is`
+- **summary**:    Controller is already paired. 
+ 
+### BadState
+- **interface**: `api.errors.staking.BadState.is`
+- **summary**:    Internal state has become somehow corrupted and the operation cannot continue. 
+ 
+### BadTarget
+- **interface**: `api.errors.staking.BadTarget.is`
+- **summary**:    A nomination target was supplied that was blocked or otherwise not a validator. 
+ 
+### BoundNotMet
+- **interface**: `api.errors.staking.BoundNotMet.is`
+- **summary**:    Some bound is not met. 
+ 
+### CancelledSlash
+- **interface**: `api.errors.staking.CancelledSlash.is`
+- **summary**:    The slash has been cancelled and cannot be applied. 
+ 
+### CannotChillOther
+- **interface**: `api.errors.staking.CannotChillOther.is`
+- **summary**:    The user has enough bond and thus cannot be chilled forcefully by an external person. 
+ 
+### CannotReapStash
+- **interface**: `api.errors.staking.CannotReapStash.is`
+- **summary**:    Stash could not be reaped as other pallet might depend on it. 
+ 
+### CannotRestoreLedger
+- **interface**: `api.errors.staking.CannotRestoreLedger.is`
+- **summary**:    Cannot reset a ledger. 
+ 
+### CommissionTooLow
+- **interface**: `api.errors.staking.CommissionTooLow.is`
+- **summary**:    Commission is too low. Must be at least `MinCommission`. 
+ 
+### ControllerDeprecated
+- **interface**: `api.errors.staking.ControllerDeprecated.is`
+- **summary**:    Used when attempting to use deprecated controller account logic. 
+ 
+### DuplicateIndex
+- **interface**: `api.errors.staking.DuplicateIndex.is`
+- **summary**:    Duplicate index. 
+ 
+### EmptyTargets
+- **interface**: `api.errors.staking.EmptyTargets.is`
+- **summary**:    Targets cannot be empty. 
+ 
+### EraNotPrunable
+- **interface**: `api.errors.staking.EraNotPrunable.is`
+- **summary**:    The era is not eligible for pruning. 
+ 
+### EraNotStarted
+- **interface**: `api.errors.staking.EraNotStarted.is`
+- **summary**:    Era not yet started. 
+ 
+### FundedTarget
+- **interface**: `api.errors.staking.FundedTarget.is`
+- **summary**:    Attempting to target a stash that still has funds. 
+ 
+### IncorrectHistoryDepth
+- **interface**: `api.errors.staking.IncorrectHistoryDepth.is`
+- **summary**:    Incorrect previous history depth input provided. 
+ 
+### InsufficientBond
+- **interface**: `api.errors.staking.InsufficientBond.is`
+- **summary**:    Cannot bond, nominate or validate with value less than the minimum defined by  governance (see `MinValidatorBond` and `MinNominatorBond`). If unbonding is the  intention, `chill` first to remove one's role as validator/nominator. 
+ 
+### InvalidEraToReward
+- **interface**: `api.errors.staking.InvalidEraToReward.is`
+- **summary**:    Invalid era to reward. 
+ 
+### InvalidNumberOfNominations
+- **interface**: `api.errors.staking.InvalidNumberOfNominations.is`
+- **summary**:    Invalid number of nominations. 
+ 
+### InvalidPage
+- **interface**: `api.errors.staking.InvalidPage.is`
+- **summary**:    No nominators exist on this page. 
+ 
+### InvalidSlashRecord
+- **interface**: `api.errors.staking.InvalidSlashRecord.is`
+- **summary**:    Slash record not found. 
+ 
+### NoMoreChunks
+- **interface**: `api.errors.staking.NoMoreChunks.is`
+- **summary**:    Can not schedule more unlock chunks. 
+ 
+### NotController
+- **interface**: `api.errors.staking.NotController.is`
+- **summary**:    Not a controller account. 
+ 
+### NotEnoughFunds
+- **interface**: `api.errors.staking.NotEnoughFunds.is`
+- **summary**:    Not enough funds available to withdraw. 
+ 
+### NotStash
+- **interface**: `api.errors.staking.NotStash.is`
+- **summary**:    Not a stash account. 
+ 
+### NoUnlockChunk
+- **interface**: `api.errors.staking.NoUnlockChunk.is`
+- **summary**:    Can not rebond without unlocking chunks. 
+ 
+### Restricted
+- **interface**: `api.errors.staking.Restricted.is`
+- **summary**:    Account is restricted from participation in staking. This may happen if the account is  staking in another way already, such as via pool. 
+ 
+### RewardDestinationRestricted
+- **interface**: `api.errors.staking.RewardDestinationRestricted.is`
+- **summary**:    Provided reward destination is not allowed. 
+ 
+### TooManyNominators
+- **interface**: `api.errors.staking.TooManyNominators.is`
+- **summary**:    There are too many nominators in the system. Governance needs to adjust the staking  settings to keep things safe for the runtime. 
+ 
+### TooManyTargets
+- **interface**: `api.errors.staking.TooManyTargets.is`
+- **summary**:    Too many nomination targets supplied. 
+ 
+### TooManyValidators
+- **interface**: `api.errors.staking.TooManyValidators.is`
+- **summary**:    There are too many validator candidates in the system. Governance needs to adjust the  staking settings to keep things safe for the runtime. 
+ 
+### UnappliedSlashesInPreviousEra
+- **interface**: `api.errors.staking.UnappliedSlashesInPreviousEra.is`
+- **summary**:    Unapplied slashes in the recently concluded era is blocking this operation.  See `Call::apply_slash` to apply them. 
+ 
+### VirtualStakerNotAllowed
+- **interface**: `api.errors.staking.VirtualStakerNotAllowed.is`
+- **summary**:    Operation not allowed for virtual stakers. 
 
 ___
 
@@ -1094,6 +2063,10 @@ ___
 - **interface**: `api.errors.system.CallFiltered.is`
 - **summary**:    The origin filter prevent the call to be dispatched. 
  
+### FailedTask
+- **interface**: `api.errors.system.FailedTask.is`
+- **summary**:    The specified [`Task`] failed during execution. 
+ 
 ### FailedToExtractRuntimeVersion
 - **interface**: `api.errors.system.FailedToExtractRuntimeVersion.is`
 - **summary**:    Failed to extract the runtime version from the new runtime. 
@@ -1103,6 +2076,10 @@ ___
 ### InvalidSpecName
 - **interface**: `api.errors.system.InvalidSpecName.is`
 - **summary**:    The name of specification does not match between the current runtime  and the new runtime. 
+ 
+### InvalidTask
+- **interface**: `api.errors.system.InvalidTask.is`
+- **summary**:    The specified [`Task`] is not valid. 
  
 ### MultiBlockMigrationsOngoing
 - **interface**: `api.errors.system.MultiBlockMigrationsOngoing.is`
@@ -1131,11 +2108,64 @@ ___
 ___
 
 
+## treasury
+ 
+### AlreadyAttempted
+- **interface**: `api.errors.treasury.AlreadyAttempted.is`
+- **summary**:    The payment has already been attempted. 
+ 
+### EarlyPayout
+- **interface**: `api.errors.treasury.EarlyPayout.is`
+- **summary**:    The spend is not yet eligible for payout. 
+ 
+### FailedToConvertBalance
+- **interface**: `api.errors.treasury.FailedToConvertBalance.is`
+- **summary**:    The balance of the asset kind is not convertible to the balance of the native asset. 
+ 
+### Inconclusive
+- **interface**: `api.errors.treasury.Inconclusive.is`
+- **summary**:    The payment has neither failed nor succeeded yet. 
+ 
+### InsufficientPermission
+- **interface**: `api.errors.treasury.InsufficientPermission.is`
+- **summary**:    The spend origin is valid but the amount it is allowed to spend is lower than the  amount to be spent. 
+ 
+### InvalidIndex
+- **interface**: `api.errors.treasury.InvalidIndex.is`
+- **summary**:    No proposal, bounty or spend at that index. 
+ 
+### NotAttempted
+- **interface**: `api.errors.treasury.NotAttempted.is`
+- **summary**:    The payout was not yet attempted/claimed. 
+ 
+### PayoutError
+- **interface**: `api.errors.treasury.PayoutError.is`
+- **summary**:    There was some issue with the mechanism of payment. 
+ 
+### ProposalNotApproved
+- **interface**: `api.errors.treasury.ProposalNotApproved.is`
+- **summary**:    Proposal has not been approved. 
+ 
+### SpendExpired
+- **interface**: `api.errors.treasury.SpendExpired.is`
+- **summary**:    The spend has expired and cannot be claimed. 
+ 
+### TooManyApprovals
+- **interface**: `api.errors.treasury.TooManyApprovals.is`
+- **summary**:    Too many approvals in the queue. 
+
+___
+
+
 ## uniques
  
 ### AlreadyExists
 - **interface**: `api.errors.uniques.AlreadyExists.is`
 - **summary**:    The item ID has already been used for an item. 
+ 
+### AttributeNotFound
+- **interface**: `api.errors.uniques.AttributeNotFound.is`
+- **summary**:    An attribute is not found. 
  
 ### BadWitness
 - **interface**: `api.errors.uniques.BadWitness.is`
@@ -1173,6 +2203,10 @@ ___
 - **interface**: `api.errors.uniques.NoDelegate.is`
 - **summary**:    There is no delegate approved. 
  
+### NoMetadata
+- **interface**: `api.errors.uniques.NoMetadata.is`
+- **summary**:    No metadata is found. 
+ 
 ### NoPermission
 - **interface**: `api.errors.uniques.NoPermission.is`
 - **summary**:    The signing account has no permission to do the operation. 
@@ -1197,9 +2231,17 @@ ___
 - **interface**: `api.errors.uniques.UnknownItem.is`
 - **summary**:    The given item ID is unknown. 
  
+### WrongAttribute
+- **interface**: `api.errors.uniques.WrongAttribute.is`
+- **summary**:    Wrong attribute key/value bytes supplied. 
+ 
 ### WrongDelegate
 - **interface**: `api.errors.uniques.WrongDelegate.is`
 - **summary**:    The delegate turned out to be different to what was expected. 
+ 
+### WrongMetadata
+- **interface**: `api.errors.uniques.WrongMetadata.is`
+- **summary**:    Wrong metadata key/value bytes supplied. 
  
 ### WrongOwner
 - **interface**: `api.errors.uniques.WrongOwner.is`
@@ -1238,6 +2280,44 @@ ___
 ### ScheduleIndexOutOfBounds
 - **interface**: `api.errors.vesting.ScheduleIndexOutOfBounds.is`
 - **summary**:    An index was out of bounds of the vesting schedules. 
+
+___
+
+
+## voterList
+ 
+### List
+- **interface**: `api.errors.voterList.List.is`
+- **summary**:    A error in the list interface implementation. 
+ 
+### Locked
+- **interface**: `api.errors.voterList.Locked.is`
+- **summary**:    Could not update a node, because the pallet is locked. 
+
+___
+
+
+## whitelist
+ 
+### CallAlreadyWhitelisted
+- **interface**: `api.errors.whitelist.CallAlreadyWhitelisted.is`
+- **summary**:    The call was already whitelisted; No-Op. 
+ 
+### CallIsNotWhitelisted
+- **interface**: `api.errors.whitelist.CallIsNotWhitelisted.is`
+- **summary**:    The call was not whitelisted. 
+ 
+### InvalidCallWeightWitness
+- **interface**: `api.errors.whitelist.InvalidCallWeightWitness.is`
+- **summary**:    The weight of the decoded call was higher than the witness. 
+ 
+### UnavailablePreImage
+- **interface**: `api.errors.whitelist.UnavailablePreImage.is`
+- **summary**:    The preimage of the call hash could not be loaded. 
+ 
+### UndecodableCall
+- **interface**: `api.errors.whitelist.UndecodableCall.is`
+- **summary**:    The call could not be decoded. 
 
 ___
 

--- a/docs/asset-hub-polkadot/events.md
+++ b/docs/asset-hub-polkadot/events.md
@@ -6,7 +6,13 @@ Events are emitted for certain operations on the runtime. The following sections
 
 (NOTE: These were generated from a static/snapshot view of a recent default asset-hub-polkadot runtime. Some items may not be available in older nodes, or in any customized implementations.)
 
+- **[ahMigrator](#ahmigrator)**
+
+- **[ahOps](#ahops)**
+
 - **[assetConversion](#assetconversion)**
+
+- **[assetRate](#assetrate)**
 
 - **[assets](#assets)**
 
@@ -14,27 +20,61 @@ Events are emitted for certain operations on the runtime. The following sections
 
 - **[balances](#balances)**
 
+- **[bounties](#bounties)**
+
+- **[childBounties](#childbounties)**
+
+- **[claims](#claims)**
+
 - **[collatorSelection](#collatorselection)**
+
+- **[convictionVoting](#convictionvoting)**
 
 - **[cumulusXcm](#cumulusxcm)**
 
+- **[delegatedStaking](#delegatedstaking)**
+
 - **[foreignAssets](#foreignassets)**
 
+- **[indices](#indices)**
+
 - **[messageQueue](#messagequeue)**
+
+- **[multiBlockElection](#multiblockelection)**
+
+- **[multiBlockElectionSigned](#multiblockelectionsigned)**
+
+- **[multiBlockElectionVerifier](#multiblockelectionverifier)**
 
 - **[multisig](#multisig)**
 
 - **[nfts](#nfts)**
 
+- **[nominationPools](#nominationpools)**
+
 - **[parachainSystem](#parachainsystem)**
+
+- **[parameters](#parameters)**
 
 - **[polkadotXcm](#polkadotxcm)**
 
 - **[poolAssets](#poolassets)**
 
+- **[preimage](#preimage)**
+
 - **[proxy](#proxy)**
 
+- **[referenda](#referenda)**
+
+- **[scheduler](#scheduler)**
+
 - **[session](#session)**
+
+- **[snowbridgeSystemFrontend](#snowbridgesystemfrontend)**
+
+- **[staking](#staking)**
+
+- **[stakingRcClient](#stakingrcclient)**
 
 - **[stateTrieMigration](#statetriemigration)**
 
@@ -44,11 +84,17 @@ Events are emitted for certain operations on the runtime. The following sections
 
 - **[transactionPayment](#transactionpayment)**
 
+- **[treasury](#treasury)**
+
 - **[uniques](#uniques)**
 
 - **[utility](#utility)**
 
 - **[vesting](#vesting)**
+
+- **[voterList](#voterlist)**
+
+- **[whitelist](#whitelist)**
 
 - **[xcmpQueue](#xcmpqueue)**
 
@@ -56,31 +102,133 @@ Events are emitted for certain operations on the runtime. The following sections
 ___
 
 
+## ahMigrator
+ 
+### AccountTranslatedParachainSovereign(`AccountId32`, `AccountId32`)
+- **interface**: `api.events.ahMigrator.AccountTranslatedParachainSovereign.is`
+ 
+### AccountTranslatedParachainSovereignDerived(`AccountId32`, `AccountId32`, `u16`)
+- **interface**: `api.events.ahMigrator.AccountTranslatedParachainSovereignDerived.is`
+ 
+### AssetHubMigrationFinished()
+- **interface**: `api.events.ahMigrator.AssetHubMigrationFinished.is`
+- **summary**:    The Asset Hub Migration finished. 
+
+   This event is equivalent to `StageTransition { new: MigrationDone, .. }` but is easier  to understand. The finishing is immediate and affects all events happening  afterwards. 
+ 
+### AssetHubMigrationStarted()
+- **interface**: `api.events.ahMigrator.AssetHubMigrationStarted.is`
+- **summary**:    The Asset Hub Migration started and is active until `AssetHubMigrationFinished` is  emitted. 
+
+   This event is equivalent to `StageTransition { new: DataMigrationOngoing, .. }` but is  easier to understand. The activation is immediate and affects all events happening  afterwards. 
+ 
+### BalancesBeforeRecordConsumed(`u128`, `u128`)
+- **interface**: `api.events.ahMigrator.BalancesBeforeRecordConsumed.is`
+- **summary**:    The balances before the migration were consumed. 
+ 
+### BalancesBeforeRecordSet(`u128`, `u128`)
+- **interface**: `api.events.ahMigrator.BalancesBeforeRecordSet.is`
+- **summary**:    The balances before the migration were recorded. 
+ 
+### BatchProcessed(`PalletAhMigratorPalletEventName`, `u32`, `u32`)
+- **interface**: `api.events.ahMigrator.BatchProcessed.is`
+- **summary**:    We processed a batch of messages for this pallet. 
+ 
+### BatchReceived(`PalletAhMigratorPalletEventName`, `u32`)
+- **interface**: `api.events.ahMigrator.BatchReceived.is`
+- **summary**:    We received a batch of messages that will be integrated into a pallet. 
+ 
+### DmpQueuePriorityConfigSet(`PalletRcMigratorQueuePriority`, `PalletRcMigratorQueuePriority`)
+- **interface**: `api.events.ahMigrator.DmpQueuePriorityConfigSet.is`
+- **summary**:    The DMP queue priority config was set. 
+ 
+### DmpQueuePrioritySet(`bool`, `u32`, `u32`)
+- **interface**: `api.events.ahMigrator.DmpQueuePrioritySet.is`
+- **summary**:    Whether the DMP queue was prioritized for the next block. 
+ 
+### FailedToUnreserveMultisigDeposit(`u128`, `u128`, `AccountId32`)
+- **interface**: `api.events.ahMigrator.FailedToUnreserveMultisigDeposit.is`
+- **summary**:    Failed to unreserve a multisig deposit. 
+ 
+### FailedToUnreservePreimageDeposit(`u128`, `u128`, `AccountId32`)
+- **interface**: `api.events.ahMigrator.FailedToUnreservePreimageDeposit.is`
+- **summary**:    Failed to unreserve a legacy status preimage deposit. 
+ 
+### ManagerSet(`Option<AccountId32>`, `Option<AccountId32>`)
+- **interface**: `api.events.ahMigrator.ManagerSet.is`
+- **summary**:    The manager account id was set. 
+ 
+### ReferendumCanceled(`u32`)
+- **interface**: `api.events.ahMigrator.ReferendumCanceled.is`
+- **summary**:    A referendum was cancelled because it could not be mapped. 
+ 
+### StageTransition(`PalletAhMigratorMigrationStage`, `PalletAhMigratorMigrationStage`)
+- **interface**: `api.events.ahMigrator.StageTransition.is`
+- **summary**:    A stage transition has occurred. 
+ 
+### XcmSent(`StagingXcmV5Location`, `StagingXcmV5Location`, `StagingXcmV5Xcm`, `[u8;32]`)
+- **interface**: `api.events.ahMigrator.XcmSent.is`
+- **summary**:    An XCM message was sent. 
+
+___
+
+
+## ahOps
+ 
+### CrowdloanUnreserveRemaining(`AccountId32`, `u32`, `u128`)
+- **interface**: `api.events.ahOps.CrowdloanUnreserveRemaining.is`
+- **summary**:    Some amount for a crowdloan reserve could not be unreserved and needs manual cleanup. 
+ 
+### LeaseUnreserveRemaining(`AccountId32`, `u32`, `u128`)
+- **interface**: `api.events.ahOps.LeaseUnreserveRemaining.is`
+- **summary**:    Some lease reserve could not be unreserved and needs manual cleanup. 
+ 
+### SovereignMigrated(`u32`, `AccountId32`, `AccountId32`, `Option<u16>`)
+- **interface**: `api.events.ahOps.SovereignMigrated.is`
+- **summary**:    A sovereign parachain account has been migrated from its child to sibling  representation. 
+
+___
+
+
 ## assetConversion
  
-### LiquidityAdded(`AccountId32`, `AccountId32`, `(StagingXcmV4Location,StagingXcmV4Location)`, `u128`, `u128`, `u32`, `u128`)
+### LiquidityAdded(`AccountId32`, `AccountId32`, `(StagingXcmV5Location,StagingXcmV5Location)`, `u128`, `u128`, `u32`, `u128`)
 - **interface**: `api.events.assetConversion.LiquidityAdded.is`
 - **summary**:    A successful call of the `AddLiquidity` extrinsic will create this event. 
  
-### LiquidityRemoved(`AccountId32`, `AccountId32`, `(StagingXcmV4Location,StagingXcmV4Location)`, `u128`, `u128`, `u32`, `u128`, `Permill`)
+### LiquidityRemoved(`AccountId32`, `AccountId32`, `(StagingXcmV5Location,StagingXcmV5Location)`, `u128`, `u128`, `u32`, `u128`, `Permill`)
 - **interface**: `api.events.assetConversion.LiquidityRemoved.is`
 - **summary**:    A successful call of the `RemoveLiquidity` extrinsic will create this event. 
  
-### PoolCreated(`AccountId32`, `(StagingXcmV4Location,StagingXcmV4Location)`, `AccountId32`, `u32`)
+### PoolCreated(`AccountId32`, `(StagingXcmV5Location,StagingXcmV5Location)`, `AccountId32`, `u32`)
 - **interface**: `api.events.assetConversion.PoolCreated.is`
 - **summary**:    A successful call of the `CreatePool` extrinsic will create this event. 
  
-### SwapCreditExecuted(`u128`, `u128`, `Vec<(StagingXcmV4Location,u128)>`)
+### SwapCreditExecuted(`u128`, `u128`, `Vec<(StagingXcmV5Location,u128)>`)
 - **interface**: `api.events.assetConversion.SwapCreditExecuted.is`
 - **summary**:    Assets have been converted from one to another. 
  
-### SwapExecuted(`AccountId32`, `AccountId32`, `u128`, `u128`, `Vec<(StagingXcmV4Location,u128)>`)
+### SwapExecuted(`AccountId32`, `AccountId32`, `u128`, `u128`, `Vec<(StagingXcmV5Location,u128)>`)
 - **interface**: `api.events.assetConversion.SwapExecuted.is`
 - **summary**:    Assets have been converted from one to another. Both `SwapExactTokenForToken`  and `SwapTokenForExactToken` will generate this event. 
  
-### Touched(`(StagingXcmV4Location,StagingXcmV4Location)`, `AccountId32`)
+### Touched(`(StagingXcmV5Location,StagingXcmV5Location)`, `AccountId32`)
 - **interface**: `api.events.assetConversion.Touched.is`
 - **summary**:    Pool has been touched in order to fulfill operational requirements. 
+
+___
+
+
+## assetRate
+ 
+### AssetRateCreated(`PolkadotRuntimeCommonImplsVersionedLocatableAsset`, `u128`)
+- **interface**: `api.events.assetRate.AssetRateCreated.is`
+ 
+### AssetRateRemoved(`PolkadotRuntimeCommonImplsVersionedLocatableAsset`)
+- **interface**: `api.events.assetRate.AssetRateRemoved.is`
+ 
+### AssetRateUpdated(`PolkadotRuntimeCommonImplsVersionedLocatableAsset`, `u128`, `u128`)
+- **interface**: `api.events.assetRate.AssetRateUpdated.is`
 
 ___
 
@@ -200,7 +348,7 @@ ___
 - **interface**: `api.events.assetTxPayment.AssetRefundFailed.is`
 - **summary**:    A swap of the refund in native currency back to asset failed. 
  
-### AssetTxFeePaid(`AccountId32`, `u128`, `u128`, `StagingXcmV4Location`)
+### AssetTxFeePaid(`AccountId32`, `u128`, `u128`, `StagingXcmV5Location`)
 - **interface**: `api.events.assetTxPayment.AssetTxFeePaid.is`
 - **summary**:    A transaction fee `actual_fee`, of which `tip` was added to the minimum inclusion fee,  has been paid by `who` in an asset `asset_id`. 
 
@@ -281,6 +429,10 @@ ___
 - **interface**: `api.events.balances.Transfer.is`
 - **summary**:    Transfer succeeded. 
  
+### Unexpected(`PalletBalancesUnexpectedKind`)
+- **interface**: `api.events.balances.Unexpected.is`
+- **summary**:    An unexpected/defensive event was triggered. 
+ 
 ### Unlocked(`AccountId32`, `u128`)
 - **interface**: `api.events.balances.Unlocked.is`
 - **summary**:    Some balance was unlocked. 
@@ -296,6 +448,89 @@ ___
 ### Withdraw(`AccountId32`, `u128`)
 - **interface**: `api.events.balances.Withdraw.is`
 - **summary**:    Some amount was withdrawn from the account (e.g. for transaction fees). 
+
+___
+
+
+## bounties
+ 
+### BountyApproved(`u32`)
+- **interface**: `api.events.bounties.BountyApproved.is`
+- **summary**:    A bounty is approved. 
+ 
+### BountyAwarded(`u32`, `AccountId32`)
+- **interface**: `api.events.bounties.BountyAwarded.is`
+- **summary**:    A bounty is awarded to a beneficiary. 
+ 
+### BountyBecameActive(`u32`)
+- **interface**: `api.events.bounties.BountyBecameActive.is`
+- **summary**:    A bounty proposal is funded and became active. 
+ 
+### BountyCanceled(`u32`)
+- **interface**: `api.events.bounties.BountyCanceled.is`
+- **summary**:    A bounty is cancelled. 
+ 
+### BountyClaimed(`u32`, `u128`, `AccountId32`)
+- **interface**: `api.events.bounties.BountyClaimed.is`
+- **summary**:    A bounty is claimed by beneficiary. 
+ 
+### BountyExtended(`u32`)
+- **interface**: `api.events.bounties.BountyExtended.is`
+- **summary**:    A bounty expiry is extended. 
+ 
+### BountyProposed(`u32`)
+- **interface**: `api.events.bounties.BountyProposed.is`
+- **summary**:    New bounty proposal. 
+ 
+### BountyRejected(`u32`, `u128`)
+- **interface**: `api.events.bounties.BountyRejected.is`
+- **summary**:    A bounty proposal was rejected; funds were slashed. 
+ 
+### CuratorAccepted(`u32`, `AccountId32`)
+- **interface**: `api.events.bounties.CuratorAccepted.is`
+- **summary**:    A bounty curator is accepted. 
+ 
+### CuratorProposed(`u32`, `AccountId32`)
+- **interface**: `api.events.bounties.CuratorProposed.is`
+- **summary**:    A bounty curator is proposed. 
+ 
+### CuratorUnassigned(`u32`)
+- **interface**: `api.events.bounties.CuratorUnassigned.is`
+- **summary**:    A bounty curator is unassigned. 
+ 
+### DepositPoked(`u32`, `AccountId32`, `u128`, `u128`)
+- **interface**: `api.events.bounties.DepositPoked.is`
+- **summary**:    A bounty deposit has been poked. 
+
+___
+
+
+## childBounties
+ 
+### Added(`u32`, `u32`)
+- **interface**: `api.events.childBounties.Added.is`
+- **summary**:    A child-bounty is added. 
+ 
+### Awarded(`u32`, `u32`, `AccountId32`)
+- **interface**: `api.events.childBounties.Awarded.is`
+- **summary**:    A child-bounty is awarded to a beneficiary. 
+ 
+### Canceled(`u32`, `u32`)
+- **interface**: `api.events.childBounties.Canceled.is`
+- **summary**:    A child-bounty is cancelled. 
+ 
+### Claimed(`u32`, `u32`, `u128`, `AccountId32`)
+- **interface**: `api.events.childBounties.Claimed.is`
+- **summary**:    A child-bounty is claimed by beneficiary. 
+
+___
+
+
+## claims
+ 
+### Claimed(`AccountId32`, `EthereumAddress`, `u128`)
+- **interface**: `api.events.claims.Claimed.is`
+- **summary**:    Someone claimed some DOTs. 
 
 ___
 
@@ -345,6 +580,31 @@ ___
 ___
 
 
+## convictionVoting
+ 
+### Delegated(`AccountId32`, `AccountId32`)
+- **interface**: `api.events.convictionVoting.Delegated.is`
+- **summary**:    An account has delegated their vote to another account. \[who, target\] 
+ 
+### Undelegated(`AccountId32`)
+- **interface**: `api.events.convictionVoting.Undelegated.is`
+- **summary**:    An \[account\] has cancelled a previous delegation operation. 
+ 
+### Voted(`AccountId32`, `PalletConvictionVotingVoteAccountVote`)
+- **interface**: `api.events.convictionVoting.Voted.is`
+- **summary**:    An account has voted 
+ 
+### VoteRemoved(`AccountId32`, `PalletConvictionVotingVoteAccountVote`)
+- **interface**: `api.events.convictionVoting.VoteRemoved.is`
+- **summary**:    A vote has been removed 
+ 
+### VoteUnlocked(`AccountId32`, `u16`)
+- **interface**: `api.events.convictionVoting.VoteUnlocked.is`
+- **summary**:    The lockup period of a conviction vote expired, and the funds have been unlocked. 
+
+___
+
+
 ## cumulusXcm
  
 ### ExecutedDownward(`[u8;32]`, `StagingXcmV5TraitsOutcome`)
@@ -362,111 +622,153 @@ ___
 ___
 
 
+## delegatedStaking
+ 
+### Delegated(`AccountId32`, `AccountId32`, `u128`)
+- **interface**: `api.events.delegatedStaking.Delegated.is`
+- **summary**:    Funds delegated by a delegator. 
+ 
+### MigratedDelegation(`AccountId32`, `AccountId32`, `u128`)
+- **interface**: `api.events.delegatedStaking.MigratedDelegation.is`
+- **summary**:    Unclaimed delegation funds migrated to delegator. 
+ 
+### Released(`AccountId32`, `AccountId32`, `u128`)
+- **interface**: `api.events.delegatedStaking.Released.is`
+- **summary**:    Funds released to a delegator. 
+ 
+### Slashed(`AccountId32`, `AccountId32`, `u128`)
+- **interface**: `api.events.delegatedStaking.Slashed.is`
+- **summary**:    Funds slashed from a delegator. 
+
+___
+
+
 ## foreignAssets
  
-### AccountsDestroyed(`StagingXcmV4Location`, `u32`, `u32`)
+### AccountsDestroyed(`StagingXcmV5Location`, `u32`, `u32`)
 - **interface**: `api.events.foreignAssets.AccountsDestroyed.is`
 - **summary**:    Accounts were destroyed for given asset. 
  
-### ApprovalCancelled(`StagingXcmV4Location`, `AccountId32`, `AccountId32`)
+### ApprovalCancelled(`StagingXcmV5Location`, `AccountId32`, `AccountId32`)
 - **interface**: `api.events.foreignAssets.ApprovalCancelled.is`
 - **summary**:    An approval for account `delegate` was cancelled by `owner`. 
  
-### ApprovalsDestroyed(`StagingXcmV4Location`, `u32`, `u32`)
+### ApprovalsDestroyed(`StagingXcmV5Location`, `u32`, `u32`)
 - **interface**: `api.events.foreignAssets.ApprovalsDestroyed.is`
 - **summary**:    Approvals were destroyed for given asset. 
  
-### ApprovedTransfer(`StagingXcmV4Location`, `AccountId32`, `AccountId32`, `u128`)
+### ApprovedTransfer(`StagingXcmV5Location`, `AccountId32`, `AccountId32`, `u128`)
 - **interface**: `api.events.foreignAssets.ApprovedTransfer.is`
 - **summary**:    (Additional) funds have been approved for transfer to a destination account. 
  
-### AssetFrozen(`StagingXcmV4Location`)
+### AssetFrozen(`StagingXcmV5Location`)
 - **interface**: `api.events.foreignAssets.AssetFrozen.is`
 - **summary**:    Some asset `asset_id` was frozen. 
  
-### AssetMinBalanceChanged(`StagingXcmV4Location`, `u128`)
+### AssetMinBalanceChanged(`StagingXcmV5Location`, `u128`)
 - **interface**: `api.events.foreignAssets.AssetMinBalanceChanged.is`
 - **summary**:    The min_balance of an asset has been updated by the asset owner. 
  
-### AssetStatusChanged(`StagingXcmV4Location`)
+### AssetStatusChanged(`StagingXcmV5Location`)
 - **interface**: `api.events.foreignAssets.AssetStatusChanged.is`
 - **summary**:    An asset has had its attributes changed by the `Force` origin. 
  
-### AssetThawed(`StagingXcmV4Location`)
+### AssetThawed(`StagingXcmV5Location`)
 - **interface**: `api.events.foreignAssets.AssetThawed.is`
 - **summary**:    Some asset `asset_id` was thawed. 
  
-### Blocked(`StagingXcmV4Location`, `AccountId32`)
+### Blocked(`StagingXcmV5Location`, `AccountId32`)
 - **interface**: `api.events.foreignAssets.Blocked.is`
 - **summary**:    Some account `who` was blocked. 
  
-### Burned(`StagingXcmV4Location`, `AccountId32`, `u128`)
+### Burned(`StagingXcmV5Location`, `AccountId32`, `u128`)
 - **interface**: `api.events.foreignAssets.Burned.is`
 - **summary**:    Some assets were destroyed. 
  
-### Created(`StagingXcmV4Location`, `AccountId32`, `AccountId32`)
+### Created(`StagingXcmV5Location`, `AccountId32`, `AccountId32`)
 - **interface**: `api.events.foreignAssets.Created.is`
 - **summary**:    Some asset class was created. 
  
-### Deposited(`StagingXcmV4Location`, `AccountId32`, `u128`)
+### Deposited(`StagingXcmV5Location`, `AccountId32`, `u128`)
 - **interface**: `api.events.foreignAssets.Deposited.is`
 - **summary**:    Some assets were deposited (e.g. for transaction fees). 
  
-### Destroyed(`StagingXcmV4Location`)
+### Destroyed(`StagingXcmV5Location`)
 - **interface**: `api.events.foreignAssets.Destroyed.is`
 - **summary**:    An asset class was destroyed. 
  
-### DestructionStarted(`StagingXcmV4Location`)
+### DestructionStarted(`StagingXcmV5Location`)
 - **interface**: `api.events.foreignAssets.DestructionStarted.is`
 - **summary**:    An asset class is in the process of being destroyed. 
  
-### ForceCreated(`StagingXcmV4Location`, `AccountId32`)
+### ForceCreated(`StagingXcmV5Location`, `AccountId32`)
 - **interface**: `api.events.foreignAssets.ForceCreated.is`
 - **summary**:    Some asset class was force-created. 
  
-### Frozen(`StagingXcmV4Location`, `AccountId32`)
+### Frozen(`StagingXcmV5Location`, `AccountId32`)
 - **interface**: `api.events.foreignAssets.Frozen.is`
 - **summary**:    Some account `who` was frozen. 
  
-### Issued(`StagingXcmV4Location`, `AccountId32`, `u128`)
+### Issued(`StagingXcmV5Location`, `AccountId32`, `u128`)
 - **interface**: `api.events.foreignAssets.Issued.is`
 - **summary**:    Some assets were issued. 
  
-### MetadataCleared(`StagingXcmV4Location`)
+### MetadataCleared(`StagingXcmV5Location`)
 - **interface**: `api.events.foreignAssets.MetadataCleared.is`
 - **summary**:    Metadata has been cleared for an asset. 
  
-### MetadataSet(`StagingXcmV4Location`, `Bytes`, `Bytes`, `u8`, `bool`)
+### MetadataSet(`StagingXcmV5Location`, `Bytes`, `Bytes`, `u8`, `bool`)
 - **interface**: `api.events.foreignAssets.MetadataSet.is`
 - **summary**:    New metadata has been set for an asset. 
  
-### OwnerChanged(`StagingXcmV4Location`, `AccountId32`)
+### OwnerChanged(`StagingXcmV5Location`, `AccountId32`)
 - **interface**: `api.events.foreignAssets.OwnerChanged.is`
 - **summary**:    The owner changed. 
  
-### TeamChanged(`StagingXcmV4Location`, `AccountId32`, `AccountId32`, `AccountId32`)
+### TeamChanged(`StagingXcmV5Location`, `AccountId32`, `AccountId32`, `AccountId32`)
 - **interface**: `api.events.foreignAssets.TeamChanged.is`
 - **summary**:    The management team changed. 
  
-### Thawed(`StagingXcmV4Location`, `AccountId32`)
+### Thawed(`StagingXcmV5Location`, `AccountId32`)
 - **interface**: `api.events.foreignAssets.Thawed.is`
 - **summary**:    Some account `who` was thawed. 
  
-### Touched(`StagingXcmV4Location`, `AccountId32`, `AccountId32`)
+### Touched(`StagingXcmV5Location`, `AccountId32`, `AccountId32`)
 - **interface**: `api.events.foreignAssets.Touched.is`
 - **summary**:    Some account `who` was created with a deposit from `depositor`. 
  
-### Transferred(`StagingXcmV4Location`, `AccountId32`, `AccountId32`, `u128`)
+### Transferred(`StagingXcmV5Location`, `AccountId32`, `AccountId32`, `u128`)
 - **interface**: `api.events.foreignAssets.Transferred.is`
 - **summary**:    Some assets were transferred. 
  
-### TransferredApproved(`StagingXcmV4Location`, `AccountId32`, `AccountId32`, `AccountId32`, `u128`)
+### TransferredApproved(`StagingXcmV5Location`, `AccountId32`, `AccountId32`, `AccountId32`, `u128`)
 - **interface**: `api.events.foreignAssets.TransferredApproved.is`
 - **summary**:    An `amount` was transferred in its entirety from `owner` to `destination` by  the approved `delegate`. 
  
-### Withdrawn(`StagingXcmV4Location`, `AccountId32`, `u128`)
+### Withdrawn(`StagingXcmV5Location`, `AccountId32`, `u128`)
 - **interface**: `api.events.foreignAssets.Withdrawn.is`
 - **summary**:    Some assets were withdrawn from the account (e.g. for transaction fees). 
+
+___
+
+
+## indices
+ 
+### DepositPoked(`AccountId32`, `u32`, `u128`, `u128`)
+- **interface**: `api.events.indices.DepositPoked.is`
+- **summary**:    A deposit to reserve an index has been poked/reconsidered. 
+ 
+### IndexAssigned(`AccountId32`, `u32`)
+- **interface**: `api.events.indices.IndexAssigned.is`
+- **summary**:    A account index was assigned. 
+ 
+### IndexFreed(`u32`)
+- **interface**: `api.events.indices.IndexFreed.is`
+- **summary**:    A account index has been freed up (unassigned). 
+ 
+### IndexFrozen(`u32`, `AccountId32`)
+- **interface**: `api.events.indices.IndexFrozen.is`
+- **summary**:    A account index has been frozen to its current account ID. 
 
 ___
 
@@ -488,6 +790,75 @@ ___
 ### ProcessingFailed(`H256`, `CumulusPrimitivesCoreAggregateMessageOrigin`, `FrameSupportMessagesProcessMessageError`)
 - **interface**: `api.events.messageQueue.ProcessingFailed.is`
 - **summary**:    Message discarded due to an error in the `MessageProcessor` (usually a format error). 
+
+___
+
+
+## multiBlockElection
+ 
+### PhaseTransitioned(`PalletElectionProviderMultiBlockPhase`, `PalletElectionProviderMultiBlockPhase`)
+- **interface**: `api.events.multiBlockElection.PhaseTransitioned.is`
+- **summary**:    A phase transition happened. Only checks major changes in the variants, not minor inner  values. 
+ 
+### UnexpectedTargetSnapshotFailed()
+- **interface**: `api.events.multiBlockElection.UnexpectedTargetSnapshotFailed.is`
+- **summary**:    Target snapshot creation failed 
+ 
+### UnexpectedVoterSnapshotFailed()
+- **interface**: `api.events.multiBlockElection.UnexpectedVoterSnapshotFailed.is`
+- **summary**:    Voter snapshot creation failed 
+
+___
+
+
+## multiBlockElectionSigned
+ 
+### Bailed(`u32`, `AccountId32`)
+- **interface**: `api.events.multiBlockElectionSigned.Bailed.is`
+- **summary**:    The given account has bailed. 
+ 
+### Discarded(`u32`, `AccountId32`)
+- **interface**: `api.events.multiBlockElectionSigned.Discarded.is`
+- **summary**:    The given account has been discarded. 
+ 
+### Ejected(`u32`, `AccountId32`)
+- **interface**: `api.events.multiBlockElectionSigned.Ejected.is`
+- **summary**:    The given solution, for the given round, was ejected. 
+ 
+### Registered(`u32`, `AccountId32`, `SpNposElectionsElectionScore`)
+- **interface**: `api.events.multiBlockElectionSigned.Registered.is`
+- **summary**:    Upcoming submission has been registered for the given account, with the given score. 
+ 
+### Rewarded(`u32`, `AccountId32`, `u128`)
+- **interface**: `api.events.multiBlockElectionSigned.Rewarded.is`
+- **summary**:    The given account has been rewarded with the given amount. 
+ 
+### Slashed(`u32`, `AccountId32`, `u128`)
+- **interface**: `api.events.multiBlockElectionSigned.Slashed.is`
+- **summary**:    The given account has been slashed with the given amount. 
+ 
+### Stored(`u32`, `AccountId32`, `u32`)
+- **interface**: `api.events.multiBlockElectionSigned.Stored.is`
+- **summary**:    A page of solution solution with the given index has been stored for the given account. 
+
+___
+
+
+## multiBlockElectionVerifier
+ 
+### Queued(`SpNposElectionsElectionScore`, `Option<SpNposElectionsElectionScore>`)
+- **interface**: `api.events.multiBlockElectionVerifier.Queued.is`
+- **summary**:    A solution with the given score has replaced our current best solution. 
+ 
+### VerificationFailed(`u32`, `PalletElectionProviderMultiBlockVerifierFeasibilityError`)
+- **interface**: `api.events.multiBlockElectionVerifier.VerificationFailed.is`
+- **summary**:    A verification failed at the given page. 
+
+   NOTE: if the index is 0, then this could mean either the feasibility of the last page  was wrong, or the final checks of `finalize_verification` failed. 
+ 
+### Verified(`u32`, `u32`)
+- **interface**: `api.events.multiBlockElectionVerifier.Verified.is`
+- **summary**:    The given page of a solution has been verified, with the given number of winners being  found in it. 
 
 ___
 
@@ -674,6 +1045,115 @@ ___
 ___
 
 
+## nominationPools
+ 
+### Bonded(`AccountId32`, `u32`, `u128`, `bool`)
+- **interface**: `api.events.nominationPools.Bonded.is`
+- **summary**:    A member has became bonded in a pool. 
+ 
+### Created(`AccountId32`, `u32`)
+- **interface**: `api.events.nominationPools.Created.is`
+- **summary**:    A pool has been created. 
+ 
+### Destroyed(`u32`)
+- **interface**: `api.events.nominationPools.Destroyed.is`
+- **summary**:    A pool has been destroyed. 
+ 
+### GlobalParamsUpdated(`u128`, `u128`, `Option<u32>`, `Option<u32>`, `Option<u32>`, `Option<Perbill>`)
+- **interface**: `api.events.nominationPools.GlobalParamsUpdated.is`
+- **summary**:    Global parameters regulating nomination pools have been updated. 
+ 
+### MemberClaimPermissionUpdated(`AccountId32`, `PalletNominationPoolsClaimPermission`)
+- **interface**: `api.events.nominationPools.MemberClaimPermissionUpdated.is`
+- **summary**:    A pool member's claim permission has been updated. 
+ 
+### MemberRemoved(`u32`, `AccountId32`, `u128`)
+- **interface**: `api.events.nominationPools.MemberRemoved.is`
+- **summary**:    A member has been removed from a pool. 
+
+   The removal can be voluntary (withdrawn all unbonded funds) or involuntary (kicked).  Any funds that are still delegated (i.e. dangling delegation) are released and are  represented by `released_balance`. 
+ 
+### MetadataUpdated(`u32`, `AccountId32`)
+- **interface**: `api.events.nominationPools.MetadataUpdated.is`
+- **summary**:    A pool's metadata was updated. 
+ 
+### MinBalanceDeficitAdjusted(`u32`, `u128`)
+- **interface**: `api.events.nominationPools.MinBalanceDeficitAdjusted.is`
+- **summary**:    Topped up deficit in frozen ED of the reward pool. 
+ 
+### MinBalanceExcessAdjusted(`u32`, `u128`)
+- **interface**: `api.events.nominationPools.MinBalanceExcessAdjusted.is`
+- **summary**:    Claimed excess frozen ED of af the reward pool. 
+ 
+### PaidOut(`AccountId32`, `u32`, `u128`)
+- **interface**: `api.events.nominationPools.PaidOut.is`
+- **summary**:    A payout has been made to a member. 
+ 
+### PoolCommissionChangeRateUpdated(`u32`, `PalletNominationPoolsCommissionChangeRate`)
+- **interface**: `api.events.nominationPools.PoolCommissionChangeRateUpdated.is`
+- **summary**:    A pool's commission `change_rate` has been changed. 
+ 
+### PoolCommissionClaimed(`u32`, `u128`)
+- **interface**: `api.events.nominationPools.PoolCommissionClaimed.is`
+- **summary**:    Pool commission has been claimed. 
+ 
+### PoolCommissionClaimPermissionUpdated(`u32`, `Option<PalletNominationPoolsCommissionClaimPermission>`)
+- **interface**: `api.events.nominationPools.PoolCommissionClaimPermissionUpdated.is`
+- **summary**:    Pool commission claim permission has been updated. 
+ 
+### PoolCommissionUpdated(`u32`, `Option<(Perbill,AccountId32)>`)
+- **interface**: `api.events.nominationPools.PoolCommissionUpdated.is`
+- **summary**:    A pool's commission setting has been changed. 
+ 
+### PoolMaxCommissionUpdated(`u32`, `Perbill`)
+- **interface**: `api.events.nominationPools.PoolMaxCommissionUpdated.is`
+- **summary**:    A pool's maximum commission setting has been changed. 
+ 
+### PoolNominationMade(`u32`, `AccountId32`)
+- **interface**: `api.events.nominationPools.PoolNominationMade.is`
+- **summary**:    A pool's nominating account (or the pool's root account) has nominated a validator set  on behalf of the pool. 
+ 
+### PoolNominatorChilled(`u32`, `AccountId32`)
+- **interface**: `api.events.nominationPools.PoolNominatorChilled.is`
+- **summary**:    The pool is chilled i.e. no longer nominating. 
+ 
+### PoolSlashed(`u32`, `u128`)
+- **interface**: `api.events.nominationPools.PoolSlashed.is`
+- **summary**:    The active balance of pool `pool_id` has been slashed to `balance`. 
+ 
+### RolesUpdated(`Option<AccountId32>`, `Option<AccountId32>`, `Option<AccountId32>`)
+- **interface**: `api.events.nominationPools.RolesUpdated.is`
+- **summary**:    The roles of a pool have been updated to the given new roles. Note that the depositor  can never change. 
+ 
+### StateChanged(`u32`, `PalletNominationPoolsPoolState`)
+- **interface**: `api.events.nominationPools.StateChanged.is`
+- **summary**:    The state of a pool has changed 
+ 
+### Unbonded(`AccountId32`, `u32`, `u128`, `u128`, `u32`)
+- **interface**: `api.events.nominationPools.Unbonded.is`
+- **summary**:    A member has unbonded from their pool. 
+
+   - `balance` is the corresponding balance of the number of points that has been  requested to be unbonded (the argument of the `unbond` transaction) from the bonded  pool. 
+
+  - `points` is the number of points that are issued as a result of `balance` being dissolved into the corresponding unbonding pool. 
+
+  - `era` is the era in which the balance will be unbonded. In the absence of slashing, these values will match. In the presence of slashing, the  number of points that are issued in the unbonding pool will be less than the amount  requested to be unbonded. 
+ 
+### UnbondingPoolSlashed(`u32`, `u32`, `u128`)
+- **interface**: `api.events.nominationPools.UnbondingPoolSlashed.is`
+- **summary**:    The unbond pool at `era` of pool `pool_id` has been slashed to `balance`. 
+ 
+### Withdrawn(`AccountId32`, `u32`, `u128`, `u128`)
+- **interface**: `api.events.nominationPools.Withdrawn.is`
+- **summary**:    A member has withdrawn from their pool. 
+
+   The given number of `points` have been dissolved in return of `balance`. 
+
+   Similar to `Unbonded` event, in the absence of slashing, the ratio of point to balance  will be 1. 
+
+___
+
+
 ## parachainSystem
  
 ### DownwardMessagesProcessed(`SpWeightsWeightV2Weight`, `H256`)
@@ -699,6 +1179,17 @@ ___
 ### ValidationFunctionStored()
 - **interface**: `api.events.parachainSystem.ValidationFunctionStored.is`
 - **summary**:    The validation function has been scheduled to apply. 
+
+___
+
+
+## parameters
+ 
+### Updated(`AssetHubPolkadotRuntimeRuntimeParametersKey`, `Option<AssetHubPolkadotRuntimeRuntimeParametersValue>`, `Option<AssetHubPolkadotRuntimeRuntimeParametersValue>`)
+- **interface**: `api.events.parameters.Updated.is`
+- **summary**:    A Parameter was set. 
+
+   Is also emitted when the value was not changed. 
 
 ___
 
@@ -939,6 +1430,23 @@ ___
 ___
 
 
+## preimage
+ 
+### Cleared(`H256`)
+- **interface**: `api.events.preimage.Cleared.is`
+- **summary**:    A preimage has ben cleared. 
+ 
+### Noted(`H256`)
+- **interface**: `api.events.preimage.Noted.is`
+- **summary**:    A preimage has been noted. 
+ 
+### Requested(`H256`)
+- **interface**: `api.events.preimage.Requested.is`
+- **summary**:    A preimage has been requested. 
+
+___
+
+
 ## proxy
  
 ### Announced(`AccountId32`, `AccountId32`, `H256`)
@@ -964,11 +1472,131 @@ ___
 ### PureCreated(`AccountId32`, `AccountId32`, `AssetHubPolkadotRuntimeProxyType`, `u16`)
 - **interface**: `api.events.proxy.PureCreated.is`
 - **summary**:    A pure account has been created by new proxy with given  disambiguation index and proxy type. 
+ 
+### PureKilled(`AccountId32`, `AccountId32`, `AssetHubPolkadotRuntimeProxyType`, `u16`)
+- **interface**: `api.events.proxy.PureKilled.is`
+- **summary**:    A pure proxy was killed by its spawner. 
+
+___
+
+
+## referenda
+ 
+### Approved(`u32`)
+- **interface**: `api.events.referenda.Approved.is`
+- **summary**:    A referendum has been approved and its proposal has been scheduled. 
+ 
+### Cancelled(`u32`, `PalletConvictionVotingTally`)
+- **interface**: `api.events.referenda.Cancelled.is`
+- **summary**:    A referendum has been cancelled. 
+ 
+### ConfirmAborted(`u32`)
+- **interface**: `api.events.referenda.ConfirmAborted.is`
+ 
+### Confirmed(`u32`, `PalletConvictionVotingTally`)
+- **interface**: `api.events.referenda.Confirmed.is`
+- **summary**:    A referendum has ended its confirmation phase and is ready for approval. 
+ 
+### ConfirmStarted(`u32`)
+- **interface**: `api.events.referenda.ConfirmStarted.is`
+ 
+### DecisionDepositPlaced(`u32`, `AccountId32`, `u128`)
+- **interface**: `api.events.referenda.DecisionDepositPlaced.is`
+- **summary**:    The decision deposit has been placed. 
+ 
+### DecisionDepositRefunded(`u32`, `AccountId32`, `u128`)
+- **interface**: `api.events.referenda.DecisionDepositRefunded.is`
+- **summary**:    The decision deposit has been refunded. 
+ 
+### DecisionStarted(`u32`, `u16`, `FrameSupportPreimagesBounded`, `PalletConvictionVotingTally`)
+- **interface**: `api.events.referenda.DecisionStarted.is`
+- **summary**:    A referendum has moved into the deciding phase. 
+ 
+### DepositSlashed(`AccountId32`, `u128`)
+- **interface**: `api.events.referenda.DepositSlashed.is`
+- **summary**:    A deposit has been slashed. 
+ 
+### Killed(`u32`, `PalletConvictionVotingTally`)
+- **interface**: `api.events.referenda.Killed.is`
+- **summary**:    A referendum has been killed. 
+ 
+### MetadataCleared(`u32`, `H256`)
+- **interface**: `api.events.referenda.MetadataCleared.is`
+- **summary**:    Metadata for a referendum has been cleared. 
+ 
+### MetadataSet(`u32`, `H256`)
+- **interface**: `api.events.referenda.MetadataSet.is`
+- **summary**:    Metadata for a referendum has been set. 
+ 
+### Rejected(`u32`, `PalletConvictionVotingTally`)
+- **interface**: `api.events.referenda.Rejected.is`
+- **summary**:    A proposal has been rejected by referendum. 
+ 
+### SubmissionDepositRefunded(`u32`, `AccountId32`, `u128`)
+- **interface**: `api.events.referenda.SubmissionDepositRefunded.is`
+- **summary**:    The submission deposit has been refunded. 
+ 
+### Submitted(`u32`, `u16`, `FrameSupportPreimagesBounded`)
+- **interface**: `api.events.referenda.Submitted.is`
+- **summary**:    A referendum has been submitted. 
+ 
+### TimedOut(`u32`, `PalletConvictionVotingTally`)
+- **interface**: `api.events.referenda.TimedOut.is`
+- **summary**:    A referendum has been timed out without being decided. 
+
+___
+
+
+## scheduler
+ 
+### AgendaIncomplete(`u32`)
+- **interface**: `api.events.scheduler.AgendaIncomplete.is`
+- **summary**:    Agenda is incomplete from `when`. 
+ 
+### CallUnavailable(`(u32,u32)`, `Option<[u8;32]>`)
+- **interface**: `api.events.scheduler.CallUnavailable.is`
+- **summary**:    The call for the provided hash was not found so the task has been aborted. 
+ 
+### Canceled(`u32`, `u32`)
+- **interface**: `api.events.scheduler.Canceled.is`
+- **summary**:    Canceled some task. 
+ 
+### Dispatched(`(u32,u32)`, `Option<[u8;32]>`, `Result<Null, SpRuntimeDispatchError>`)
+- **interface**: `api.events.scheduler.Dispatched.is`
+- **summary**:    Dispatched some task. 
+ 
+### PeriodicFailed(`(u32,u32)`, `Option<[u8;32]>`)
+- **interface**: `api.events.scheduler.PeriodicFailed.is`
+- **summary**:    The given task was unable to be renewed since the agenda is full at that block. 
+ 
+### PermanentlyOverweight(`(u32,u32)`, `Option<[u8;32]>`)
+- **interface**: `api.events.scheduler.PermanentlyOverweight.is`
+- **summary**:    The given task can never be executed since it is overweight. 
+ 
+### RetryCancelled(`(u32,u32)`, `Option<[u8;32]>`)
+- **interface**: `api.events.scheduler.RetryCancelled.is`
+- **summary**:    Cancel a retry configuration for some task. 
+ 
+### RetryFailed(`(u32,u32)`, `Option<[u8;32]>`)
+- **interface**: `api.events.scheduler.RetryFailed.is`
+- **summary**:    The given task was unable to be retried since the agenda is full at that block or there  was not enough weight to reschedule it. 
+ 
+### RetrySet(`(u32,u32)`, `Option<[u8;32]>`, `u32`, `u8`)
+- **interface**: `api.events.scheduler.RetrySet.is`
+- **summary**:    Set a retry configuration for some task. 
+ 
+### Scheduled(`u32`, `u32`)
+- **interface**: `api.events.scheduler.Scheduled.is`
+- **summary**:    Scheduled some task. 
 
 ___
 
 
 ## session
+ 
+### NewQueued()
+- **interface**: `api.events.session.NewQueued.is`
+- **summary**:    The `NewSession` event in the current block also implies a new validator set to be  queued. 
  
 ### NewSession(`u32`)
 - **interface**: `api.events.session.NewSession.is`
@@ -981,6 +1609,148 @@ ___
 ### ValidatorReenabled(`AccountId32`)
 - **interface**: `api.events.session.ValidatorReenabled.is`
 - **summary**:    Validator has been re-enabled. 
+
+___
+
+
+## snowbridgeSystemFrontend
+ 
+### ExportOperatingModeChanged(`SnowbridgeCoreOperatingModeBasicOperatingMode`)
+- **interface**: `api.events.snowbridgeSystemFrontend.ExportOperatingModeChanged.is`
+- **summary**:    Set OperatingMode 
+ 
+### MessageSent(`StagingXcmV5Location`, `StagingXcmV5Location`, `StagingXcmV5Xcm`, `[u8;32]`)
+- **interface**: `api.events.snowbridgeSystemFrontend.MessageSent.is`
+- **summary**:    An XCM was sent 
+
+___
+
+
+## staking
+ 
+### Bonded(`AccountId32`, `u128`)
+- **interface**: `api.events.staking.Bonded.is`
+- **summary**:    An account has bonded this amount. \[stash, amount\] 
+
+   NOTE: This event is only emitted when funds are bonded via a dispatchable. Notably,  it will not be emitted for staking rewards when they are added to stake. 
+ 
+### Chilled(`AccountId32`)
+- **interface**: `api.events.staking.Chilled.is`
+- **summary**:    An account has stopped participating as either a validator or nominator. 
+ 
+### ControllerBatchDeprecated(`u32`)
+- **interface**: `api.events.staking.ControllerBatchDeprecated.is`
+- **summary**:    Report of a controller batch deprecation. 
+ 
+### CurrencyMigrated(`AccountId32`, `u128`)
+- **interface**: `api.events.staking.CurrencyMigrated.is`
+- **summary**:    Staking balance migrated from locks to holds, with any balance that could not be held  is force withdrawn. 
+ 
+### EraPaid(`u32`, `u128`, `u128`)
+- **interface**: `api.events.staking.EraPaid.is`
+- **summary**:    The era payout has been set; the first balance is the validator-payout; the second is  the remainder from the maximum amount of reward. 
+ 
+### EraPruned(`u32`)
+- **interface**: `api.events.staking.EraPruned.is`
+- **summary**:    An old era with the given index was pruned. 
+ 
+### ForceEra(`PalletStakingAsyncForcing`)
+- **interface**: `api.events.staking.ForceEra.is`
+ 
+### Kicked(`AccountId32`, `AccountId32`)
+- **interface**: `api.events.staking.Kicked.is`
+- **summary**:    A nominator has been kicked from a validator. 
+ 
+### OffenceReported(`u32`, `AccountId32`, `Perbill`)
+- **interface**: `api.events.staking.OffenceReported.is`
+- **summary**:    An offence for the given validator, for the given percentage of their stake, at the  given era as been reported. 
+ 
+### OffenceTooOld(`u32`, `AccountId32`, `Perbill`)
+- **interface**: `api.events.staking.OffenceTooOld.is`
+- **summary**:    An offence was reported that was too old to be processed, and thus was dropped. 
+ 
+### OldSlashingReportDiscarded(`u32`)
+- **interface**: `api.events.staking.OldSlashingReportDiscarded.is`
+- **summary**:    An old slashing report from a prior era was discarded because it could  not be processed. 
+ 
+### PagedElectionProceeded(`u32`, `Result<u32, u32>`)
+- **interface**: `api.events.staking.PagedElectionProceeded.is`
+- **summary**:    A page from a multi-page election was fetched. A number of these are followed by  `StakersElected`. 
+
+   `Ok(count)` indicates the give number of stashes were added.  `Err(index)` indicates that the stashes after index were dropped.  `Err(0)` indicates that an error happened but no stashes were dropped nor added. 
+
+   The error indicates that a number of validators were dropped due to excess size, but  the overall election will continue. 
+ 
+### PayoutStarted(`u32`, `AccountId32`, `u32`, `Option<u32>`)
+- **interface**: `api.events.staking.PayoutStarted.is`
+- **summary**:    A Page of stakers rewards are getting paid. `next` is `None` if all pages are claimed. 
+ 
+### Rewarded(`AccountId32`, `PalletStakingAsyncRewardDestination`, `u128`)
+- **interface**: `api.events.staking.Rewarded.is`
+- **summary**:    The nominator has been rewarded by this amount to this destination. 
+ 
+### SessionRotated(`u32`, `u32`, `u32`)
+- **interface**: `api.events.staking.SessionRotated.is`
+- **summary**:    Session change has been triggered. 
+
+   If planned_era is one era ahead of active_era, it implies new era is being planned and  election is ongoing. 
+ 
+### SlashCancelled(`u32`, `AccountId32`)
+- **interface**: `api.events.staking.SlashCancelled.is`
+- **summary**:    An unapplied slash has been cancelled. 
+ 
+### SlashComputed(`u32`, `u32`, `AccountId32`, `u32`)
+- **interface**: `api.events.staking.SlashComputed.is`
+- **summary**:    An offence has been processed and the corresponding slash has been computed. 
+ 
+### Slashed(`AccountId32`, `u128`)
+- **interface**: `api.events.staking.Slashed.is`
+- **summary**:    A staker (validator or nominator) has been slashed by the given amount. 
+ 
+### SnapshotTargetsSizeExceeded(`u32`)
+- **interface**: `api.events.staking.SnapshotTargetsSizeExceeded.is`
+- **summary**:    Targets size limit reached. 
+ 
+### SnapshotVotersSizeExceeded(`u32`)
+- **interface**: `api.events.staking.SnapshotVotersSizeExceeded.is`
+- **summary**:    Voters size limit reached. 
+ 
+### StakerRemoved(`AccountId32`)
+- **interface**: `api.events.staking.StakerRemoved.is`
+- **summary**:    A subsequent event of `Withdrawn`, indicating that `stash` was fully removed from the  system. 
+ 
+### Unbonded(`AccountId32`, `u128`)
+- **interface**: `api.events.staking.Unbonded.is`
+- **summary**:    An account has unbonded this amount. 
+ 
+### Unexpected(`PalletStakingAsyncPalletUnexpectedKind`)
+- **interface**: `api.events.staking.Unexpected.is`
+- **summary**:    Something occurred that should never happen under normal operation.  Logged as an event for fail-safe observability. 
+ 
+### ValidatorPrefsSet(`AccountId32`, `PalletStakingAsyncValidatorPrefs`)
+- **interface**: `api.events.staking.ValidatorPrefsSet.is`
+- **summary**:    A validator has set their preferences. 
+ 
+### Withdrawn(`AccountId32`, `u128`)
+- **interface**: `api.events.staking.Withdrawn.is`
+- **summary**:    An account has called `withdraw_unbonded` and removed unbonding chunks worth `Balance`  from the unlocking queue. 
+
+___
+
+
+## stakingRcClient
+ 
+### OffenceReceived(`u32`, `u32`)
+- **interface**: `api.events.stakingRcClient.OffenceReceived.is`
+- **summary**:    A new offence was reported. 
+ 
+### SessionReportReceived(`u32`, `Option<(u64,u32)>`, `u32`, `bool`)
+- **interface**: `api.events.stakingRcClient.SessionReportReceived.is`
+- **summary**:    A said session report was received. 
+ 
+### Unexpected(`PalletStakingAsyncRcClientUnexpectedKind`)
+- **interface**: `api.events.stakingRcClient.Unexpected.is`
+- **summary**:    Something occurred that should never happen under normal operation.  Logged as an event for fail-safe observability. 
 
 ___
 
@@ -1036,6 +1806,18 @@ ___
 - **interface**: `api.events.system.Remarked.is`
 - **summary**:    On on-chain remark happened. 
  
+### TaskCompleted(`AssetHubPolkadotRuntimeRuntimeTask`)
+- **interface**: `api.events.system.TaskCompleted.is`
+- **summary**:    A [`Task`] has finished executing. 
+ 
+### TaskFailed(`AssetHubPolkadotRuntimeRuntimeTask`, `SpRuntimeDispatchError`)
+- **interface**: `api.events.system.TaskFailed.is`
+- **summary**:    A [`Task`] failed during execution. 
+ 
+### TaskStarted(`AssetHubPolkadotRuntimeRuntimeTask`)
+- **interface**: `api.events.system.TaskStarted.is`
+- **summary**:    A [`Task`] has started executing 
+ 
 ### UpgradeAuthorized(`H256`, `bool`)
 - **interface**: `api.events.system.UpgradeAuthorized.is`
 - **summary**:    An upgrade was authorized. 
@@ -1061,6 +1843,59 @@ ___
 ### TransactionFeePaid(`AccountId32`, `u128`, `u128`)
 - **interface**: `api.events.transactionPayment.TransactionFeePaid.is`
 - **summary**:    A transaction fee `actual_fee`, of which `tip` was added to the minimum inclusion fee,  has been paid by `who`. 
+
+___
+
+
+## treasury
+ 
+### AssetSpendApproved(`u32`, `PolkadotRuntimeCommonImplsVersionedLocatableAsset`, `u128`, `ParachainsCommonPayVersionedLocatableAccount`, `u32`, `u32`)
+- **interface**: `api.events.treasury.AssetSpendApproved.is`
+- **summary**:    A new asset spend proposal has been approved. 
+ 
+### AssetSpendVoided(`u32`)
+- **interface**: `api.events.treasury.AssetSpendVoided.is`
+- **summary**:    An approved spend was voided. 
+ 
+### Awarded(`u32`, `u128`, `AccountId32`)
+- **interface**: `api.events.treasury.Awarded.is`
+- **summary**:    Some funds have been allocated. 
+ 
+### Burnt(`u128`)
+- **interface**: `api.events.treasury.Burnt.is`
+- **summary**:    Some of our funds have been burnt. 
+ 
+### Deposit(`u128`)
+- **interface**: `api.events.treasury.Deposit.is`
+- **summary**:    Some funds have been deposited. 
+ 
+### Paid(`u32`, `u64`)
+- **interface**: `api.events.treasury.Paid.is`
+- **summary**:    A payment happened. 
+ 
+### PaymentFailed(`u32`, `u64`)
+- **interface**: `api.events.treasury.PaymentFailed.is`
+- **summary**:    A payment failed and can be retried. 
+ 
+### Rollover(`u128`)
+- **interface**: `api.events.treasury.Rollover.is`
+- **summary**:    Spending has finished; this is the amount that rolls over until next spend. 
+ 
+### SpendApproved(`u32`, `u128`, `AccountId32`)
+- **interface**: `api.events.treasury.SpendApproved.is`
+- **summary**:    A new spend proposal has been approved. 
+ 
+### Spending(`u128`)
+- **interface**: `api.events.treasury.Spending.is`
+- **summary**:    We have ended a spend period and will now allocate funds. 
+ 
+### SpendProcessed(`u32`)
+- **interface**: `api.events.treasury.SpendProcessed.is`
+- **summary**:    A spend was processed and removed from the storage. It might have been successfully  paid or it may have expired. 
+ 
+### UpdatedInactive(`u128`, `u128`)
+- **interface**: `api.events.treasury.UpdatedInactive.is`
+- **summary**:    The inactive funds of the pallet have been updated. 
 
 ___
 
@@ -1221,9 +2056,40 @@ ___
 - **interface**: `api.events.vesting.VestingCompleted.is`
 - **summary**:    An \[account\] has become fully vested. 
  
+### VestingCreated(`AccountId32`, `u32`)
+- **interface**: `api.events.vesting.VestingCreated.is`
+- **summary**:    A vesting schedule has been created. 
+ 
 ### VestingUpdated(`AccountId32`, `u128`)
 - **interface**: `api.events.vesting.VestingUpdated.is`
 - **summary**:    The amount vested has been updated. This could indicate a change in funds available.  The balance given is the amount which is left unvested (and thus locked). 
+
+___
+
+
+## voterList
+ 
+### Rebagged(`AccountId32`, `u64`, `u64`)
+- **interface**: `api.events.voterList.Rebagged.is`
+- **summary**:    Moved an account from one bag to another. 
+ 
+### ScoreUpdated(`AccountId32`, `u64`)
+- **interface**: `api.events.voterList.ScoreUpdated.is`
+- **summary**:    Updated the score of some account to the given amount. 
+
+___
+
+
+## whitelist
+ 
+### CallWhitelisted(`H256`)
+- **interface**: `api.events.whitelist.CallWhitelisted.is`
+ 
+### WhitelistedCallDispatched(`H256`, `Result<FrameSupportDispatchPostDispatchInfo, SpRuntimeDispatchErrorWithPostInfo>`)
+- **interface**: `api.events.whitelist.WhitelistedCallDispatched.is`
+ 
+### WhitelistedCallRemoved(`H256`)
+- **interface**: `api.events.whitelist.WhitelistedCallRemoved.is`
 
 ___
 

--- a/docs/asset-hub-polkadot/extrinsics.md
+++ b/docs/asset-hub-polkadot/extrinsics.md
@@ -6,35 +6,75 @@ The following sections contain Extrinsics methods are part of the default asset-
 
 (NOTE: These were generated from a static/snapshot view of a recent default asset-hub-polkadot runtime. Some items may not be available in older nodes, or in any customized implementations.)
 
+- **[ahMigrator](#ahmigrator)**
+
+- **[ahOps](#ahops)**
+
 - **[assetConversion](#assetconversion)**
+
+- **[assetRate](#assetrate)**
 
 - **[assets](#assets)**
 
 - **[balances](#balances)**
 
+- **[bounties](#bounties)**
+
+- **[childBounties](#childbounties)**
+
+- **[claims](#claims)**
+
 - **[collatorSelection](#collatorselection)**
+
+- **[convictionVoting](#convictionvoting)**
 
 - **[cumulusXcm](#cumulusxcm)**
 
 - **[foreignAssets](#foreignassets)**
 
+- **[indices](#indices)**
+
 - **[messageQueue](#messagequeue)**
+
+- **[multiBlockElection](#multiblockelection)**
+
+- **[multiBlockElectionSigned](#multiblockelectionsigned)**
+
+- **[multiBlockElectionUnsigned](#multiblockelectionunsigned)**
+
+- **[multiBlockElectionVerifier](#multiblockelectionverifier)**
 
 - **[multisig](#multisig)**
 
 - **[nfts](#nfts)**
 
+- **[nominationPools](#nominationpools)**
+
 - **[parachainInfo](#parachaininfo)**
 
 - **[parachainSystem](#parachainsystem)**
+
+- **[parameters](#parameters)**
 
 - **[polkadotXcm](#polkadotxcm)**
 
 - **[poolAssets](#poolassets)**
 
+- **[preimage](#preimage)**
+
 - **[proxy](#proxy)**
 
+- **[referenda](#referenda)**
+
+- **[scheduler](#scheduler)**
+
 - **[session](#session)**
+
+- **[snowbridgeSystemFrontend](#snowbridgesystemfrontend)**
+
+- **[staking](#staking)**
+
+- **[stakingRcClient](#stakingrcclient)**
 
 - **[stateTrieMigration](#statetriemigration)**
 
@@ -44,11 +84,17 @@ The following sections contain Extrinsics methods are part of the default asset-
 
 - **[toKusamaXcmRouter](#tokusamaxcmrouter)**
 
+- **[treasury](#treasury)**
+
 - **[uniques](#uniques)**
 
 - **[utility](#utility)**
 
 - **[vesting](#vesting)**
+
+- **[voterList](#voterlist)**
+
+- **[whitelist](#whitelist)**
 
 - **[xcmpQueue](#xcmpqueue)**
 
@@ -56,9 +102,178 @@ The following sections contain Extrinsics methods are part of the default asset-
 ___
 
 
+## ahMigrator
+ 
+### finishMigration(data: `Option<PalletRcMigratorMigrationFinishedData>`, cool_off_end_at: `u32`)
+- **interface**: `api.tx.ahMigrator.finishMigration`
+- **summary**:    Finish the migration. 
+
+   This is typically called by the Relay Chain to signal the migration has finished. 
+
+   The `data` parameter might be `None` if we are running the migration for a second time  for some pallets and have already performed the checking account balance correction,  so we do not need to do it this time. 
+ 
+### forceSetStage(stage: `PalletAhMigratorMigrationStage`)
+- **interface**: `api.tx.ahMigrator.forceSetStage`
+- **summary**:    Set the migration stage. 
+
+   This call is intended for emergency use only and is guarded by the  [`Config::AdminOrigin`]. 
+ 
+### receiveAccounts(accounts: `Vec<PalletRcMigratorAccountsAccount>`)
+- **interface**: `api.tx.ahMigrator.receiveAccounts`
+- **summary**:    Receive accounts from the Relay Chain. 
+
+   The accounts sent with `pallet_rc_migrator::Pallet::migrate_accounts` function. 
+ 
+### receiveAssetRates(rates: `Vec<(PolkadotRuntimeCommonImplsVersionedLocatableAsset,u128)>`)
+- **interface**: `api.tx.ahMigrator.receiveAssetRates`
+ 
+### receiveBagsListMessages(messages: `Vec<PalletRcMigratorStakingBagsListPortableBagsListMessage>`)
+- **interface**: `api.tx.ahMigrator.receiveBagsListMessages`
+ 
+### receiveBountiesMessages(messages: `Vec<PalletRcMigratorBountiesRcBountiesMessage>`)
+- **interface**: `api.tx.ahMigrator.receiveBountiesMessages`
+ 
+### receiveChildBountiesMessages(messages: `Vec<PalletRcMigratorChildBountiesPortableChildBountiesMessage>`)
+- **interface**: `api.tx.ahMigrator.receiveChildBountiesMessages`
+ 
+### receiveClaims(messages: `Vec<PalletRcMigratorClaimsRcClaimsMessage>`)
+- **interface**: `api.tx.ahMigrator.receiveClaims`
+ 
+### receiveConvictionVotingMessages(messages: `Vec<PalletRcMigratorConvictionVotingRcConvictionVotingMessage>`)
+- **interface**: `api.tx.ahMigrator.receiveConvictionVotingMessages`
+ 
+### receiveCrowdloanMessages(messages: `Vec<PalletRcMigratorCrowdloanRcCrowdloanMessage>`)
+- **interface**: `api.tx.ahMigrator.receiveCrowdloanMessages`
+ 
+### receiveDelegatedStakingMessages(messages: `Vec<PalletRcMigratorStakingDelegatedStakingPortableDelegatedStakingMessage>`)
+- **interface**: `api.tx.ahMigrator.receiveDelegatedStakingMessages`
+ 
+### receiveIndices(indices: `Vec<PalletRcMigratorIndicesRcIndicesIndex>`)
+- **interface**: `api.tx.ahMigrator.receiveIndices`
+ 
+### receiveMultisigs(accounts: `Vec<PalletRcMigratorMultisigRcMultisig>`)
+- **interface**: `api.tx.ahMigrator.receiveMultisigs`
+- **summary**:    Receive multisigs from the Relay Chain. 
+
+   This will be called from an XCM `Transact` inside a DMP from the relay chain. The  multisigs were prepared by  `pallet_rc_migrator::multisig::MultisigMigrator::migrate_many`. 
+ 
+### receiveNomPoolsMessages(messages: `Vec<PalletRcMigratorStakingNomPoolsRcNomPoolsMessage>`)
+- **interface**: `api.tx.ahMigrator.receiveNomPoolsMessages`
+ 
+### receivePreimageChunks(chunks: `Vec<PalletRcMigratorPreimageChunksRcPreimageChunk>`)
+- **interface**: `api.tx.ahMigrator.receivePreimageChunks`
+ 
+### receivePreimageLegacyStatus(legacy_status: `Vec<PalletRcMigratorPreimageLegacyRequestStatusRcPreimageLegacyStatus>`)
+- **interface**: `api.tx.ahMigrator.receivePreimageLegacyStatus`
+ 
+### receivePreimageRequestStatus(request_status: `Vec<PalletRcMigratorPreimageRequestStatusPortableRequestStatus>`)
+- **interface**: `api.tx.ahMigrator.receivePreimageRequestStatus`
+ 
+### receiveProxyAnnouncements(announcements: `Vec<PalletRcMigratorProxyRcProxyAnnouncement>`)
+- **interface**: `api.tx.ahMigrator.receiveProxyAnnouncements`
+- **summary**:    Receive proxy announcements from the Relay Chain. 
+ 
+### receiveProxyProxies(proxies: `Vec<PalletRcMigratorProxyRcProxy>`)
+- **interface**: `api.tx.ahMigrator.receiveProxyProxies`
+- **summary**:    Receive proxies from the Relay Chain. 
+ 
+### receiveReferendaMetadata(metadata: `Vec<(u32,H256)>`)
+- **interface**: `api.tx.ahMigrator.receiveReferendaMetadata`
+ 
+### receiveReferendaValues(values: `Vec<PalletRcMigratorReferendaReferendaMessage>`)
+- **interface**: `api.tx.ahMigrator.receiveReferendaValues`
+- **summary**:    Receive referendum counts, deciding counts, votes for the track queue. 
+ 
+### receiveReferendums(referendums: `Vec<(u32,PalletReferendaReferendumInfoRcPalletsOrigin)>`)
+- **interface**: `api.tx.ahMigrator.receiveReferendums`
+- **summary**:    Receive referendums from the Relay Chain. 
+ 
+### receiveSchedulerAgendaMessages(messages: `Vec<PalletRcMigratorSchedulerSchedulerAgendaMessage>`)
+- **interface**: `api.tx.ahMigrator.receiveSchedulerAgendaMessages`
+ 
+### receiveSchedulerMessages(messages: `Vec<PalletRcMigratorSchedulerRcSchedulerMessage>`)
+- **interface**: `api.tx.ahMigrator.receiveSchedulerMessages`
+ 
+### receiveStakingMessages(messages: `Vec<PalletRcMigratorStakingMessagePortableStakingMessage>`)
+- **interface**: `api.tx.ahMigrator.receiveStakingMessages`
+ 
+### receiveTreasuryMessages(messages: `Vec<PalletRcMigratorTreasuryPortableTreasuryMessage>`)
+- **interface**: `api.tx.ahMigrator.receiveTreasuryMessages`
+ 
+### receiveVestingSchedules(schedules: `Vec<PalletRcMigratorVestingRcVestingSchedule>`)
+- **interface**: `api.tx.ahMigrator.receiveVestingSchedules`
+ 
+### sendXcmMessage(dest: `XcmVersionedLocation`, message: `XcmVersionedXcm`)
+- **interface**: `api.tx.ahMigrator.sendXcmMessage`
+- **summary**:    XCM send call identical to the [`pallet_xcm::Pallet::send`] call but with the  [Config::SendXcm] router which will be able to send messages to the Relay Chain during  the migration. 
+ 
+### setDmpQueuePriority(new: `PalletRcMigratorQueuePriority`)
+- **interface**: `api.tx.ahMigrator.setDmpQueuePriority`
+- **summary**:    Set the DMP queue priority configuration. 
+
+   Can only be called by the `AdminOrigin`. 
+ 
+### setManager(new: `Option<AccountId32>`)
+- **interface**: `api.tx.ahMigrator.setManager`
+- **summary**:    Set the manager account id. 
+
+   The manager has the similar to [`Config::AdminOrigin`] privileges except that it  can not set the manager account id via `set_manager` call. 
+ 
+### startMigration()
+- **interface**: `api.tx.ahMigrator.startMigration`
+- **summary**:    Start the data migration. 
+
+   This is typically called by the Relay Chain to start the migration on the Asset Hub and  receive a handshake message indicating the Asset Hub's readiness. 
+
+___
+
+
+## ahOps
+ 
+### transferToPostMigrationTreasury(asset_id: `StagingXcmV5Location`)
+- **interface**: `api.tx.ahOps.transferToPostMigrationTreasury`
+- **summary**:    Transfer the balance from the pre-migration treasury account to the post-migration  treasury account. 
+
+   This call can only be called after the migration is completed. 
+ 
+### unreserveCrowdloanReserve(block: `u32`, depositor: `Option<AccountId32>`, para_id: `u32`)
+- **interface**: `api.tx.ahOps.unreserveCrowdloanReserve`
+- **summary**:    Unreserve the deposit that was taken for creating a crowdloan. 
+
+   This can be called once either: 
+
+  - The crowdloan failed to win an auction and timed out
+
+  - Won an auction, all leases expired and all contributions are withdrawn
+
+   Can be called by any signed origin. The condition that all contributions are withdrawn  is in place since the reserve acts as a storage deposit. 
+ 
+### unreserveLeaseDeposit(block: `u32`, depositor: `Option<AccountId32>`, para_id: `u32`)
+- **interface**: `api.tx.ahOps.unreserveLeaseDeposit`
+- **summary**:    Unreserve the deposit that was taken for creating a crowdloan. 
+
+   This can be called by any signed origin. It unreserves the lease deposit on the account  that won the lease auction. It can be unreserved once all leases expired. Note that it  will be called automatically from `withdraw_crowdloan_contribution` for the matching  crowdloan account. 
+
+   Solo bidder accounts that won lease auctions can use this to unreserve their amount. 
+ 
+### withdrawCrowdloanContribution(block: `u32`, depositor: `Option<AccountId32>`, para_id: `u32`)
+- **interface**: `api.tx.ahOps.withdrawCrowdloanContribution`
+- **summary**:    Withdraw the contribution of a finished crowdloan. 
+
+   A crowdloan contribution can be withdrawn if either: 
+
+  - The crowdloan failed to in an auction and timed out
+
+  - Won an auction and all leases expired
+
+   Can be called by any signed origin. 
+
+___
+
+
 ## assetConversion
  
-### addLiquidity(asset1: `StagingXcmV4Location`, asset2: `StagingXcmV4Location`, amount1_desired: `u128`, amount2_desired: `u128`, amount1_min: `u128`, amount2_min: `u128`, mint_to: `AccountId32`)
+### addLiquidity(asset1: `StagingXcmV5Location`, asset2: `StagingXcmV5Location`, amount1_desired: `u128`, amount2_desired: `u128`, amount1_min: `u128`, amount2_min: `u128`, mint_to: `AccountId32`)
 - **interface**: `api.tx.assetConversion.addLiquidity`
 - **summary**:    Provide liquidity into the pool of `asset1` and `asset2`.  NOTE: an optimal amount of asset1 and asset2 will be calculated and  might be different than the provided `amount1_desired`/`amount2_desired`  thus you should provide the min amount you're happy to provide.  Params `amount1_min`/`amount2_min` represent that.  `mint_to` will be sent the liquidity tokens that represent this share of the pool. 
 
@@ -66,29 +281,29 @@ ___
 
    Once liquidity is added, someone may successfully call  [`Pallet::swap_exact_tokens_for_tokens`]. 
  
-### createPool(asset1: `StagingXcmV4Location`, asset2: `StagingXcmV4Location`)
+### createPool(asset1: `StagingXcmV5Location`, asset2: `StagingXcmV5Location`)
 - **interface**: `api.tx.assetConversion.createPool`
 - **summary**:    Creates an empty liquidity pool and an associated new `lp_token` asset  (the id of which is returned in the `Event::PoolCreated` event). 
 
    Once a pool is created, someone may [`Pallet::add_liquidity`] to it. 
  
-### removeLiquidity(asset1: `StagingXcmV4Location`, asset2: `StagingXcmV4Location`, lp_token_burn: `u128`, amount1_min_receive: `u128`, amount2_min_receive: `u128`, withdraw_to: `AccountId32`)
+### removeLiquidity(asset1: `StagingXcmV5Location`, asset2: `StagingXcmV5Location`, lp_token_burn: `u128`, amount1_min_receive: `u128`, amount2_min_receive: `u128`, withdraw_to: `AccountId32`)
 - **interface**: `api.tx.assetConversion.removeLiquidity`
 - **summary**:    Allows you to remove liquidity by providing the `lp_token_burn` tokens that will be  burned in the process. With the usage of `amount1_min_receive`/`amount2_min_receive`  it's possible to control the min amount of returned tokens you're happy with. 
  
-### swapExactTokensForTokens(path: `Vec<StagingXcmV4Location>`, amount_in: `u128`, amount_out_min: `u128`, send_to: `AccountId32`, keep_alive: `bool`)
+### swapExactTokensForTokens(path: `Vec<StagingXcmV5Location>`, amount_in: `u128`, amount_out_min: `u128`, send_to: `AccountId32`, keep_alive: `bool`)
 - **interface**: `api.tx.assetConversion.swapExactTokensForTokens`
 - **summary**:    Swap the exact amount of `asset1` into `asset2`.  `amount_out_min` param allows you to specify the min amount of the `asset2`  you're happy to receive. 
 
    [`AssetConversionApi::quote_price_exact_tokens_for_tokens`] runtime call can be called  for a quote. 
  
-### swapTokensForExactTokens(path: `Vec<StagingXcmV4Location>`, amount_out: `u128`, amount_in_max: `u128`, send_to: `AccountId32`, keep_alive: `bool`)
+### swapTokensForExactTokens(path: `Vec<StagingXcmV5Location>`, amount_out: `u128`, amount_in_max: `u128`, send_to: `AccountId32`, keep_alive: `bool`)
 - **interface**: `api.tx.assetConversion.swapTokensForExactTokens`
 - **summary**:    Swap any amount of `asset1` to get the exact amount of `asset2`.  `amount_in_max` param allows to specify the max amount of the `asset1`  you're happy to provide. 
 
    [`AssetConversionApi::quote_price_tokens_for_exact_tokens`] runtime call can be called  for a quote. 
  
-### touch(asset1: `StagingXcmV4Location`, asset2: `StagingXcmV4Location`)
+### touch(asset1: `StagingXcmV5Location`, asset2: `StagingXcmV5Location`)
 - **interface**: `api.tx.assetConversion.touch`
 - **summary**:    Touch an existing pool to fulfill prerequisites before providing liquidity, such as  ensuring that the pool's accounts are in place. It is typically useful when a pool  creator removes the pool's accounts and does not provide a liquidity. This action may  involve holding assets from the caller as a deposit for creating the pool's accounts. 
 
@@ -99,6 +314,35 @@ ___
   - `asset2`: The asset ID of an existing pool with a pair (asset1, asset2).
 
    Emits `Touched` event when successful. 
+
+___
+
+
+## assetRate
+ 
+### create(asset_kind: `PolkadotRuntimeCommonImplsVersionedLocatableAsset`, rate: `u128`)
+- **interface**: `api.tx.assetRate.create`
+- **summary**:    Initialize a conversion rate to native balance for the given asset. 
+
+   #### Complexity 
+
+  - O(1)
+ 
+### remove(asset_kind: `PolkadotRuntimeCommonImplsVersionedLocatableAsset`)
+- **interface**: `api.tx.assetRate.remove`
+- **summary**:    Remove an existing conversion rate to native balance for the given asset. 
+
+   #### Complexity 
+
+  - O(1)
+ 
+### update(asset_kind: `PolkadotRuntimeCommonImplsVersionedLocatableAsset`, rate: `u128`)
+- **interface**: `api.tx.assetRate.update`
+- **summary**:    Update the conversion rate to native balance for the given asset. 
+
+   #### Complexity 
+
+  - O(1)
 
 ___
 
@@ -701,6 +945,372 @@ ___
 ___
 
 
+## bounties
+ 
+### acceptCurator(bounty_id: `Compact<u32>`)
+- **interface**: `api.tx.bounties.acceptCurator`
+- **summary**:    Accept the curator role for a bounty.  A deposit will be reserved from curator and refund upon successful payout. 
+
+   May only be called from the curator. 
+
+   #### Complexity 
+
+  - O(1).
+ 
+### approveBounty(bounty_id: `Compact<u32>`)
+- **interface**: `api.tx.bounties.approveBounty`
+- **summary**:    Approve a bounty proposal. At a later time, the bounty will be funded and become active  and the original deposit will be returned. 
+
+   May only be called from `T::SpendOrigin`. 
+
+   #### Complexity 
+
+  - O(1).
+ 
+### approveBountyWithCurator(bounty_id: `Compact<u32>`, curator: `MultiAddress`, fee: `Compact<u128>`)
+- **interface**: `api.tx.bounties.approveBountyWithCurator`
+- **summary**:    Approve bountry and propose a curator simultaneously.  This call is a shortcut to calling `approve_bounty` and `propose_curator` separately. 
+
+   May only be called from `T::SpendOrigin`. 
+
+   - `bounty_id`: Bounty ID to approve. 
+
+  - `curator`: The curator account whom will manage this bounty.
+
+  - `fee`: The curator fee.
+
+   #### Complexity 
+
+  - O(1).
+ 
+### awardBounty(bounty_id: `Compact<u32>`, beneficiary: `MultiAddress`)
+- **interface**: `api.tx.bounties.awardBounty`
+- **summary**:    Award bounty to a beneficiary account. The beneficiary will be able to claim the funds  after a delay. 
+
+   The dispatch origin for this call must be the curator of this bounty. 
+
+   - `bounty_id`: Bounty ID to award. 
+
+  - `beneficiary`: The beneficiary account whom will receive the payout.
+
+   #### Complexity 
+
+  - O(1).
+ 
+### claimBounty(bounty_id: `Compact<u32>`)
+- **interface**: `api.tx.bounties.claimBounty`
+- **summary**:    Claim the payout from an awarded bounty after payout delay. 
+
+   The dispatch origin for this call must be the beneficiary of this bounty. 
+
+   - `bounty_id`: Bounty ID to claim. 
+
+   #### Complexity 
+
+  - O(1).
+ 
+### closeBounty(bounty_id: `Compact<u32>`)
+- **interface**: `api.tx.bounties.closeBounty`
+- **summary**:    Cancel a proposed or active bounty. All the funds will be sent to treasury and  the curator deposit will be unreserved if possible. 
+
+   Only `T::RejectOrigin` is able to cancel a bounty. 
+
+   - `bounty_id`: Bounty ID to cancel. 
+
+   #### Complexity 
+
+  - O(1).
+ 
+### extendBountyExpiry(bounty_id: `Compact<u32>`, remark: `Bytes`)
+- **interface**: `api.tx.bounties.extendBountyExpiry`
+- **summary**:    Extend the expiry time of an active bounty. 
+
+   The dispatch origin for this call must be the curator of this bounty. 
+
+   - `bounty_id`: Bounty ID to extend. 
+
+  - `remark`: additional information.
+
+   #### Complexity 
+
+  - O(1).
+ 
+### pokeDeposit(bounty_id: `Compact<u32>`)
+- **interface**: `api.tx.bounties.pokeDeposit`
+- **summary**:    Poke the deposit reserved for creating a bounty proposal. 
+
+   This can be used by accounts to update their reserved amount. 
+
+   The dispatch origin for this call must be _Signed_. 
+
+   Parameters: 
+
+  - `bounty_id`: The bounty id for which to adjust the deposit.
+
+   If the deposit is updated, the difference will be reserved/unreserved from the  proposer's account. 
+
+   The transaction is made free if the deposit is updated and paid otherwise. 
+
+   Emits `DepositPoked` if the deposit is updated. 
+ 
+### proposeBounty(value: `Compact<u128>`, description: `Bytes`)
+- **interface**: `api.tx.bounties.proposeBounty`
+- **summary**:    Propose a new bounty. 
+
+   The dispatch origin for this call must be _Signed_. 
+
+   Payment: `TipReportDepositBase` will be reserved from the origin account, as well as  `DataDepositPerByte` for each byte in `reason`. It will be unreserved upon approval,  or slashed when rejected. 
+
+   - `curator`: The curator account whom will manage this bounty. 
+
+  - `fee`: The curator fee.
+
+  - `value`: The total payment amount of this bounty, curator fee included.
+
+  - `description`: The description of this bounty.
+ 
+### proposeCurator(bounty_id: `Compact<u32>`, curator: `MultiAddress`, fee: `Compact<u128>`)
+- **interface**: `api.tx.bounties.proposeCurator`
+- **summary**:    Propose a curator to a funded bounty. 
+
+   May only be called from `T::SpendOrigin`. 
+
+   #### Complexity 
+
+  - O(1).
+ 
+### unassignCurator(bounty_id: `Compact<u32>`)
+- **interface**: `api.tx.bounties.unassignCurator`
+- **summary**:    Unassign curator from a bounty. 
+
+   This function can only be called by the `RejectOrigin` a signed origin. 
+
+   If this function is called by the `RejectOrigin`, we assume that the curator is  malicious or inactive. As a result, we will slash the curator when possible. 
+
+   If the origin is the curator, we take this as a sign they are unable to do their job and  they willingly give up. We could slash them, but for now we allow them to recover their  deposit and exit without issue. (We may want to change this if it is abused.) 
+
+   Finally, the origin can be anyone if and only if the curator is "inactive". This allows  anyone in the community to call out that a curator is not doing their due diligence, and  we should pick a new curator. In this case the curator should also be slashed. 
+
+   #### Complexity 
+
+  - O(1).
+
+___
+
+
+## childBounties
+ 
+### acceptCurator(parent_bounty_id: `Compact<u32>`, child_bounty_id: `Compact<u32>`)
+- **interface**: `api.tx.childBounties.acceptCurator`
+- **summary**:    Accept the curator role for the child-bounty. 
+
+   The dispatch origin for this call must be the curator of this  child-bounty. 
+
+   A deposit will be reserved from the curator and refund upon  successful payout or cancellation. 
+
+   Fee for curator is deducted from curator fee of parent bounty. 
+
+   Parent bounty must be in active state, for this child-bounty call to  work. 
+
+   Child-bounty must be in "CuratorProposed" state, for processing the  call. And state of child-bounty is moved to "Active" on successful  call completion. 
+
+   - `parent_bounty_id`: Index of parent bounty. 
+
+  - `child_bounty_id`: Index of child bounty.
+ 
+### addChildBounty(parent_bounty_id: `Compact<u32>`, value: `Compact<u128>`, description: `Bytes`)
+- **interface**: `api.tx.childBounties.addChildBounty`
+- **summary**:    Add a new child-bounty. 
+
+   The dispatch origin for this call must be the curator of parent  bounty and the parent bounty must be in "active" state. 
+
+   Child-bounty gets added successfully & fund gets transferred from  parent bounty to child-bounty account, if parent bounty has enough  funds, else the call fails. 
+
+   Upper bound to maximum number of active  child bounties that can be  added are managed via runtime trait config  [`Config::MaxActiveChildBountyCount`]. 
+
+   If the call is success, the status of child-bounty is updated to  "Added". 
+
+   - `parent_bounty_id`: Index of parent bounty for which child-bounty is being added. 
+
+  - `value`: Value for executing the proposal.
+
+  - `description`: Text description for the child-bounty.
+ 
+### awardChildBounty(parent_bounty_id: `Compact<u32>`, child_bounty_id: `Compact<u32>`, beneficiary: `MultiAddress`)
+- **interface**: `api.tx.childBounties.awardChildBounty`
+- **summary**:    Award child-bounty to a beneficiary. 
+
+   The beneficiary will be able to claim the funds after a delay. 
+
+   The dispatch origin for this call must be the parent curator or  curator of this child-bounty. 
+
+   Parent bounty must be in active state, for this child-bounty call to  work. 
+
+   Child-bounty must be in active state, for processing the call. And  state of child-bounty is moved to "PendingPayout" on successful call  completion. 
+
+   - `parent_bounty_id`: Index of parent bounty. 
+
+  - `child_bounty_id`: Index of child bounty.
+
+  - `beneficiary`: Beneficiary account.
+ 
+### claimChildBounty(parent_bounty_id: `Compact<u32>`, child_bounty_id: `Compact<u32>`)
+- **interface**: `api.tx.childBounties.claimChildBounty`
+- **summary**:    Claim the payout from an awarded child-bounty after payout delay. 
+
+   The dispatch origin for this call may be any signed origin. 
+
+   Call works independent of parent bounty state, No need for parent  bounty to be in active state. 
+
+   The Beneficiary is paid out with agreed bounty value. Curator fee is  paid & curator deposit is unreserved. 
+
+   Child-bounty must be in "PendingPayout" state, for processing the  call. And instance of child-bounty is removed from the state on  successful call completion. 
+
+   - `parent_bounty_id`: Index of parent bounty. 
+
+  - `child_bounty_id`: Index of child bounty.
+ 
+### closeChildBounty(parent_bounty_id: `Compact<u32>`, child_bounty_id: `Compact<u32>`)
+- **interface**: `api.tx.childBounties.closeChildBounty`
+- **summary**:    Cancel a proposed or active child-bounty. Child-bounty account funds  are transferred to parent bounty account. The child-bounty curator  deposit may be unreserved if possible. 
+
+   The dispatch origin for this call must be either parent curator or  `T::RejectOrigin`. 
+
+   If the state of child-bounty is `Active`, curator deposit is  unreserved. 
+
+   If the state of child-bounty is `PendingPayout`, call fails &  returns `PendingPayout` error. 
+
+   For the origin other than T::RejectOrigin, parent bounty must be in  active state, for this child-bounty call to work. For origin  T::RejectOrigin execution is forced. 
+
+   Instance of child-bounty is removed from the state on successful  call completion. 
+
+   - `parent_bounty_id`: Index of parent bounty. 
+
+  - `child_bounty_id`: Index of child bounty.
+ 
+### proposeCurator(parent_bounty_id: `Compact<u32>`, child_bounty_id: `Compact<u32>`, curator: `MultiAddress`, fee: `Compact<u128>`)
+- **interface**: `api.tx.childBounties.proposeCurator`
+- **summary**:    Propose curator for funded child-bounty. 
+
+   The dispatch origin for this call must be curator of parent bounty. 
+
+   Parent bounty must be in active state, for this child-bounty call to  work. 
+
+   Child-bounty must be in "Added" state, for processing the call. And  state of child-bounty is moved to "CuratorProposed" on successful  call completion. 
+
+   - `parent_bounty_id`: Index of parent bounty. 
+
+  - `child_bounty_id`: Index of child bounty.
+
+  - `curator`: Address of child-bounty curator.
+
+  - `fee`: payment fee to child-bounty curator for execution.
+ 
+### unassignCurator(parent_bounty_id: `Compact<u32>`, child_bounty_id: `Compact<u32>`)
+- **interface**: `api.tx.childBounties.unassignCurator`
+- **summary**:    Unassign curator from a child-bounty. 
+
+   The dispatch origin for this call can be either `RejectOrigin`, or  the curator of the parent bounty, or any signed origin. 
+
+   For the origin other than T::RejectOrigin and the child-bounty  curator, parent bounty must be in active state, for this call to  work. We allow child-bounty curator and T::RejectOrigin to execute  this call irrespective of the parent bounty state. 
+
+   If this function is called by the `RejectOrigin` or the  parent bounty curator, we assume that the child-bounty curator is  malicious or inactive. As a result, child-bounty curator deposit is  slashed. 
+
+   If the origin is the child-bounty curator, we take this as a sign  that they are unable to do their job, and are willingly giving up.  We could slash the deposit, but for now we allow them to unreserve  their deposit and exit without issue. (We may want to change this if  it is abused.) 
+
+   Finally, the origin can be anyone iff the child-bounty curator is  "inactive". Expiry update due of parent bounty is used to estimate  inactive state of child-bounty curator. 
+
+   This allows anyone in the community to call out that a child-bounty  curator is not doing their due diligence, and we should pick a new  one. In this case the child-bounty curator deposit is slashed. 
+
+   State of child-bounty is moved to Added state on successful call  completion. 
+
+   - `parent_bounty_id`: Index of parent bounty. 
+
+  - `child_bounty_id`: Index of child bounty.
+
+___
+
+
+## claims
+ 
+### attest(statement: `Bytes`)
+- **interface**: `api.tx.claims.attest`
+- **summary**:    Attest to a statement, needed to finalize the claims process. 
+
+   WARNING: Insecure unless your chain includes `PrevalidateAttests` as a  `TransactionExtension`. 
+
+   Unsigned Validation:  A call to attest is deemed valid if the sender has a `Preclaim` registered  and provides a `statement` which is expected for the account. 
+
+   Parameters: 
+
+  - `statement`: The identity of the statement which is being attested to in the signature. 
+
+    
+ 
+### claim(dest: `AccountId32`, ethereum_signature: `PolkadotRuntimeCommonClaimsEcdsaSignature`)
+- **interface**: `api.tx.claims.claim`
+- **summary**:    Make a claim to collect your DOTs. 
+
+   The dispatch origin for this call must be _None_. 
+
+   Unsigned Validation:  A call to claim is deemed valid if the signature provided matches  the expected signed message of: 
+
+   > Ethereum Signed Message:  > (configured prefix string)(address) 
+
+   and `address` matches the `dest` account. 
+
+   Parameters: 
+
+  - `dest`: The destination account to payout the claim.
+
+  - `ethereum_signature`: The signature of an ethereum signed message matching the format described above. 
+
+    
+ 
+### claimAttest(dest: `AccountId32`, ethereum_signature: `PolkadotRuntimeCommonClaimsEcdsaSignature`, statement: `Bytes`)
+- **interface**: `api.tx.claims.claimAttest`
+- **summary**:    Make a claim to collect your DOTs by signing a statement. 
+
+   The dispatch origin for this call must be _None_. 
+
+   Unsigned Validation:  A call to `claim_attest` is deemed valid if the signature provided matches  the expected signed message of: 
+
+   > Ethereum Signed Message:  > (configured prefix string)(address)(statement) 
+
+   and `address` matches the `dest` account; the `statement` must match that which is  expected according to your purchase arrangement. 
+
+   Parameters: 
+
+  - `dest`: The destination account to payout the claim.
+
+  - `ethereum_signature`: The signature of an ethereum signed message matching the format described above. 
+
+  - `statement`: The identity of the statement which is being attested to in the signature. 
+
+    
+ 
+### mintClaim(who: `EthereumAddress`, value: `u128`, vesting_schedule: `Option<(u128,u128,u32)>`, statement: `Option<PolkadotRuntimeCommonClaimsStatementKind>`)
+- **interface**: `api.tx.claims.mintClaim`
+- **summary**:    Mint a new claim to collect DOTs. 
+
+   The dispatch origin for this call must be _Root_. 
+
+   Parameters: 
+
+  - `who`: The Ethereum address allowed to collect this claim.
+
+  - `value`: The number of DOTs that will be claimed.
+
+  - `vesting_schedule`: An optional vesting schedule for these DOTs.
+
+    
+ 
+### moveClaim(old: `EthereumAddress`, new: `EthereumAddress`, maybe_preclaim: `Option<AccountId32>`)
+- **interface**: `api.tx.claims.moveClaim`
+
+___
+
+
 ## collatorSelection
  
 ### addInvulnerable(who: `AccountId32`)
@@ -768,6 +1378,125 @@ ___
 ___
 
 
+## convictionVoting
+ 
+### delegate(class: `u16`, to: `MultiAddress`, conviction: `PalletConvictionVotingConviction`, balance: `u128`)
+- **interface**: `api.tx.convictionVoting.delegate`
+- **summary**:    Delegate the voting power (with some given conviction) of the sending account for a  particular class of polls. 
+
+   The balance delegated is locked for as long as it's delegated, and thereafter for the  time appropriate for the conviction's lock period. 
+
+   The dispatch origin of this call must be _Signed_, and the signing account must either: 
+
+  - be delegating already; or
+
+  - have no voting activity (if there is, then it will need to be removed through `remove_vote`). 
+
+   - `to`: The account whose voting the `target` account's voting power will follow. 
+
+  - `class`: The class of polls to delegate. To delegate multiple classes, multiple calls to this function are required. 
+
+  - `conviction`: The conviction that will be attached to the delegated votes. When the account is undelegated, the funds will be locked for the corresponding period. 
+
+  - `balance`: The amount of the account's balance to be used in delegating. This must not be more than the account's current balance. 
+
+   Emits `Delegated`. 
+
+   Weight: `O(R)` where R is the number of polls the voter delegating to has  voted on. Weight is initially charged as if maximum votes, but is refunded later. 
+ 
+### removeOtherVote(target: `MultiAddress`, class: `u16`, index: `u32`)
+- **interface**: `api.tx.convictionVoting.removeOtherVote`
+- **summary**:    Remove a vote for a poll. 
+
+   If the `target` is equal to the signer, then this function is exactly equivalent to  `remove_vote`. If not equal to the signer, then the vote must have expired,  either because the poll was cancelled, because the voter lost the poll or  because the conviction period is over. 
+
+   The dispatch origin of this call must be _Signed_. 
+
+   - `target`: The account of the vote to be removed; this account must have voted for poll  `index`. 
+
+  - `index`: The index of poll of the vote to be removed.
+
+  - `class`: The class of the poll.
+
+   Weight: `O(R + log R)` where R is the number of polls that `target` has voted on.  Weight is calculated for the maximum number of vote. 
+ 
+### removeVote(class: `Option<u16>`, index: `u32`)
+- **interface**: `api.tx.convictionVoting.removeVote`
+- **summary**:    Remove a vote for a poll. 
+
+   If: 
+
+  - the poll was cancelled, or
+
+  - the poll is ongoing, or
+
+  - the poll has ended such that
+
+  - the vote of the account was in opposition to the result; or
+
+  - there was no conviction to the account's vote; or
+
+  - the account made a split vote ...then the vote is removed cleanly and a following call to `unlock` may result in more  funds being available. 
+
+   If, however, the poll has ended and: 
+
+  - it finished corresponding to the vote of the account, and
+
+  - the account made a standard vote with conviction, and
+
+  - the lock period of the conviction is not over ...then the lock will be aggregated into the overall account's lock, which may involve 
+
+  *overlocking* (where the two locks are combined into a single lock that is the maximum of both the amount locked and the time is it locked for). 
+
+   The dispatch origin of this call must be _Signed_, and the signer must have a vote  registered for poll `index`. 
+
+   - `index`: The index of poll of the vote to be removed. 
+
+  - `class`: Optional parameter, if given it indicates the class of the poll. For polls which have finished or are cancelled, this must be `Some`. 
+
+   Weight: `O(R + log R)` where R is the number of polls that `target` has voted on.  Weight is calculated for the maximum number of vote. 
+ 
+### undelegate(class: `u16`)
+- **interface**: `api.tx.convictionVoting.undelegate`
+- **summary**:    Undelegate the voting power of the sending account for a particular class of polls. 
+
+   Tokens may be unlocked following once an amount of time consistent with the lock period  of the conviction with which the delegation was issued has passed. 
+
+   The dispatch origin of this call must be _Signed_ and the signing account must be  currently delegating. 
+
+   - `class`: The class of polls to remove the delegation from. 
+
+   Emits `Undelegated`. 
+
+   Weight: `O(R)` where R is the number of polls the voter delegating to has  voted on. Weight is initially charged as if maximum votes, but is refunded later. 
+ 
+### unlock(class: `u16`, target: `MultiAddress`)
+- **interface**: `api.tx.convictionVoting.unlock`
+- **summary**:    Remove the lock caused by prior voting/delegating which has expired within a particular  class. 
+
+   The dispatch origin of this call must be _Signed_. 
+
+   - `class`: The class of polls to unlock. 
+
+  - `target`: The account to remove the lock on.
+
+   Weight: `O(R)` with R number of vote of target. 
+ 
+### vote(poll_index: `Compact<u32>`, vote: `PalletConvictionVotingVoteAccountVote`)
+- **interface**: `api.tx.convictionVoting.vote`
+- **summary**:    Vote in a poll. If `vote.is_aye()`, the vote is to enact the proposal;  otherwise it is a vote to keep the status quo. 
+
+   The dispatch origin of this call must be _Signed_. 
+
+   - `poll_index`: The index of the poll to vote for. 
+
+  - `vote`: The vote configuration.
+
+   Weight: `O(R)` where R is the number of polls the voter has voted on. 
+
+___
+
+
 ## cumulusXcm
 
 ___
@@ -775,7 +1504,7 @@ ___
 
 ## foreignAssets
  
-### approveTransfer(id: `StagingXcmV4Location`, delegate: `MultiAddress`, amount: `Compact<u128>`)
+### approveTransfer(id: `StagingXcmV5Location`, delegate: `MultiAddress`, amount: `Compact<u128>`)
 - **interface**: `api.tx.foreignAssets.approveTransfer`
 - **summary**:    Approve an amount of asset for transfer by a delegated third-party account. 
 
@@ -795,7 +1524,7 @@ ___
 
    Weight: `O(1)` 
  
-### block(id: `StagingXcmV4Location`, who: `MultiAddress`)
+### block(id: `StagingXcmV5Location`, who: `MultiAddress`)
 - **interface**: `api.tx.foreignAssets.block`
 - **summary**:    Disallow further unprivileged transfers of an asset `id` to and from an account `who`. 
 
@@ -809,7 +1538,7 @@ ___
 
    Weight: `O(1)` 
  
-### burn(id: `StagingXcmV4Location`, who: `MultiAddress`, amount: `Compact<u128>`)
+### burn(id: `StagingXcmV5Location`, who: `MultiAddress`, amount: `Compact<u128>`)
 - **interface**: `api.tx.foreignAssets.burn`
 - **summary**:    Reduce the balance of `who` by as much as possible up to `amount` assets of `id`. 
 
@@ -827,7 +1556,7 @@ ___
 
    Weight: `O(1)`  Modes: Post-existence of `who`; Pre & post Zombie-status of `who`. 
  
-### cancelApproval(id: `StagingXcmV4Location`, delegate: `MultiAddress`)
+### cancelApproval(id: `StagingXcmV5Location`, delegate: `MultiAddress`)
 - **interface**: `api.tx.foreignAssets.cancelApproval`
 - **summary**:    Cancel all of some asset approved for delegated transfer by a third-party account. 
 
@@ -843,7 +1572,7 @@ ___
 
    Weight: `O(1)` 
  
-### clearMetadata(id: `StagingXcmV4Location`)
+### clearMetadata(id: `StagingXcmV5Location`)
 - **interface**: `api.tx.foreignAssets.clearMetadata`
 - **summary**:    Clear the metadata for an asset. 
 
@@ -857,7 +1586,7 @@ ___
 
    Weight: `O(1)` 
  
-### create(id: `StagingXcmV4Location`, admin: `MultiAddress`, min_balance: `u128`)
+### create(id: `StagingXcmV5Location`, admin: `MultiAddress`, min_balance: `u128`)
 - **interface**: `api.tx.foreignAssets.create`
 - **summary**:    Issue a new class of fungible assets from a public origin. 
 
@@ -879,7 +1608,7 @@ ___
 
    Weight: `O(1)` 
  
-### destroyAccounts(id: `StagingXcmV4Location`)
+### destroyAccounts(id: `StagingXcmV5Location`)
 - **interface**: `api.tx.foreignAssets.destroyAccounts`
 - **summary**:    Destroy all accounts associated with a given asset. 
 
@@ -891,7 +1620,7 @@ ___
 
    Each call emits the `Event::DestroyedAccounts` event. 
  
-### destroyApprovals(id: `StagingXcmV4Location`)
+### destroyApprovals(id: `StagingXcmV5Location`)
 - **interface**: `api.tx.foreignAssets.destroyApprovals`
 - **summary**:    Destroy all approvals associated with a given asset up to the max (T::RemoveItemsLimit). 
 
@@ -903,7 +1632,7 @@ ___
 
    Each call emits the `Event::DestroyedApprovals` event. 
  
-### finishDestroy(id: `StagingXcmV4Location`)
+### finishDestroy(id: `StagingXcmV5Location`)
 - **interface**: `api.tx.foreignAssets.finishDestroy`
 - **summary**:    Complete destroying asset and unreserve currency. 
 
@@ -913,7 +1642,7 @@ ___
 
    Each successful call emits the `Event::Destroyed` event. 
  
-### forceAssetStatus(id: `StagingXcmV4Location`, owner: `MultiAddress`, issuer: `MultiAddress`, admin: `MultiAddress`, freezer: `MultiAddress`, min_balance: `Compact<u128>`, is_sufficient: `bool`, is_frozen: `bool`)
+### forceAssetStatus(id: `StagingXcmV5Location`, owner: `MultiAddress`, issuer: `MultiAddress`, admin: `MultiAddress`, freezer: `MultiAddress`, min_balance: `Compact<u128>`, is_sufficient: `bool`, is_frozen: `bool`)
 - **interface**: `api.tx.foreignAssets.forceAssetStatus`
 - **summary**:    Alter the attributes of a given asset. 
 
@@ -939,7 +1668,7 @@ ___
 
    Weight: `O(1)` 
  
-### forceCancelApproval(id: `StagingXcmV4Location`, owner: `MultiAddress`, delegate: `MultiAddress`)
+### forceCancelApproval(id: `StagingXcmV5Location`, owner: `MultiAddress`, delegate: `MultiAddress`)
 - **interface**: `api.tx.foreignAssets.forceCancelApproval`
 - **summary**:    Cancel all of some asset approved for delegated transfer by a third-party account. 
 
@@ -955,7 +1684,7 @@ ___
 
    Weight: `O(1)` 
  
-### forceClearMetadata(id: `StagingXcmV4Location`)
+### forceClearMetadata(id: `StagingXcmV5Location`)
 - **interface**: `api.tx.foreignAssets.forceClearMetadata`
 - **summary**:    Clear the metadata for an asset. 
 
@@ -969,7 +1698,7 @@ ___
 
    Weight: `O(1)` 
  
-### forceCreate(id: `StagingXcmV4Location`, owner: `MultiAddress`, is_sufficient: `bool`, min_balance: `Compact<u128>`)
+### forceCreate(id: `StagingXcmV5Location`, owner: `MultiAddress`, is_sufficient: `bool`, min_balance: `Compact<u128>`)
 - **interface**: `api.tx.foreignAssets.forceCreate`
 - **summary**:    Issue a new class of fungible assets from a privileged origin. 
 
@@ -989,7 +1718,7 @@ ___
 
    Weight: `O(1)` 
  
-### forceSetMetadata(id: `StagingXcmV4Location`, name: `Bytes`, symbol: `Bytes`, decimals: `u8`, is_frozen: `bool`)
+### forceSetMetadata(id: `StagingXcmV5Location`, name: `Bytes`, symbol: `Bytes`, decimals: `u8`, is_frozen: `bool`)
 - **interface**: `api.tx.foreignAssets.forceSetMetadata`
 - **summary**:    Force the metadata for an asset to some value. 
 
@@ -1009,7 +1738,7 @@ ___
 
    Weight: `O(N + S)` where N and S are the length of the name and symbol respectively. 
  
-### forceTransfer(id: `StagingXcmV4Location`, source: `MultiAddress`, dest: `MultiAddress`, amount: `Compact<u128>`)
+### forceTransfer(id: `StagingXcmV5Location`, source: `MultiAddress`, dest: `MultiAddress`, amount: `Compact<u128>`)
 - **interface**: `api.tx.foreignAssets.forceTransfer`
 - **summary**:    Move some assets from one account to another. 
 
@@ -1027,7 +1756,7 @@ ___
 
    Weight: `O(1)`  Modes: Pre-existence of `dest`; Post-existence of `source`; Account pre-existence of  `dest`. 
  
-### freeze(id: `StagingXcmV4Location`, who: `MultiAddress`)
+### freeze(id: `StagingXcmV5Location`, who: `MultiAddress`)
 - **interface**: `api.tx.foreignAssets.freeze`
 - **summary**:    Disallow further unprivileged transfers of an asset `id` from an account `who`. `who`  must already exist as an entry in `Account`s of the asset. If you want to freeze an  account that does not have an entry, use `touch_other` first. 
 
@@ -1041,7 +1770,7 @@ ___
 
    Weight: `O(1)` 
  
-### freezeAsset(id: `StagingXcmV4Location`)
+### freezeAsset(id: `StagingXcmV5Location`)
 - **interface**: `api.tx.foreignAssets.freezeAsset`
 - **summary**:    Disallow further unprivileged transfers for the asset class. 
 
@@ -1053,7 +1782,7 @@ ___
 
    Weight: `O(1)` 
  
-### mint(id: `StagingXcmV4Location`, beneficiary: `MultiAddress`, amount: `Compact<u128>`)
+### mint(id: `StagingXcmV5Location`, beneficiary: `MultiAddress`, amount: `Compact<u128>`)
 - **interface**: `api.tx.foreignAssets.mint`
 - **summary**:    Mint assets of a particular class. 
 
@@ -1069,7 +1798,7 @@ ___
 
    Weight: `O(1)`  Modes: Pre-existing balance of `beneficiary`; Account pre-existence of `beneficiary`. 
  
-### refund(id: `StagingXcmV4Location`, allow_burn: `bool`)
+### refund(id: `StagingXcmV5Location`, allow_burn: `bool`)
 - **interface**: `api.tx.foreignAssets.refund`
 - **summary**:    Return the deposit (if any) of an asset account or a consumer reference (if any) of an  account. 
 
@@ -1083,7 +1812,7 @@ ___
 
    Emits `Refunded` event when successful. 
  
-### refundOther(id: `StagingXcmV4Location`, who: `MultiAddress`)
+### refundOther(id: `StagingXcmV5Location`, who: `MultiAddress`)
 - **interface**: `api.tx.foreignAssets.refundOther`
 - **summary**:    Return the deposit (if any) of a target asset account. Useful if you are the depositor. 
 
@@ -1097,7 +1826,7 @@ ___
 
    Emits `Refunded` event when successful. 
  
-### setMetadata(id: `StagingXcmV4Location`, name: `Bytes`, symbol: `Bytes`, decimals: `u8`)
+### setMetadata(id: `StagingXcmV5Location`, name: `Bytes`, symbol: `Bytes`, decimals: `u8`)
 - **interface**: `api.tx.foreignAssets.setMetadata`
 - **summary**:    Set the metadata for an asset. 
 
@@ -1117,7 +1846,7 @@ ___
 
    Weight: `O(1)` 
  
-### setMinBalance(id: `StagingXcmV4Location`, min_balance: `u128`)
+### setMinBalance(id: `StagingXcmV5Location`, min_balance: `u128`)
 - **interface**: `api.tx.foreignAssets.setMinBalance`
 - **summary**:    Sets the minimum balance of an asset. 
 
@@ -1131,7 +1860,7 @@ ___
 
    Emits `AssetMinBalanceChanged` event when successful. 
  
-### setTeam(id: `StagingXcmV4Location`, issuer: `MultiAddress`, admin: `MultiAddress`, freezer: `MultiAddress`)
+### setTeam(id: `StagingXcmV5Location`, issuer: `MultiAddress`, admin: `MultiAddress`, freezer: `MultiAddress`)
 - **interface**: `api.tx.foreignAssets.setTeam`
 - **summary**:    Change the Issuer, Admin and Freezer of an asset. 
 
@@ -1149,7 +1878,7 @@ ___
 
    Weight: `O(1)` 
  
-### startDestroy(id: `StagingXcmV4Location`)
+### startDestroy(id: `StagingXcmV5Location`)
 - **interface**: `api.tx.foreignAssets.startDestroy`
 - **summary**:    Start the process of destroying a fungible asset class. 
 
@@ -1161,7 +1890,7 @@ ___
 
    It will fail with either [`Error::ContainsHolds`] or [`Error::ContainsFreezes`] if  an account contains holds or freezes in place. 
  
-### thaw(id: `StagingXcmV4Location`, who: `MultiAddress`)
+### thaw(id: `StagingXcmV5Location`, who: `MultiAddress`)
 - **interface**: `api.tx.foreignAssets.thaw`
 - **summary**:    Allow unprivileged transfers to and from an account again. 
 
@@ -1175,7 +1904,7 @@ ___
 
    Weight: `O(1)` 
  
-### thawAsset(id: `StagingXcmV4Location`)
+### thawAsset(id: `StagingXcmV5Location`)
 - **interface**: `api.tx.foreignAssets.thawAsset`
 - **summary**:    Allow unprivileged transfers for the asset again. 
 
@@ -1187,7 +1916,7 @@ ___
 
    Weight: `O(1)` 
  
-### touch(id: `StagingXcmV4Location`)
+### touch(id: `StagingXcmV5Location`)
 - **interface**: `api.tx.foreignAssets.touch`
 - **summary**:    Create an asset account for non-provider assets. 
 
@@ -1199,7 +1928,7 @@ ___
 
    Emits `Touched` event when successful. 
  
-### touchOther(id: `StagingXcmV4Location`, who: `MultiAddress`)
+### touchOther(id: `StagingXcmV5Location`, who: `MultiAddress`)
 - **interface**: `api.tx.foreignAssets.touchOther`
 - **summary**:    Create an asset account for `who`. 
 
@@ -1213,7 +1942,7 @@ ___
 
    Emits `Touched` event when successful. 
  
-### transfer(id: `StagingXcmV4Location`, target: `MultiAddress`, amount: `Compact<u128>`)
+### transfer(id: `StagingXcmV5Location`, target: `MultiAddress`, amount: `Compact<u128>`)
 - **interface**: `api.tx.foreignAssets.transfer`
 - **summary**:    Move some assets from the sender account to another. 
 
@@ -1229,7 +1958,7 @@ ___
 
    Weight: `O(1)`  Modes: Pre-existence of `target`; Post-existence of sender; Account pre-existence of  `target`. 
  
-### transferAll(id: `StagingXcmV4Location`, dest: `MultiAddress`, keep_alive: `bool`)
+### transferAll(id: `StagingXcmV5Location`, dest: `MultiAddress`, keep_alive: `bool`)
 - **interface**: `api.tx.foreignAssets.transferAll`
 - **summary**:    Transfer the entire transferable balance from the caller asset account. 
 
@@ -1243,7 +1972,7 @@ ___
 
   - `keep_alive`: A boolean to determine if the `transfer_all` operation should send all of the funds the asset account has, causing the sender asset account to be killed  (false), or transfer everything except at least the minimum balance, which will  guarantee to keep the sender asset account alive (true). 
  
-### transferApproved(id: `StagingXcmV4Location`, owner: `MultiAddress`, destination: `MultiAddress`, amount: `Compact<u128>`)
+### transferApproved(id: `StagingXcmV5Location`, owner: `MultiAddress`, destination: `MultiAddress`, amount: `Compact<u128>`)
 - **interface**: `api.tx.foreignAssets.transferApproved`
 - **summary**:    Transfer some asset balance from a previously delegated account to some third-party  account. 
 
@@ -1263,7 +1992,7 @@ ___
 
    Weight: `O(1)` 
  
-### transferKeepAlive(id: `StagingXcmV4Location`, target: `MultiAddress`, amount: `Compact<u128>`)
+### transferKeepAlive(id: `StagingXcmV5Location`, target: `MultiAddress`, amount: `Compact<u128>`)
 - **interface**: `api.tx.foreignAssets.transferKeepAlive`
 - **summary**:    Move some assets from the sender account to another, keeping the sender account alive. 
 
@@ -1279,7 +2008,7 @@ ___
 
    Weight: `O(1)`  Modes: Pre-existence of `target`; Post-existence of sender; Account pre-existence of  `target`. 
  
-### transferOwnership(id: `StagingXcmV4Location`, owner: `MultiAddress`)
+### transferOwnership(id: `StagingXcmV5Location`, owner: `MultiAddress`)
 - **interface**: `api.tx.foreignAssets.transferOwnership`
 - **summary**:    Change the Owner of an asset. 
 
@@ -1292,6 +2021,103 @@ ___
    Emits `OwnerChanged`. 
 
    Weight: `O(1)` 
+
+___
+
+
+## indices
+ 
+### claim(index: `u32`)
+- **interface**: `api.tx.indices.claim`
+- **summary**:    Assign an previously unassigned index. 
+
+   Payment: `Deposit` is reserved from the sender account. 
+
+   The dispatch origin for this call must be _Signed_. 
+
+   - `index`: the index to be claimed. This must not be in use. 
+
+   Emits `IndexAssigned` if successful. 
+
+   #### Complexity 
+
+  - `O(1)`.
+ 
+### forceTransfer(new: `MultiAddress`, index: `u32`, freeze: `bool`)
+- **interface**: `api.tx.indices.forceTransfer`
+- **summary**:    Force an index to an account. This doesn't require a deposit. If the index is already  held, then any deposit is reimbursed to its current owner. 
+
+   The dispatch origin for this call must be _Root_. 
+
+   - `index`: the index to be (re-)assigned. 
+
+  - `new`: the new owner of the index. This function is a no-op if it is equal to sender.
+
+  - `freeze`: if set to `true`, will freeze the index so it cannot be transferred.
+
+   Emits `IndexAssigned` if successful. 
+
+   #### Complexity 
+
+  - `O(1)`.
+ 
+### free(index: `u32`)
+- **interface**: `api.tx.indices.free`
+- **summary**:    Free up an index owned by the sender. 
+
+   Payment: Any previous deposit placed for the index is unreserved in the sender account. 
+
+   The dispatch origin for this call must be _Signed_ and the sender must own the index. 
+
+   - `index`: the index to be freed. This must be owned by the sender. 
+
+   Emits `IndexFreed` if successful. 
+
+   #### Complexity 
+
+  - `O(1)`.
+ 
+### freeze(index: `u32`)
+- **interface**: `api.tx.indices.freeze`
+- **summary**:    Freeze an index so it will always point to the sender account. This consumes the  deposit. 
+
+   The dispatch origin for this call must be _Signed_ and the signing account must have a  non-frozen account `index`. 
+
+   - `index`: the index to be frozen in place. 
+
+   Emits `IndexFrozen` if successful. 
+
+   #### Complexity 
+
+  - `O(1)`.
+ 
+### pokeDeposit(index: `u32`)
+- **interface**: `api.tx.indices.pokeDeposit`
+- **summary**:    Poke the deposit reserved for an index. 
+
+   The dispatch origin for this call must be _Signed_ and the signing account must have a  non-frozen account `index`. 
+
+   The transaction fees is waived if the deposit is changed after poking/reconsideration. 
+
+   - `index`: the index whose deposit is to be poked/reconsidered. 
+
+   Emits `DepositPoked` if successful. 
+ 
+### transfer(new: `MultiAddress`, index: `u32`)
+- **interface**: `api.tx.indices.transfer`
+- **summary**:    Assign an index already owned by the sender to another account. The balance reservation  is effectively transferred to the new account. 
+
+   The dispatch origin for this call must be _Signed_. 
+
+   - `index`: the index to be re-assigned. This must be owned by the sender. 
+
+  - `new`: the new owner of the index. This function is a no-op if it is equal to sender.
+
+   Emits `IndexAssigned` if successful. 
+
+   #### Complexity 
+
+  - `O(1)`.
 
 ___
 
@@ -1319,6 +2145,82 @@ ___
 ### reapPage(message_origin: `CumulusPrimitivesCoreAggregateMessageOrigin`, page_index: `u32`)
 - **interface**: `api.tx.messageQueue.reapPage`
 - **summary**:    Remove a page which has no more messages remaining to be processed or is stale. 
+
+___
+
+
+## multiBlockElection
+ 
+### manage(op: `PalletElectionProviderMultiBlockAdminOperation`)
+- **interface**: `api.tx.multiBlockElection.manage`
+- **summary**:    Manage this pallet. 
+
+   The origin of this call must be [`Config::AdminOrigin`]. 
+
+   See [`AdminOperation`] for various operations that are possible. 
+
+___
+
+
+## multiBlockElectionSigned
+ 
+### bail()
+- **interface**: `api.tx.multiBlockElectionSigned.bail`
+- **summary**:    Retract a submission. 
+
+   A portion of the deposit may be returned, based on the [`Config::BailoutGraceRatio`]. 
+
+   This will fully remove the solution from storage. 
+ 
+### clearOldRoundData(round: `u32`, witness_pages: `u32`)
+- **interface**: `api.tx.multiBlockElectionSigned.clearOldRoundData`
+- **summary**:    Clear the data of a submitter form an old round. 
+
+   The dispatch origin of this call must be signed, and the original submitter. 
+
+   This can only be called for submissions that end up being discarded, as in they are not  processed and they end up lingering in the queue. 
+ 
+### register(claimed_score: `SpNposElectionsElectionScore`)
+- **interface**: `api.tx.multiBlockElectionSigned.register`
+- **summary**:    Register oneself for an upcoming signed election. 
+ 
+### setInvulnerables(inv: `Vec<AccountId32>`)
+- **interface**: `api.tx.multiBlockElectionSigned.setInvulnerables`
+- **summary**:    Set the invulnerable list. 
+
+   Dispatch origin must the the same as [`crate::Config::AdminOrigin`]. 
+ 
+### submitPage(page: `u32`, maybe_solution: `Option<AssetHubPolkadotRuntimeStakingNposCompactSolution16>`)
+- **interface**: `api.tx.multiBlockElectionSigned.submitPage`
+- **summary**:    Submit a single page of a solution. 
+
+   Must always come after [`Pallet::register`]. 
+
+   `maybe_solution` can be set to `None` to erase the page. 
+
+   Collects deposits from the signed origin based on [`Config::DepositBase`] and  [`Config::DepositPerPage`]. 
+
+___
+
+
+## multiBlockElectionUnsigned
+ 
+### submitUnsigned(paged_solution: `PalletElectionProviderMultiBlockPagedRawSolution`)
+- **interface**: `api.tx.multiBlockElectionUnsigned.submitUnsigned`
+- **summary**:    Submit an unsigned solution. 
+
+   This works very much like an inherent, as only the validators are permitted to submit  anything. By default validators will compute this call in their `offchain_worker` hook  and try and submit it back. 
+
+   This is different from signed page submission mainly in that the solution page is  verified on the fly. 
+
+   The `paged_solution` may contain at most [`Config::MinerPages`] pages. They are  interpreted as msp -> lsp, as per [`crate::Pallet::msp_range_for`]. 
+
+   For example, if `Pages = 4`, and `MinerPages = 2`, our full snapshot range would be [0,  1, 2, 3], with 3 being msp. But, in this case, then the `paged_raw_solution.pages` is  expected to correspond to `[snapshot(2), snapshot(3)]`. 
+
+___
+
+
+## multiBlockElectionVerifier
 
 ___
 
@@ -2121,6 +3023,301 @@ ___
 ___
 
 
+## nominationPools
+ 
+### adjustPoolDeposit(pool_id: `u32`)
+- **interface**: `api.tx.nominationPools.adjustPoolDeposit`
+- **summary**:    Top up the deficit or withdraw the excess ED from the pool. 
+
+   When a pool is created, the pool depositor transfers ED to the reward account of the  pool. ED is subject to change and over time, the deposit in the reward account may be  insufficient to cover the ED deficit of the pool or vice-versa where there is excess  deposit to the pool. This call allows anyone to adjust the ED deposit of the  pool by either topping up the deficit or claiming the excess. 
+ 
+### applySlash(member_account: `MultiAddress`)
+- **interface**: `api.tx.nominationPools.applySlash`
+- **summary**:    Apply a pending slash on a member. 
+
+   Fails unless [`crate::pallet::Config::StakeAdapter`] is of strategy type:  [`adapter::StakeStrategyType::Delegate`]. 
+
+   The pending slash amount of the member must be equal or more than `ExistentialDeposit`.  This call can be dispatched permissionlessly (i.e. by any account). If the execution  is successful, fee is refunded and caller may be rewarded with a part of the slash  based on the [`crate::pallet::Config::StakeAdapter`] configuration. 
+ 
+### bondExtra(extra: `PalletNominationPoolsBondExtra`)
+- **interface**: `api.tx.nominationPools.bondExtra`
+- **summary**:    Bond `extra` more funds from `origin` into the pool to which they already belong. 
+
+   Additional funds can come from either the free balance of the account, of from the  accumulated rewards, see [`BondExtra`]. 
+
+   Bonding extra funds implies an automatic payout of all pending rewards as well.  See `bond_extra_other` to bond pending rewards of `other` members. 
+ 
+### bondExtraOther(member: `MultiAddress`, extra: `PalletNominationPoolsBondExtra`)
+- **interface**: `api.tx.nominationPools.bondExtraOther`
+- **summary**:    `origin` bonds funds from `extra` for some pool member `member` into their respective  pools. 
+
+   `origin` can bond extra funds from free balance or pending rewards when `origin ==  other`. 
+
+   In the case of `origin != other`, `origin` can only bond extra pending rewards of  `other` members assuming set_claim_permission for the given member is  `PermissionlessCompound` or `PermissionlessAll`. 
+ 
+### chill(pool_id: `u32`)
+- **interface**: `api.tx.nominationPools.chill`
+- **summary**:    Chill on behalf of the pool. 
+
+   The dispatch origin of this call can be signed by the pool nominator or the pool  root role, same as [`Pallet::nominate`]. 
+
+   This directly forwards the call to an implementation of `StakingInterface` (e.g.,  `pallet-staking`) through [`Config::StakeAdapter`], on behalf of the bonded pool. 
+
+   Under certain conditions, this call can be dispatched permissionlessly (i.e. by any  account). 
+
+   #### Conditions for a permissionless dispatch: 
+
+  * When pool depositor has less than `MinNominatorBond` staked, otherwise pool members are unable to unbond. 
+
+   #### Conditions for permissioned dispatch: 
+
+  * The caller is the pool's nominator or root.
+ 
+### claimCommission(pool_id: `u32`)
+- **interface**: `api.tx.nominationPools.claimCommission`
+- **summary**:    Claim pending commission. 
+
+   The `root` role of the pool is _always_ allowed to claim the pool's commission. 
+
+   If the pool has set `CommissionClaimPermission::Permissionless`, then any account can  trigger the process of claiming the pool's commission. 
+
+   If the pool has set its `CommissionClaimPermission` to `Account(acc)`, then only  accounts 
+
+  * `acc`, and
+
+  * the pool's root account
+
+   may call this extrinsic on behalf of the pool. 
+
+   Pending commissions are paid out and added to the total claimed commission.  The total pending commission is reset to zero. 
+ 
+### claimPayout()
+- **interface**: `api.tx.nominationPools.claimPayout`
+- **summary**:    A bonded member can use this to claim their payout based on the rewards that the pool  has accumulated since their last claimed payout (OR since joining if this is their first  time claiming rewards). The payout will be transferred to the member's account. 
+
+   The member will earn rewards pro rata based on the members stake vs the sum of the  members in the pools stake. Rewards do not "expire". 
+
+   See `claim_payout_other` to claim rewards on behalf of some `other` pool member. 
+ 
+### claimPayoutOther(other: `AccountId32`)
+- **interface**: `api.tx.nominationPools.claimPayoutOther`
+- **summary**:    `origin` can claim payouts on some pool member `other`'s behalf. 
+
+   Pool member `other` must have a `PermissionlessWithdraw` or `PermissionlessAll` claim  permission for this call to be successful. 
+ 
+### create(amount: `Compact<u128>`, root: `MultiAddress`, nominator: `MultiAddress`, bouncer: `MultiAddress`)
+- **interface**: `api.tx.nominationPools.create`
+- **summary**:    Create a new delegation pool. 
+
+   #### Arguments 
+
+   * `amount` - The amount of funds to delegate to the pool. This also acts of a sort of  deposit since the pools creator cannot fully unbond funds until the pool is being  destroyed. 
+
+  * `index` - A disambiguation index for creating the account. Likely only useful when creating multiple pools in the same extrinsic. 
+
+  * `root` - The account to set as [`PoolRoles::root`].
+
+  * `nominator` - The account to set as the [`PoolRoles::nominator`].
+
+  * `bouncer` - The account to set as the [`PoolRoles::bouncer`].
+
+   #### Note 
+
+   In addition to `amount`, the caller will transfer the existential deposit; so the caller  needs at have at least `amount + existential_deposit` transferable. 
+ 
+### createWithPoolId(amount: `Compact<u128>`, root: `MultiAddress`, nominator: `MultiAddress`, bouncer: `MultiAddress`, pool_id: `u32`)
+- **interface**: `api.tx.nominationPools.createWithPoolId`
+- **summary**:    Create a new delegation pool with a previously used pool id 
+
+   #### Arguments 
+
+   same as `create` with the inclusion of 
+
+  * `pool_id` - `A valid PoolId.
+ 
+### join(amount: `Compact<u128>`, pool_id: `u32`)
+- **interface**: `api.tx.nominationPools.join`
+- **summary**:    Stake funds with a pool. The amount to bond is delegated (or transferred based on  [`adapter::StakeStrategyType`]) from the member to the pool account and immediately  increases the pool's bond. 
+
+   The method of transferring the amount to the pool account is determined by  [`adapter::StakeStrategyType`]. If the pool is configured to use  [`adapter::StakeStrategyType::Delegate`], the funds remain in the account of  the `origin`, while the pool gains the right to use these funds for staking. 
+
+   #### Note 
+
+   * An account can only be a member of a single pool. 
+
+  * An account cannot join the same pool multiple times.
+
+  * This call will *not* dust the member account, so the member must have at least `existential deposit + amount` in their account. 
+
+  * Only a pool with [`PoolState::Open`] can be joined
+ 
+### migrateDelegation(member_account: `MultiAddress`)
+- **interface**: `api.tx.nominationPools.migrateDelegation`
+- **summary**:    Migrates delegated funds from the pool account to the `member_account`. 
+
+   Fails unless [`crate::pallet::Config::StakeAdapter`] is of strategy type:  [`adapter::StakeStrategyType::Delegate`]. 
+
+   This is a permission-less call and refunds any fee if claim is successful. 
+
+   If the pool has migrated to delegation based staking, the staked tokens of pool members  can be moved and held in their own account. See [`adapter::DelegateStake`] 
+ 
+### migratePoolToDelegateStake(pool_id: `u32`)
+- **interface**: `api.tx.nominationPools.migratePoolToDelegateStake`
+- **summary**:    Migrate pool from [`adapter::StakeStrategyType::Transfer`] to  [`adapter::StakeStrategyType::Delegate`]. 
+
+   Fails unless [`crate::pallet::Config::StakeAdapter`] is of strategy type:  [`adapter::StakeStrategyType::Delegate`]. 
+
+   This call can be dispatched permissionlessly, and refunds any fee if successful. 
+
+   If the pool has already migrated to delegation based staking, this call will fail. 
+ 
+### nominate(pool_id: `u32`, validators: `Vec<AccountId32>`)
+- **interface**: `api.tx.nominationPools.nominate`
+- **summary**:    Nominate on behalf of the pool. 
+
+   The dispatch origin of this call must be signed by the pool nominator or the pool  root role. 
+
+   This directly forwards the call to an implementation of `StakingInterface` (e.g.,  `pallet-staking`) through [`Config::StakeAdapter`], on behalf of the bonded pool. 
+
+   #### Note 
+
+   In addition to a `root` or `nominator` role of `origin`, the pool's depositor needs to  have at least `depositor_min_bond` in the pool to start nominating. 
+ 
+### poolWithdrawUnbonded(pool_id: `u32`, num_slashing_spans: `u32`)
+- **interface**: `api.tx.nominationPools.poolWithdrawUnbonded`
+- **summary**:    Call `withdraw_unbonded` for the pools account. This call can be made by any account. 
+
+   This is useful if there are too many unlocking chunks to call `unbond`, and some  can be cleared by withdrawing. In the case there are too many unlocking chunks, the user  would probably see an error like `NoMoreChunks` emitted from the staking system when  they attempt to unbond. 
+ 
+### setClaimPermission(permission: `PalletNominationPoolsClaimPermission`)
+- **interface**: `api.tx.nominationPools.setClaimPermission`
+- **summary**:    Allows a pool member to set a claim permission to allow or disallow permissionless  bonding and withdrawing. 
+
+   #### Arguments 
+
+   * `origin` - Member of a pool. 
+
+  * `permission` - The permission to be applied.
+ 
+### setCommission(pool_id: `u32`, new_commission: `Option<(Perbill,AccountId32)>`)
+- **interface**: `api.tx.nominationPools.setCommission`
+- **summary**:    Set the commission of a pool.  Both a commission percentage and a commission payee must be provided in the `current`  tuple. Where a `current` of `None` is provided, any current commission will be removed. 
+
+   - If a `None` is supplied to `new_commission`, existing commission will be removed. 
+ 
+### setCommissionChangeRate(pool_id: `u32`, change_rate: `PalletNominationPoolsCommissionChangeRate`)
+- **interface**: `api.tx.nominationPools.setCommissionChangeRate`
+- **summary**:    Set the commission change rate for a pool. 
+
+   Initial change rate is not bounded, whereas subsequent updates can only be more  restrictive than the current. 
+ 
+### setCommissionClaimPermission(pool_id: `u32`, permission: `Option<PalletNominationPoolsCommissionClaimPermission>`)
+- **interface**: `api.tx.nominationPools.setCommissionClaimPermission`
+- **summary**:    Set or remove a pool's commission claim permission. 
+
+   Determines who can claim the pool's pending commission. Only the `Root` role of the pool  is able to configure commission claim permissions. 
+ 
+### setCommissionMax(pool_id: `u32`, max_commission: `Perbill`)
+- **interface**: `api.tx.nominationPools.setCommissionMax`
+- **summary**:    Set the maximum commission of a pool. 
+
+   - Initial max can be set to any `Perbill`, and only smaller values thereafter. 
+
+  - Current commission will be lowered in the event it is higher than a new max commission. 
+ 
+### setConfigs(min_join_bond: `PalletNominationPoolsConfigOpU128`, min_create_bond: `PalletNominationPoolsConfigOpU128`, max_pools: `PalletNominationPoolsConfigOpU32`, max_members: `PalletNominationPoolsConfigOpU32`, max_members_per_pool: `PalletNominationPoolsConfigOpU32`, global_max_commission: `PalletNominationPoolsConfigOpPerbill`)
+- **interface**: `api.tx.nominationPools.setConfigs`
+- **summary**:    Update configurations for the nomination pools. The origin for this call must be  [`Config::AdminOrigin`]. 
+
+   #### Arguments 
+
+   * `min_join_bond` - Set [`MinJoinBond`]. 
+
+  * `min_create_bond` - Set [`MinCreateBond`].
+
+  * `max_pools` - Set [`MaxPools`].
+
+  * `max_members` - Set [`MaxPoolMembers`].
+
+  * `max_members_per_pool` - Set [`MaxPoolMembersPerPool`].
+
+  * `global_max_commission` - Set [`GlobalMaxCommission`].
+ 
+### setMetadata(pool_id: `u32`, metadata: `Bytes`)
+- **interface**: `api.tx.nominationPools.setMetadata`
+- **summary**:    Set a new metadata for the pool. 
+
+   The dispatch origin of this call must be signed by the bouncer, or the root role of the  pool. 
+ 
+### setState(pool_id: `u32`, state: `PalletNominationPoolsPoolState`)
+- **interface**: `api.tx.nominationPools.setState`
+- **summary**:    Set a new state for the pool. 
+
+   If a pool is already in the `Destroying` state, then under no condition can its state  change again. 
+
+   The dispatch origin of this call must be either: 
+
+   1. signed by the bouncer, or the root role of the pool,  2. if the pool conditions to be open are NOT met (as described by `ok_to_be_open`), and  then the state of the pool can be permissionlessly changed to `Destroying`. 
+ 
+### unbond(member_account: `MultiAddress`, unbonding_points: `Compact<u128>`)
+- **interface**: `api.tx.nominationPools.unbond`
+- **summary**:    Unbond up to `unbonding_points` of the `member_account`'s funds from the pool. It  implicitly collects the rewards one last time, since not doing so would mean some  rewards would be forfeited. 
+
+   Under certain conditions, this call can be dispatched permissionlessly (i.e. by any  account). 
+
+   #### Conditions for a permissionless dispatch. 
+
+   * The pool is blocked and the caller is either the root or bouncer. This is refereed to  as a kick. 
+
+  * The pool is destroying and the member is not the depositor.
+
+  * The pool is destroying, the member is the depositor and no other members are in the pool. 
+
+   #### Conditions for permissioned dispatch (i.e. the caller is also the  `member_account`): 
+
+   * The caller is not the depositor. 
+
+  * The caller is the depositor, the pool is destroying and no other members are in the pool. 
+
+   #### Note 
+
+   If there are too many unlocking chunks to unbond with the pool account,  [`Call::pool_withdraw_unbonded`] can be called to try and minimize unlocking chunks.  The [`StakingInterface::unbond`] will implicitly call [`Call::pool_withdraw_unbonded`]  to try to free chunks if necessary (ie. if unbound was called and no unlocking chunks  are available). However, it may not be possible to release the current unlocking chunks,  in which case, the result of this call will likely be the `NoMoreChunks` error from the  staking system. 
+ 
+### updateRoles(pool_id: `u32`, new_root: `PalletNominationPoolsConfigOpAccountId32`, new_nominator: `PalletNominationPoolsConfigOpAccountId32`, new_bouncer: `PalletNominationPoolsConfigOpAccountId32`)
+- **interface**: `api.tx.nominationPools.updateRoles`
+- **summary**:    Update the roles of the pool. 
+
+   The root is the only entity that can change any of the roles, including itself,  excluding the depositor, who can never change. 
+
+   It emits an event, notifying UIs of the role change. This event is quite relevant to  most pool members and they should be informed of changes to pool roles. 
+ 
+### withdrawUnbonded(member_account: `MultiAddress`, num_slashing_spans: `u32`)
+- **interface**: `api.tx.nominationPools.withdrawUnbonded`
+- **summary**:    Withdraw unbonded funds from `member_account`. If no bonded funds can be unbonded, an  error is returned. 
+
+   Under certain conditions, this call can be dispatched permissionlessly (i.e. by any  account). 
+
+   #### Conditions for a permissionless dispatch 
+
+   * The pool is in destroy mode and the target is not the depositor. 
+
+  * The target is the depositor and they are the only member in the sub pools.
+
+  * The pool is blocked and the caller is either the root or bouncer.
+
+   #### Conditions for permissioned dispatch 
+
+   * The caller is the target and they are not the depositor. 
+
+   #### Note 
+
+   - If the target is the depositor, the pool will be destroyed. 
+
+  - If the pool has any pending slash, we also try to slash the member before letting them withdraw. This calculation adds some weight overhead and is only defensive. In reality,  pool slashes must have been already applied via permissionless [`Call::apply_slash`]. 
+
+___
+
+
 ## parachainInfo
 
 ___
@@ -2128,7 +3325,7 @@ ___
 
 ## parachainSystem
  
-### setValidationData(data: `CumulusPrimitivesParachainInherentParachainInherentData`)
+### setValidationData(data: `CumulusPalletParachainSystemParachainInherentBasicParachainInherentData`, inbound_messages_data: `CumulusPalletParachainSystemParachainInherentInboundMessagesData`)
 - **interface**: `api.tx.parachainSystem.setValidationData`
 - **summary**:    Set the current validation data. 
 
@@ -2140,6 +3337,17 @@ ___
  
 ### sudoSendUpwardMessage(message: `Bytes`)
 - **interface**: `api.tx.parachainSystem.sudoSendUpwardMessage`
+
+___
+
+
+## parameters
+ 
+### setParameter(key_value: `AssetHubPolkadotRuntimeRuntimeParameters`)
+- **interface**: `api.tx.parameters.setParameter`
+- **summary**:    Set the value of a parameter. 
+
+   The dispatch origin of this call must be `AdminOrigin` for the given `key`. Values be  deleted by setting them to `None`. 
 
 ___
 
@@ -2903,6 +4111,45 @@ ___
 ___
 
 
+## preimage
+ 
+### ensureUpdated(hashes: `Vec<H256>`)
+- **interface**: `api.tx.preimage.ensureUpdated`
+- **summary**:    Ensure that the bulk of pre-images is upgraded. 
+
+   The caller pays no fee if at least 90% of pre-images were successfully updated. 
+ 
+### notePreimage(bytes: `Bytes`)
+- **interface**: `api.tx.preimage.notePreimage`
+- **summary**:    Register a preimage on-chain. 
+
+   If the preimage was previously requested, no fees or deposits are taken for providing  the preimage. Otherwise, a deposit is taken proportional to the size of the preimage. 
+ 
+### requestPreimage(hash: `H256`)
+- **interface**: `api.tx.preimage.requestPreimage`
+- **summary**:    Request a preimage be uploaded to the chain without paying any fees or deposits. 
+
+   If the preimage requests has already been provided on-chain, we unreserve any deposit  a user may have paid, and take the control of the preimage out of their hands. 
+ 
+### unnotePreimage(hash: `H256`)
+- **interface**: `api.tx.preimage.unnotePreimage`
+- **summary**:    Clear an unrequested preimage from the runtime storage. 
+
+   If `len` is provided, then it will be a much cheaper operation. 
+
+   - `hash`: The hash of the preimage to be removed from the store. 
+
+  - `len`: The length of the preimage of `hash`.
+ 
+### unrequestPreimage(hash: `H256`)
+- **interface**: `api.tx.preimage.unrequestPreimage`
+- **summary**:    Clear a previously made request for a preimage. 
+
+   NOTE: THIS MUST NOT BE CALLED ON `hash` MORE TIMES THAN `request_preimage`. 
+
+___
+
+
 ## proxy
  
 ### addProxy(delegate: `MultiAddress`, proxy_type: `AssetHubPolkadotRuntimeProxyType`, delay: `u32`)
@@ -2959,19 +4206,19 @@ ___
 
    WARNING: **All access to this account will be lost.** Any funds held in it will be  inaccessible. 
 
-   Requires a `Signed` origin, and the sender account must have been created by a call to  `pure` with corresponding parameters. 
+   Requires a `Signed` origin, and the sender account must have been created by a call to  `create_pure` with corresponding parameters. 
 
-   - `spawner`: The account that originally called `pure` to create this account. 
+   - `spawner`: The account that originally called `create_pure` to create this account. 
 
-  - `index`: The disambiguation index originally passed to `pure`. Probably `0`.
+  - `index`: The disambiguation index originally passed to `create_pure`. Probably `0`.
 
-  - `proxy_type`: The proxy type originally passed to `pure`.
+  - `proxy_type`: The proxy type originally passed to `create_pure`.
 
-  - `height`: The height of the chain when the call to `pure` was processed.
+  - `height`: The height of the chain when the call to `create_pure` was processed.
 
-  - `ext_index`: The extrinsic index in which the call to `pure` was processed.
+  - `ext_index`: The extrinsic index in which the call to `create_pure` was processed.
 
-   Fails with `NoPermission` in case the caller is not a previously created pure  account whose `pure` call has corresponding parameters. 
+   Fails with `NoPermission` in case the caller is not a previously created pure  account whose `create_pure` call has corresponding parameters. 
  
 ### pokeDeposit()
 - **interface**: `api.tx.proxy.pokeDeposit`
@@ -3047,7 +4294,7 @@ ___
 
    The dispatch origin for this call must be _Signed_. 
 
-   WARNING: This may be called on accounts created by `pure`, however if done, then  the unreserved fees will be inaccessible. **All access to this account will be lost.** 
+   WARNING: This may be called on accounts created by `create_pure`, however if done, then  the unreserved fees will be inaccessible. **All access to this account will be lost.** 
  
 ### removeProxy(delegate: `MultiAddress`, proxy_type: `AssetHubPolkadotRuntimeProxyType`, delay: `u32`)
 - **interface**: `api.tx.proxy.removeProxy`
@@ -3060,6 +4307,162 @@ ___
   - `proxy`: The account that the `caller` would like to remove as a proxy.
 
   - `proxy_type`: The permissions currently enabled for the removed proxy account.
+
+___
+
+
+## referenda
+ 
+### cancel(index: `u32`)
+- **interface**: `api.tx.referenda.cancel`
+- **summary**:    Cancel an ongoing referendum. 
+
+   - `origin`: must be the `CancelOrigin`. 
+
+  - `index`: The index of the referendum to be cancelled.
+
+   Emits `Cancelled`. 
+ 
+### kill(index: `u32`)
+- **interface**: `api.tx.referenda.kill`
+- **summary**:    Cancel an ongoing referendum and slash the deposits. 
+
+   - `origin`: must be the `KillOrigin`. 
+
+  - `index`: The index of the referendum to be cancelled.
+
+   Emits `Killed` and `DepositSlashed`. 
+ 
+### nudgeReferendum(index: `u32`)
+- **interface**: `api.tx.referenda.nudgeReferendum`
+- **summary**:    Advance a referendum onto its next logical state. Only used internally. 
+
+   - `origin`: must be `Root`. 
+
+  - `index`: the referendum to be advanced.
+ 
+### oneFewerDeciding(track: `u16`)
+- **interface**: `api.tx.referenda.oneFewerDeciding`
+- **summary**:    Advance a track onto its next logical state. Only used internally. 
+
+   - `origin`: must be `Root`. 
+
+  - `track`: the track to be advanced.
+
+   Action item for when there is now one fewer referendum in the deciding phase and the  `DecidingCount` is not yet updated. This means that we should either: 
+
+  - begin deciding another referendum (and leave `DecidingCount` alone); or
+
+  - decrement `DecidingCount`.
+ 
+### placeDecisionDeposit(index: `u32`)
+- **interface**: `api.tx.referenda.placeDecisionDeposit`
+- **summary**:    Post the Decision Deposit for a referendum. 
+
+   - `origin`: must be `Signed` and the account must have funds available for the  referendum's track's Decision Deposit. 
+
+  - `index`: The index of the submitted referendum whose Decision Deposit is yet to be posted. 
+
+   Emits `DecisionDepositPlaced`. 
+ 
+### refundDecisionDeposit(index: `u32`)
+- **interface**: `api.tx.referenda.refundDecisionDeposit`
+- **summary**:    Refund the Decision Deposit for a closed referendum back to the depositor. 
+
+   - `origin`: must be `Signed` or `Root`. 
+
+  - `index`: The index of a closed referendum whose Decision Deposit has not yet been refunded. 
+
+   Emits `DecisionDepositRefunded`. 
+ 
+### refundSubmissionDeposit(index: `u32`)
+- **interface**: `api.tx.referenda.refundSubmissionDeposit`
+- **summary**:    Refund the Submission Deposit for a closed referendum back to the depositor. 
+
+   - `origin`: must be `Signed` or `Root`. 
+
+  - `index`: The index of a closed referendum whose Submission Deposit has not yet been refunded. 
+
+   Emits `SubmissionDepositRefunded`. 
+ 
+### setMetadata(index: `u32`, maybe_hash: `Option<H256>`)
+- **interface**: `api.tx.referenda.setMetadata`
+- **summary**:    Set or clear metadata of a referendum. 
+
+   Parameters: 
+
+  - `origin`: Must be `Signed` by a creator of a referendum or by anyone to clear a metadata of a finished referendum. 
+
+  - `index`:  The index of a referendum to set or clear metadata for.
+
+  - `maybe_hash`: The hash of an on-chain stored preimage. `None` to clear a metadata.
+ 
+### submit(proposal_origin: `AssetHubPolkadotRuntimeOriginCaller`, proposal: `FrameSupportPreimagesBounded`, enactment_moment: `FrameSupportScheduleDispatchTime`)
+- **interface**: `api.tx.referenda.submit`
+- **summary**:    Propose a referendum on a privileged action. 
+
+   - `origin`: must be `SubmitOrigin` and the account must have `SubmissionDeposit` funds  available. 
+
+  - `proposal_origin`: The origin from which the proposal should be executed.
+
+  - `proposal`: The proposal.
+
+  - `enactment_moment`: The moment that the proposal should be enacted.
+
+   Emits `Submitted`. 
+
+___
+
+
+## scheduler
+ 
+### cancel(when: `u32`, index: `u32`)
+- **interface**: `api.tx.scheduler.cancel`
+- **summary**:    Cancel an anonymously scheduled task. 
+ 
+### cancelNamed(id: `[u8;32]`)
+- **interface**: `api.tx.scheduler.cancelNamed`
+- **summary**:    Cancel a named scheduled task. 
+ 
+### cancelRetry(task: `(u32,u32)`)
+- **interface**: `api.tx.scheduler.cancelRetry`
+- **summary**:    Removes the retry configuration of a task. 
+ 
+### cancelRetryNamed(id: `[u8;32]`)
+- **interface**: `api.tx.scheduler.cancelRetryNamed`
+- **summary**:    Cancel the retry configuration of a named task. 
+ 
+### schedule(when: `u32`, maybe_periodic: `Option<(u32,u32)>`, priority: `u8`, call: `Call`)
+- **interface**: `api.tx.scheduler.schedule`
+- **summary**:    Anonymously schedule a task. 
+ 
+### scheduleAfter(after: `u32`, maybe_periodic: `Option<(u32,u32)>`, priority: `u8`, call: `Call`)
+- **interface**: `api.tx.scheduler.scheduleAfter`
+- **summary**:    Anonymously schedule a task after a delay. 
+ 
+### scheduleNamed(id: `[u8;32]`, when: `u32`, maybe_periodic: `Option<(u32,u32)>`, priority: `u8`, call: `Call`)
+- **interface**: `api.tx.scheduler.scheduleNamed`
+- **summary**:    Schedule a named task. 
+ 
+### scheduleNamedAfter(id: `[u8;32]`, after: `u32`, maybe_periodic: `Option<(u32,u32)>`, priority: `u8`, call: `Call`)
+- **interface**: `api.tx.scheduler.scheduleNamedAfter`
+- **summary**:    Schedule a named task after a delay. 
+ 
+### setRetry(task: `(u32,u32)`, retries: `u8`, period: `u32`)
+- **interface**: `api.tx.scheduler.setRetry`
+- **summary**:    Set a retry configuration for a task so that, in case its scheduled run fails, it will  be retried after `period` blocks, for a total amount of `retries` retries or until it  succeeds. 
+
+   Tasks which need to be scheduled for a retry are still subject to weight metering and  agenda space, same as a regular task. If a periodic task fails, it will be scheduled  normally while the task is retrying. 
+
+   Tasks scheduled as a result of a retry for a periodic task are unnamed, non-periodic  clones of the original task. Their retry configuration will be derived from the  original task's configuration, but will have a lower value for `remaining` than the  original `total_retries`. 
+ 
+### setRetryNamed(id: `[u8;32]`, retries: `u8`, period: `u32`)
+- **interface**: `api.tx.scheduler.setRetryNamed`
+- **summary**:    Set a retry configuration for a named task so that, in case its scheduled run fails, it  will be retried after `period` blocks, for a total amount of `retries` retries or until  it succeeds. 
+
+   Tasks which need to be scheduled for a retry are still subject to weight metering and  agenda space, same as a regular task. If a periodic task fails, it will be scheduled  normally while the task is retrying. 
+
+   Tasks scheduled as a result of a retry for a periodic task are unnamed, non-periodic  clones of the original task. Their retry configuration will be derived from the  original task's configuration, but will have a lower value for `remaining` than the  original `total_retries`. 
 
 ___
 
@@ -3087,6 +4490,428 @@ ___
    #### Complexity 
 
   - `O(1)`. Actual cost depends on the number of length of `T::Keys::key_ids()` which is fixed. 
+
+___
+
+
+## snowbridgeSystemFrontend
+ 
+### addTip(message_id: `SnowbridgeCoreRewardMessageId`, asset: `StagingXcmV5Asset`)
+- **interface**: `api.tx.snowbridgeSystemFrontend.addTip`
+- **summary**:    Add an additional relayer tip for a committed message identified by `message_id`.  The tip asset will be swapped for ether. 
+ 
+### registerToken(asset_id: `XcmVersionedLocation`, metadata: `SnowbridgeCoreAssetMetadata`, fee_asset: `StagingXcmV5Asset`)
+- **interface**: `api.tx.snowbridgeSystemFrontend.registerToken`
+- **summary**:    Initiates the registration for a Polkadot-native token as a wrapped ERC20 token on  Ethereum. 
+
+  - `asset_id`: Location of the asset
+
+  - `metadata`: Metadata to include in the instantiated ERC20 contract on Ethereum
+
+   All origins are allowed, however `asset_id` must be a location nested within the origin  consensus system. 
+ 
+### setOperatingMode(mode: `SnowbridgeCoreOperatingModeBasicOperatingMode`)
+- **interface**: `api.tx.snowbridgeSystemFrontend.setOperatingMode`
+- **summary**:    Set the operating mode for exporting messages to Ethereum. 
+
+___
+
+
+## staking
+ 
+### applySlash(slash_era: `u32`, slash_key: `(AccountId32,Perbill,u32)`)
+- **interface**: `api.tx.staking.applySlash`
+- **summary**:    Manually and permissionlessly applies a deferred slash for a given era. 
+
+   Normally, slashes are automatically applied shortly after the start of the `slash_era`.  The automatic application of slashes is handled by the pallet's internal logic, and it  tries to apply one slash page per block of the era.  If for some reason, one era is not enough for applying all slash pages, the remaining  slashes need to be manually (permissionlessly) applied. 
+
+   For a given era x, if at era x+1, slashes are still unapplied, all withdrawals get  blocked, and these need to be manually applied by calling this function.  This function exists as a **fallback mechanism** for this extreme situation, but we  never expect to encounter this in normal scenarios. 
+
+   The parameters for this call can be queried by looking at the `UnappliedSlashes` storage  for eras older than the active era. 
+
+   #### Parameters 
+
+  - `slash_era`: The staking era in which the slash was originally scheduled.
+
+  - `slash_key`: A unique identifier for the slash, represented as a tuple:
+
+  - `stash`: The stash account of the validator being slashed.
+
+  - `slash_fraction`: The fraction of the stake that was slashed.
+
+  - `page_index`: The index of the exposure page being processed.
+
+   #### Behavior 
+
+  - The function is **permissionless**—anyone can call it.
+
+  - The `slash_era` **must be the current era or a past era**. If it is in the future, the  call fails with `EraNotStarted`. 
+
+  - The fee is waived if the slash is successfully applied.
+
+   #### Future Improvement 
+
+  - Implement an **off-chain worker (OCW) task** to automatically apply slashes when there is unused block space, improving efficiency. 
+ 
+### bond(value: `Compact<u128>`, payee: `PalletStakingAsyncRewardDestination`)
+- **interface**: `api.tx.staking.bond`
+- **summary**:    Take the origin account as a stash and lock up `value` of its balance. `controller` will  be the account that controls it. 
+
+   `value` must be more than the `minimum_balance` specified by `T::Currency`. 
+
+   The dispatch origin for this call must be _Signed_ by the stash account. 
+
+   Emits `Bonded`. 
+
+   NOTE: Two of the storage writes (`Self::bonded`, `Self::payee`) are _never_ cleaned  unless the `origin` falls below _existential deposit_ (or equal to 0) and gets removed  as dust. 
+ 
+### bondExtra(max_additional: `Compact<u128>`)
+- **interface**: `api.tx.staking.bondExtra`
+- **summary**:    Add some extra amount that have appeared in the stash `free_balance` into the balance up  for staking. 
+
+   The dispatch origin for this call must be _Signed_ by the stash, not the controller. 
+
+   Use this if there are additional funds in your stash account that you wish to bond.  Unlike [`bond`](Self::bond) or [`unbond`](Self::unbond) this function does not impose  any limitation on the amount that can be added. 
+
+   Emits `Bonded`. 
+ 
+### cancelDeferredSlash(era: `u32`, validator_slashes: `Vec<(AccountId32,Perbill)>`)
+- **interface**: `api.tx.staking.cancelDeferredSlash`
+- **summary**:    Cancels scheduled slashes for a given era before they are applied. 
+
+   This function allows `T::AdminOrigin` to cancel pending slashes for specified validators  in a given era. The cancelled slashes are stored and will be checked when applying  slashes. 
+
+   #### Parameters 
+
+  - `era`: The staking era for which slashes should be cancelled. This is the era where the slash would be applied, not the era in which the offence was committed. 
+
+  - `validator_slashes`: A list of validator stash accounts and their slash fractions to be cancelled. 
+ 
+### chill()
+- **interface**: `api.tx.staking.chill`
+- **summary**:    Declare no desire to either validate or nominate. 
+
+   Effects will be felt at the beginning of the next era. 
+
+   The dispatch origin for this call must be _Signed_ by the controller, not the stash. 
+
+   #### Complexity 
+
+  - Independent of the arguments. Insignificant complexity.
+
+  - Contains one read.
+
+  - Writes are limited to the `origin` account key.
+ 
+### chillOther(stash: `AccountId32`)
+- **interface**: `api.tx.staking.chillOther`
+- **summary**:    Declare a `controller` to stop participating as either a validator or nominator. 
+
+   Effects will be felt at the beginning of the next era. 
+
+   The dispatch origin for this call must be _Signed_, but can be called by anyone. 
+
+   If the caller is the same as the controller being targeted, then no further checks are  enforced, and this function behaves just like `chill`. 
+
+   If the caller is different than the controller being targeted, the following conditions  must be met: 
+
+   * `controller` must belong to a nominator who has become non-decodable, 
+
+   Or: 
+
+   * A `ChillThreshold` must be set and checked which defines how close to the max  nominators or validators we must reach before users can start chilling one-another. 
+
+  * A `MaxNominatorCount` and `MaxValidatorCount` must be set which is used to determine how close we are to the threshold. 
+
+  * A `MinNominatorBond` and `MinValidatorBond` must be set and checked, which determines if this is a person that should be chilled because they have not met the threshold  bond required. 
+
+   This can be helpful if bond requirements are updated, and we need to remove old users  who do not satisfy these requirements. 
+ 
+### deprecateControllerBatch(controllers: `Vec<AccountId32>`)
+- **interface**: `api.tx.staking.deprecateControllerBatch`
+- **summary**:    Updates a batch of controller accounts to their corresponding stash account if they are  not the same. Ignores any controller accounts that do not exist, and does not operate if  the stash and controller are already the same. 
+
+   Effects will be felt instantly (as soon as this function is completed successfully). 
+
+   The dispatch origin must be `T::AdminOrigin`. 
+ 
+### forceApplyMinCommission(validator_stash: `AccountId32`)
+- **interface**: `api.tx.staking.forceApplyMinCommission`
+- **summary**:    Force a validator to have at least the minimum commission. This will not affect a  validator who already has a commission greater than or equal to the minimum. Any account  can call this. 
+ 
+### forceNewEra()
+- **interface**: `api.tx.staking.forceNewEra`
+- **summary**:    Force there to be a new era at the end of the next session. After this, it will be  reset to normal (non-forced) behaviour. 
+
+   The dispatch origin must be Root. 
+
+   #### Warning 
+
+   The election process starts multiple blocks before the end of the era.  If this is called just before a new era is triggered, the election process may not  have enough blocks to get a result. 
+ 
+### forceNewEraAlways()
+- **interface**: `api.tx.staking.forceNewEraAlways`
+- **summary**:    Force there to be a new era at the end of sessions indefinitely. 
+
+   The dispatch origin must be Root. 
+
+   #### Warning 
+
+   The election process starts multiple blocks before the end of the era.  If this is called just before a new era is triggered, the election process may not  have enough blocks to get a result. 
+ 
+### forceNoEras()
+- **interface**: `api.tx.staking.forceNoEras`
+- **summary**:    Force there to be no new eras indefinitely. 
+
+   The dispatch origin must be Root. 
+
+   #### Warning 
+
+   The election process starts multiple blocks before the end of the era.  Thus the election process may be ongoing when this is called. In this case the  election will continue until the next era is triggered. 
+ 
+### forceUnstake(stash: `AccountId32`, num_slashing_spans: `u32`)
+- **interface**: `api.tx.staking.forceUnstake`
+- **summary**:    Force a current staker to become completely unstaked, immediately. 
+
+   The dispatch origin must be Root.  #### Parameters 
+
+   - `stash`: The stash account to be unstaked. 
+
+  - `num_slashing_spans`: **Deprecated**. This parameter is retained for backward compatibility. It no longer has any effect. 
+ 
+### increaseValidatorCount(additional: `Compact<u32>`)
+- **interface**: `api.tx.staking.increaseValidatorCount`
+- **summary**:    Increments the ideal number of validators up to maximum of  `T::MaxValidatorSet`. 
+
+   The dispatch origin must be Root. 
+ 
+### kick(who: `Vec<MultiAddress>`)
+- **interface**: `api.tx.staking.kick`
+- **summary**:    Remove the given nominations from the calling validator. 
+
+   Effects will be felt at the beginning of the next era. 
+
+   The dispatch origin for this call must be _Signed_ by the controller, not the stash. 
+
+   - `who`: A list of nominator stash accounts who are nominating this validator which  should no longer be nominating this validator. 
+
+   Note: Making this call only makes sense if you first set the validator preferences to  block any further nominations. 
+ 
+### migrateCurrency(stash: `AccountId32`)
+- **interface**: `api.tx.staking.migrateCurrency`
+- **summary**:    Migrates permissionlessly a stash from locks to holds. 
+
+   This removes the old lock on the stake and creates a hold on it atomically. If all  stake cannot be held, the best effort is made to hold as much as possible. The remaining  stake is removed from the ledger. 
+
+   The fee is waived if the migration is successful. 
+ 
+### nominate(targets: `Vec<MultiAddress>`)
+- **interface**: `api.tx.staking.nominate`
+- **summary**:    Declare the desire to nominate `targets` for the origin controller. 
+
+   Effects will be felt at the beginning of the next era. 
+
+   The dispatch origin for this call must be _Signed_ by the controller, not the stash. 
+ 
+### payoutStakers(validator_stash: `AccountId32`, era: `u32`)
+- **interface**: `api.tx.staking.payoutStakers`
+- **summary**:    Pay out next page of the stakers behind a validator for the given era. 
+
+   - `validator_stash` is the stash account of the validator. 
+
+  - `era` may be any era between `[current_era - history_depth; current_era]`.
+
+   The origin of this call must be _Signed_. Any account can call this function, even if  it is not one of the stakers. 
+
+   The reward payout could be paged in case there are too many nominators backing the  `validator_stash`. This call will payout unpaid pages in an ascending order. To claim a  specific page, use `payout_stakers_by_page`.` 
+
+   If all pages are claimed, it returns an error `InvalidPage`. 
+ 
+### payoutStakersByPage(validator_stash: `AccountId32`, era: `u32`, page: `u32`)
+- **interface**: `api.tx.staking.payoutStakersByPage`
+- **summary**:    Pay out a page of the stakers behind a validator for the given era and page. 
+
+   - `validator_stash` is the stash account of the validator. 
+
+  - `era` may be any era between `[current_era - history_depth; current_era]`.
+
+  - `page` is the page index of nominators to pay out with value between 0 and `num_nominators / T::MaxExposurePageSize`. 
+
+   The origin of this call must be _Signed_. Any account can call this function, even if  it is not one of the stakers. 
+
+   If a validator has more than [`Config::MaxExposurePageSize`] nominators backing  them, then the list of nominators is paged, with each page being capped at  [`Config::MaxExposurePageSize`.] If a validator has more than one page of nominators,  the call needs to be made for each page separately in order for all the nominators  backing a validator to receive the reward. The nominators are not sorted across pages  and so it should not be assumed the highest staker would be on the topmost page and vice  versa. If rewards are not claimed in [`Config::HistoryDepth`] eras, they are lost. 
+ 
+### pruneEraStep(era: `u32`)
+- **interface**: `api.tx.staking.pruneEraStep`
+- **summary**:    Perform one step of era pruning to prevent PoV size exhaustion from unbounded deletions. 
+
+   This extrinsic enables permissionless lazy pruning of era data by performing  incremental deletion of storage items. Each call processes a limited number  of items based on available block weight to avoid exceeding block limits. 
+
+   Returns `Pays::No` when work is performed to incentivize regular maintenance.  Anyone can call this to help maintain the chain's storage health. 
+
+   The era must be eligible for pruning (older than HistoryDepth + 1).  Check `EraPruningState` storage to see if an era needs pruning before calling. 
+ 
+### reapStash(stash: `AccountId32`, num_slashing_spans: `u32`)
+- **interface**: `api.tx.staking.reapStash`
+- **summary**:    Remove all data structures concerning a staker/stash once it is at a state where it can  be considered `dust` in the staking system. The requirements are: 
+
+   1. the `total_balance` of the stash is below `min_chilled_bond` or is zero.  2. or, the `ledger.total` of the stash is below `min_chilled_bond` or is zero. 
+
+   The former can happen in cases like a slash; the latter when a fully unbonded account  is still receiving staking rewards in `RewardDestination::Staked`. 
+
+   It can be called by anyone, as long as `stash` meets the above requirements. 
+
+   Refunds the transaction fees upon successful execution. 
+
+   #### Parameters 
+
+   - `stash`: The stash account to be reaped. 
+
+  - `num_slashing_spans`: **Deprecated**. This parameter is retained for backward compatibility. It no longer has any effect. 
+ 
+### rebond(value: `Compact<u128>`)
+- **interface**: `api.tx.staking.rebond`
+- **summary**:    Rebond a portion of the stash scheduled to be unlocked. 
+
+   The dispatch origin must be signed by the controller. 
+ 
+### restoreLedger(stash: `AccountId32`, maybe_controller: `Option<AccountId32>`, maybe_total: `Option<u128>`, maybe_unlocking: `Option<Vec<PalletStakingAsyncLedgerUnlockChunk>>`)
+- **interface**: `api.tx.staking.restoreLedger`
+- **summary**:    Restores the state of a ledger which is in an inconsistent state. 
+
+   The requirements to restore a ledger are the following: 
+
+  * The stash is bonded; or
+
+  * The stash is not bonded but it has a staking lock left behind; or
+
+  * If the stash has an associated ledger and its state is inconsistent; or
+
+  * If the ledger is not corrupted *but* its staking lock is out of sync.
+
+   The `maybe_*` input parameters will overwrite the corresponding data and metadata of the  ledger associated with the stash. If the input parameters are not set, the ledger will  be reset values from on-chain state. 
+ 
+### scaleValidatorCount(factor: `Percent`)
+- **interface**: `api.tx.staking.scaleValidatorCount`
+- **summary**:    Scale up the ideal number of validators by a factor up to maximum of  `T::MaxValidatorSet`. 
+
+   The dispatch origin must be Root. 
+ 
+### setController()
+- **interface**: `api.tx.staking.setController`
+- **summary**:    (Re-)sets the controller of a stash to the stash itself. This function previously  accepted a `controller` argument to set the controller to an account other than the  stash itself. This functionality has now been removed, now only setting the controller  to the stash, if it is not already. 
+
+   Effects will be felt instantly (as soon as this function is completed successfully). 
+
+   The dispatch origin for this call must be _Signed_ by the stash, not the controller. 
+ 
+### setInvulnerables(invulnerables: `Vec<AccountId32>`)
+- **interface**: `api.tx.staking.setInvulnerables`
+- **summary**:    Set the validators who cannot be slashed (if any). 
+
+   The dispatch origin must be Root. 
+ 
+### setMinCommission(new: `Perbill`)
+- **interface**: `api.tx.staking.setMinCommission`
+- **summary**:    Sets the minimum amount of commission that each validators must maintain. 
+
+   This call has lower privilege requirements than `set_staking_config` and can be called  by the `T::AdminOrigin`. Root can always call this. 
+ 
+### setPayee(payee: `PalletStakingAsyncRewardDestination`)
+- **interface**: `api.tx.staking.setPayee`
+- **summary**:    (Re-)set the payment target for a controller. 
+
+   Effects will be felt instantly (as soon as this function is completed successfully). 
+
+   The dispatch origin for this call must be _Signed_ by the controller, not the stash. 
+ 
+### setStakingConfigs(min_nominator_bond: `PalletStakingAsyncPalletConfigOpU128`, min_validator_bond: `PalletStakingAsyncPalletConfigOpU128`, max_nominator_count: `PalletStakingAsyncPalletConfigOpU32`, max_validator_count: `PalletStakingAsyncPalletConfigOpU32`, chill_threshold: `PalletStakingAsyncPalletConfigOpPercent`, min_commission: `PalletStakingAsyncPalletConfigOpPerbill`, max_staked_rewards: `PalletStakingAsyncPalletConfigOpPercent`)
+- **interface**: `api.tx.staking.setStakingConfigs`
+- **summary**:    Update the various staking configurations . 
+
+   * `min_nominator_bond`: The minimum active bond needed to be a nominator. 
+
+  * `min_validator_bond`: The minimum active bond needed to be a validator.
+
+  * `max_nominator_count`: The max number of users who can be a nominator at once. When set to `None`, no limit is enforced. 
+
+  * `max_validator_count`: The max number of users who can be a validator at once. When set to `None`, no limit is enforced. 
+
+  * `chill_threshold`: The ratio of `max_nominator_count` or `max_validator_count` which should be filled in order for the `chill_other` transaction to work. 
+
+  * `min_commission`: The minimum amount of commission that each validators must maintain. This is checked only upon calling `validate`. Existing validators are not affected. 
+
+   RuntimeOrigin must be Root to call this function. 
+
+   NOTE: Existing nominators and validators will not be affected by this update.  to kick people under the new limits, `chill_other` should be called. 
+ 
+### setValidatorCount(new: `Compact<u32>`)
+- **interface**: `api.tx.staking.setValidatorCount`
+- **summary**:    Sets the ideal number of validators. 
+
+   The dispatch origin must be Root. 
+ 
+### unbond(value: `Compact<u128>`)
+- **interface**: `api.tx.staking.unbond`
+- **summary**:    Schedule a portion of the stash to be unlocked ready for transfer out after the bond  period ends. If this leaves an amount actively bonded less than  [`asset::existential_deposit`], then it is increased to the full amount. 
+
+   The dispatch origin for this call must be _Signed_ by the controller, not the stash. 
+
+   Once the unlock period is done, you can call `withdraw_unbonded` to actually move  the funds out of management ready for transfer. 
+
+   No more than a limited number of unlocking chunks (see `MaxUnlockingChunks`)  can co-exists at the same time. If there are no unlocking chunks slots available  [`Call::withdraw_unbonded`] is called to remove some of the chunks (if possible). 
+
+   If a user encounters the `InsufficientBond` error when calling this extrinsic,  they should call `chill` first in order to free up their bonded funds. 
+
+   Emits `Unbonded`. 
+
+   See also [`Call::withdraw_unbonded`]. 
+ 
+### updatePayee(controller: `AccountId32`)
+- **interface**: `api.tx.staking.updatePayee`
+- **summary**:    Migrates an account's `RewardDestination::Controller` to  `RewardDestination::Account(controller)`. 
+
+   Effects will be felt instantly (as soon as this function is completed successfully). 
+
+   This will waive the transaction fee if the `payee` is successfully migrated. 
+ 
+### validate(prefs: `PalletStakingAsyncValidatorPrefs`)
+- **interface**: `api.tx.staking.validate`
+- **summary**:    Declare the desire to validate for the origin controller. 
+
+   Effects will be felt at the beginning of the next era. 
+
+   The dispatch origin for this call must be _Signed_ by the controller, not the stash. 
+ 
+### withdrawUnbonded(num_slashing_spans: `u32`)
+- **interface**: `api.tx.staking.withdrawUnbonded`
+- **summary**:    Remove any stake that has been fully unbonded and is ready for withdrawal. 
+
+   Stake is considered fully unbonded once [`Config::BondingDuration`] has elapsed since  the unbonding was initiated. In rare cases—such as when offences for the unbonded era  have been reported but not yet processed—withdrawal is restricted to eras for which  all offences have been processed. 
+
+   The unlocked stake will be returned as free balance in the stash account. 
+
+   The dispatch origin for this call must be _Signed_ by the controller. 
+
+   Emits `Withdrawn`. 
+
+   See also [`Call::unbond`]. 
+
+   #### Parameters 
+
+   - `num_slashing_spans`: **Deprecated**. Retained only for backward compatibility; this  parameter has no effect. 
+
+___
+
+
+## stakingRcClient
+ 
+### relayNewOffencePaged(offences: `Vec<(u32,PalletStakingAsyncRcClientOffence)>`)
+- **interface**: `api.tx.stakingRcClient.relayNewOffencePaged`
+ 
+### relaySessionReport(report: `PalletStakingAsyncRcClientSessionReport`)
+- **interface**: `api.tx.stakingRcClient.relaySessionReport`
+- **summary**:    Called to indicate the start of a new session on the relay chain. 
 
 ___
 
@@ -3168,6 +4993,9 @@ ___
 
    This call requires Root origin. 
  
+### doTask(task: `AssetHubPolkadotRuntimeRuntimeTask`)
+- **interface**: `api.tx.system.doTask`
+ 
 ### killPrefix(prefix: `Bytes`, subkeys: `u32`)
 - **interface**: `api.tx.system.killPrefix`
 - **summary**:    Kill all storage items with a key that starts with the given prefix. 
@@ -3239,6 +5067,141 @@ ___
 ### reportBridgeStatus(bridge_id: `H256`, is_congested: `bool`)
 - **interface**: `api.tx.toKusamaXcmRouter.reportBridgeStatus`
 - **summary**:    Notification about congested bridge queue. 
+
+___
+
+
+## treasury
+ 
+### checkStatus(index: `u32`)
+- **interface**: `api.tx.treasury.checkStatus`
+- **summary**:    Check the status of the spend and remove it from the storage if processed. 
+
+   #### Dispatch Origin 
+
+   Must be signed. 
+
+   #### Details 
+
+   The status check is a prerequisite for retrying a failed payout.  If a spend has either succeeded or expired, it is removed from the storage by this  function. In such instances, transaction fees are refunded. 
+
+   #### Parameters 
+
+  - `index`: The spend index.
+
+   #### Events 
+
+   Emits [`Event::PaymentFailed`] if the spend payout has failed.  Emits [`Event::SpendProcessed`] if the spend payout has succeed. 
+ 
+### payout(index: `u32`)
+- **interface**: `api.tx.treasury.payout`
+- **summary**:    Claim a spend. 
+
+   #### Dispatch Origin 
+
+   Must be signed 
+
+   #### Details 
+
+   Spends must be claimed within some temporal bounds. A spend may be claimed within one  [`Config::PayoutPeriod`] from the `valid_from` block.  In case of a payout failure, the spend status must be updated with the `check_status`  dispatchable before retrying with the current function. 
+
+   #### Parameters 
+
+  - `index`: The spend index.
+
+   #### Events 
+
+   Emits [`Event::Paid`] if successful. 
+ 
+### removeApproval(proposal_id: `Compact<u32>`)
+- **interface**: `api.tx.treasury.removeApproval`
+- **summary**:    Force a previously approved proposal to be removed from the approval queue. 
+
+   #### Dispatch Origin 
+
+   Must be [`Config::RejectOrigin`]. 
+
+   #### Details 
+
+   The original deposit will no longer be returned. 
+
+   #### Parameters 
+
+  - `proposal_id`: The index of a proposal
+
+   #### Complexity 
+
+  - O(A) where `A` is the number of approvals
+
+   #### Errors 
+
+  - [`Error::ProposalNotApproved`]: The `proposal_id` supplied was not found in the approval queue, i.e., the proposal has not been approved. This could also mean the  proposal does not exist altogether, thus there is no way it would have been approved  in the first place. 
+ 
+### spend(asset_kind: `PolkadotRuntimeCommonImplsVersionedLocatableAsset`, amount: `Compact<u128>`, beneficiary: `ParachainsCommonPayVersionedLocatableAccount`, valid_from: `Option<u32>`)
+- **interface**: `api.tx.treasury.spend`
+- **summary**:    Propose and approve a spend of treasury funds. 
+
+   #### Dispatch Origin 
+
+   Must be [`Config::SpendOrigin`] with the `Success` value being at least  `amount` of `asset_kind` in the native asset. The amount of `asset_kind` is converted  for assertion using the [`Config::BalanceConverter`]. 
+
+   #### Details 
+
+   Create an approved spend for transferring a specific `amount` of `asset_kind` to a  designated beneficiary. The spend must be claimed using the `payout` dispatchable within  the [`Config::PayoutPeriod`]. 
+
+   #### Parameters 
+
+  - `asset_kind`: An indicator of the specific asset class to be spent.
+
+  - `amount`: The amount to be transferred from the treasury to the `beneficiary`.
+
+  - `beneficiary`: The beneficiary of the spend.
+
+  - `valid_from`: The block number from which the spend can be claimed. It can refer to the past if the resulting spend has not yet expired according to the  [`Config::PayoutPeriod`]. If `None`, the spend can be claimed immediately after  approval. 
+
+   #### Events 
+
+   Emits [`Event::AssetSpendApproved`] if successful. 
+ 
+### spendLocal(amount: `Compact<u128>`, beneficiary: `MultiAddress`)
+- **interface**: `api.tx.treasury.spendLocal`
+- **summary**:    Propose and approve a spend of treasury funds. 
+
+   #### Dispatch Origin 
+
+   Must be [`Config::SpendOrigin`] with the `Success` value being at least `amount`. 
+
+   #### Details  NOTE: For record-keeping purposes, the proposer is deemed to be equivalent to the  beneficiary. 
+
+   #### Parameters 
+
+  - `amount`: The amount to be transferred from the treasury to the `beneficiary`.
+
+  - `beneficiary`: The destination account for the transfer.
+
+   #### Events 
+
+   Emits [`Event::SpendApproved`] if successful. 
+ 
+### voidSpend(index: `u32`)
+- **interface**: `api.tx.treasury.voidSpend`
+- **summary**:    Void previously approved spend. 
+
+   #### Dispatch Origin 
+
+   Must be [`Config::RejectOrigin`]. 
+
+   #### Details 
+
+   A spend void is only possible if the payout has not been attempted yet. 
+
+   #### Parameters 
+
+  - `index`: The spend index.
+
+   #### Events 
+
+   Emits [`Event::AssetSpendVoided`] if successful. 
 
 ___
 
@@ -3898,6 +5861,56 @@ ___
    #### Complexity 
 
   - `O(1)`.
+
+___
+
+
+## voterList
+ 
+### putInFrontOf(lighter: `MultiAddress`)
+- **interface**: `api.tx.voterList.putInFrontOf`
+- **summary**:    Move the caller's Id directly in front of `lighter`. 
+
+   The dispatch origin for this call must be _Signed_ and can only be called by the Id of  the account going in front of `lighter`. Fee is payed by the origin under all  circumstances. 
+
+   Only works if: 
+
+   - both nodes are within the same bag, 
+
+  - and `origin` has a greater `Score` than `lighter`.
+ 
+### putInFrontOfOther(heavier: `MultiAddress`, lighter: `MultiAddress`)
+- **interface**: `api.tx.voterList.putInFrontOfOther`
+- **summary**:    Same as [`Pallet::put_in_front_of`], but it can be called by anyone. 
+
+   Fee is paid by the origin under all circumstances. 
+ 
+### rebag(dislocated: `MultiAddress`)
+- **interface**: `api.tx.voterList.rebag`
+- **summary**:    Declare that some `dislocated` account has, through rewards or penalties, sufficiently  changed its score that it should properly fall into a different bag than its current  one. 
+
+   Anyone can call this function about any potentially dislocated account. 
+
+   Will always update the stored score of `dislocated` to the correct score, based on  `ScoreProvider`. 
+
+   If `dislocated` does not exists, it returns an error. 
+
+___
+
+
+## whitelist
+ 
+### dispatchWhitelistedCall(call_hash: `H256`, call_encoded_len: `u32`, call_weight_witness: `SpWeightsWeightV2Weight`)
+- **interface**: `api.tx.whitelist.dispatchWhitelistedCall`
+ 
+### dispatchWhitelistedCallWithPreimage(call: `Call`)
+- **interface**: `api.tx.whitelist.dispatchWhitelistedCallWithPreimage`
+ 
+### removeWhitelistedCall(call_hash: `H256`)
+- **interface**: `api.tx.whitelist.removeWhitelistedCall`
+ 
+### whitelistCall(call_hash: `H256`)
+- **interface**: `api.tx.whitelist.whitelistCall`
 
 ___
 

--- a/docs/asset-hub-polkadot/rpc.md
+++ b/docs/asset-hub-polkadot/rpc.md
@@ -12,8 +12,6 @@ The following sections contain known RPC methods that may be available on specif
 
 - **[dev](#dev)**
 
-- **[engine](#engine)**
-
 - **[offchain](#offchain)**
 
 - **[payment](#payment)**
@@ -160,21 +158,6 @@ ___
 - **jsonrpc**: `dev_getBlockStats`
 - **summary**: Reexecute the specified `block_hash` and gather statistics while doing so
 - **unsafe**: This method is only active with appropriate flags
-
-___
-
-
-## engine
- 
-### createBlock(createEmpty: `bool`, finalize: `bool`, parentHash?: `BlockHash`): `CreatedBlock`
-- **interface**: `api.rpc.engine.createBlock`
-- **jsonrpc**: `engine_createBlock`
-- **summary**: Instructs the manual-seal authorship task to create a new block
- 
-### finalizeBlock(hash: `BlockHash`, justification?: `Justification`): `bool`
-- **interface**: `api.rpc.engine.finalizeBlock`
-- **jsonrpc**: `engine_finalizeBlock`
-- **summary**: Instructs the manual-seal authorship task to finalize a block
 
 ___
 

--- a/docs/asset-hub-polkadot/runtime.md
+++ b/docs/asset-hub-polkadot/runtime.md
@@ -12,6 +12,8 @@ The following section contains known runtime calls that may be available on spec
 
 - **[auraUnincludedSegmentApi](#auraunincludedsegmentapi)**
 
+- **[authorizedAliasersApi](#authorizedaliasersapi)**
+
 - **[blockBuilder](#blockbuilder)**
 
 - **[collectCollationInfo](#collectcollationinfo)**
@@ -24,19 +26,31 @@ The following section contains known runtime calls that may be available on spec
 
 - **[genesisBuilder](#genesisbuilder)**
 
+- **[getParachainInfo](#getparachaininfo)**
+
 - **[locationToAccountApi](#locationtoaccountapi)**
 
 - **[metadata](#metadata)**
 
+- **[nominationPoolsApi](#nominationpoolsapi)**
+
 - **[offchainWorkerApi](#offchainworkerapi)**
 
+- **[relayParentOffsetApi](#relayparentoffsetapi)**
+
+- **[runtimeViewFunction](#runtimeviewfunction)**
+
 - **[sessionKeys](#sessionkeys)**
+
+- **[stakingApi](#stakingapi)**
 
 - **[taggedTransactionQueue](#taggedtransactionqueue)**
 
 - **[transactionPaymentApi](#transactionpaymentapi)**
 
 - **[transactionPaymentCallApi](#transactionpaymentcallapi)**
+
+- **[trustedQueryApi](#trustedqueryapi)**
 
 - **[xcmPaymentApi](#xcmpaymentapi)**
 
@@ -56,17 +70,17 @@ ___
 
 ## assetConversionApi
  
-### getReserves(asset1: `StagingXcmV4Location`, asset2: `StagingXcmV4Location`): `Option<(u128,u128)>`
+### getReserves(asset1: `StagingXcmV5Location`, asset2: `StagingXcmV5Location`): `Option<(u128,u128)>`
 - **interface**: `api.call.assetConversionApi.getReserves`
 - **runtime**: `assetConversionApi_get_reserves`
 - **summary**:  Returns the size of the liquidity pool for the given asset pair.
  
-### quotePriceExactTokensForTokens(asset1: `StagingXcmV4Location`, asset2: `StagingXcmV4Location`, amount: `u128`, include_fee: `bool`): `Option<u128>`
+### quotePriceExactTokensForTokens(asset1: `StagingXcmV5Location`, asset2: `StagingXcmV5Location`, amount: `u128`, include_fee: `bool`): `Option<u128>`
 - **interface**: `api.call.assetConversionApi.quotePriceExactTokensForTokens`
 - **runtime**: `assetConversionApi_quote_price_exact_tokens_for_tokens`
 - **summary**:  Provides a quote for [`Pallet::swap_exact_tokens_for_tokens`].,, Note that the price may have changed by the time the transaction is executed., (Use `amount_out_min` to control slippage.)
  
-### quotePriceTokensForExactTokens(asset1: `StagingXcmV4Location`, asset2: `StagingXcmV4Location`, amount: `u128`, include_fee: `bool`): `Option<u128>`
+### quotePriceTokensForExactTokens(asset1: `StagingXcmV5Location`, asset2: `StagingXcmV5Location`, amount: `u128`, include_fee: `bool`): `Option<u128>`
 - **interface**: `api.call.assetConversionApi.quotePriceTokensForExactTokens`
 - **runtime**: `assetConversionApi_quote_price_tokens_for_exact_tokens`
 - **summary**:  Provides a quote for [`Pallet::swap_tokens_for_exact_tokens`].,, Note that the price may have changed by the time the transaction is executed., (Use `amount_in_max` to control slippage.)
@@ -95,6 +109,21 @@ ___
 - **interface**: `api.call.auraUnincludedSegmentApi.canBuildUpon`
 - **runtime**: `auraUnincludedSegmentApi_can_build_upon`
 - **summary**:  Whether it is legal to extend the chain, assuming the given block is the most, recently included one as-of the relay parent that will be built against, and, the given relay chain slot.,, This should be consistent with the logic the runtime uses when validating blocks to, avoid issues.,, When the unincluded segment is empty, i.e. `included_hash == at`, where at is the block, whose state we are querying against, this must always return `true` as long as the slot, is more recent than the included block itself.
+
+___
+
+
+## authorizedAliasersApi
+ 
+### authorizedAliasers(target: `XcmVersionedLocation`): `Result<Vec<XcmRuntimeApisAuthorizedAliasesOriginAliaser>, XcmRuntimeApisAuthorizedAliasesError>`
+- **interface**: `api.call.authorizedAliasersApi.authorizedAliasers`
+- **runtime**: `authorizedAliasersApi_authorized_aliasers`
+- **summary**:  Returns locations allowed to alias into and act as `target`.
+ 
+### isAuthorizedAlias(origin: `XcmVersionedLocation`, target: `XcmVersionedLocation`): `Result<bool, XcmRuntimeApisAuthorizedAliasesError>`
+- **interface**: `api.call.authorizedAliasersApi.isAuthorizedAlias`
+- **runtime**: `authorizedAliasersApi_is_authorized_alias`
+- **summary**:  Returns whether `origin` is allowed to alias into and act as `target`.
 
 ___
 
@@ -199,6 +228,16 @@ ___
 ___
 
 
+## getParachainInfo
+ 
+### parachainId(): `PolkadotParachainPrimitivesPrimitivesId`
+- **interface**: `api.call.getParachainInfo.parachainId`
+- **runtime**: `getParachainInfo_parachain_id`
+- **summary**:  Retrieve the parachain id used for runtime.
+
+___
+
+
 ## locationToAccountApi
  
 ### convertLocation(location: `XcmVersionedLocation`): `Result<AccountId32, XcmRuntimeApisConversionsError>`
@@ -229,12 +268,87 @@ ___
 ___
 
 
+## nominationPoolsApi
+ 
+### balanceToPoints(pool_id: `u32`, new_funds: `u128`): `u128`
+- **interface**: `api.call.nominationPoolsApi.balanceToPoints`
+- **runtime**: `nominationPoolsApi_balance_to_points`
+- **summary**:  Returns the equivalent points of `new_funds` for a given pool.
+ 
+### memberNeedsDelegateMigration(member: `SpCoreCryptoAccountId32`): `bool`
+- **interface**: `api.call.nominationPoolsApi.memberNeedsDelegateMigration`
+- **runtime**: `nominationPoolsApi_member_needs_delegate_migration`
+- **summary**:  Returns true if the delegated funds of the pool `member` needs migration.,, Once a pool has successfully migrated to the strategy, [`DelegateStake`](pallet_nomination_pools::adapter::DelegateStake), the funds of the, member can be migrated from pool account to the member's account. Use, [`migrate_delegation`](pallet_nomination_pools::Call::migrate_delegation), to migrate the funds of the pool member.
+ 
+### memberPendingSlash(member: `SpCoreCryptoAccountId32`): `u128`
+- **interface**: `api.call.nominationPoolsApi.memberPendingSlash`
+- **runtime**: `nominationPoolsApi_member_pending_slash`
+- **summary**:  Returns the pending slash for a given pool member.,, If pending slash of the member exceeds `ExistentialDeposit`, it can be reported on, chain.
+ 
+### memberTotalBalance(who: `SpCoreCryptoAccountId32`): `u128`
+- **interface**: `api.call.nominationPoolsApi.memberTotalBalance`
+- **runtime**: `nominationPoolsApi_member_total_balance`
+- **summary**:  Returns the total contribution of a pool member including any balance that is unbonding.
+ 
+### pendingRewards(who: `SpCoreCryptoAccountId32`): `u128`
+- **interface**: `api.call.nominationPoolsApi.pendingRewards`
+- **runtime**: `nominationPoolsApi_pending_rewards`
+- **summary**:  Returns the pending rewards for the member that the AccountId was given for.
+ 
+### pointsToBalance(pool_id: `u32`, points: `u128`): `u128`
+- **interface**: `api.call.nominationPoolsApi.pointsToBalance`
+- **runtime**: `nominationPoolsApi_points_to_balance`
+- **summary**:  Returns the equivalent balance of `points` for a given pool.
+ 
+### poolAccounts(pool_id: `u32`): `(AccountId32,AccountId32)`
+- **interface**: `api.call.nominationPoolsApi.poolAccounts`
+- **runtime**: `nominationPoolsApi_pool_accounts`
+- **summary**:  Returns the bonded account and reward account associated with the pool_id.
+ 
+### poolBalance(pool_id: `u32`): `u128`
+- **interface**: `api.call.nominationPoolsApi.poolBalance`
+- **runtime**: `nominationPoolsApi_pool_balance`
+- **summary**:  Total balance contributed to the pool.
+ 
+### poolNeedsDelegateMigration(pool_id: `u32`): `bool`
+- **interface**: `api.call.nominationPoolsApi.poolNeedsDelegateMigration`
+- **runtime**: `nominationPoolsApi_pool_needs_delegate_migration`
+- **summary**:  Returns true if the pool with `pool_id` needs migration.,, This can happen when the `pallet-nomination-pools` has switched to using strategy, [`DelegateStake`](pallet_nomination_pools::adapter::DelegateStake) but the pool, still has funds that were staked using the older strategy, [TransferStake](pallet_nomination_pools::adapter::TransferStake). Use, [`migrate_pool_to_delegate_stake`](pallet_nomination_pools::Call::migrate_pool_to_delegate_stake), to migrate the pool.
+ 
+### poolPendingSlash(pool_id: `u32`): `u128`
+- **interface**: `api.call.nominationPoolsApi.poolPendingSlash`
+- **runtime**: `nominationPoolsApi_pool_pending_slash`
+- **summary**:  Returns the pending slash for a given pool.
+
+___
+
+
 ## offchainWorkerApi
  
 ### offchainWorker(header: `SpRuntimeHeader`): `Null`
 - **interface**: `api.call.offchainWorkerApi.offchainWorker`
 - **runtime**: `offchainWorkerApi_offchain_worker`
 - **summary**:  Starts the off-chain task for given block header.
+
+___
+
+
+## relayParentOffsetApi
+ 
+### relayParentOffset(): `u32`
+- **interface**: `api.call.relayParentOffsetApi.relayParentOffset`
+- **runtime**: `relayParentOffsetApi_relay_parent_offset`
+- **summary**:  Fetch the slot offset that is expected from the relay chain.
+
+___
+
+
+## runtimeViewFunction
+ 
+### executeViewFunction(query_id: `FrameSupportViewFunctionsViewFunctionId`, input: `Bytes`): `Result<Bytes, FrameSupportViewFunctionsViewFunctionDispatchError>`
+- **interface**: `api.call.runtimeViewFunction.executeViewFunction`
+- **runtime**: `runtimeViewFunction_execute_view_function`
+- **summary**:  Execute a view function query.
 
 ___
 
@@ -250,6 +364,26 @@ ___
 - **interface**: `api.call.sessionKeys.generateSessionKeys`
 - **runtime**: `sessionKeys_generate_session_keys`
 - **summary**:  Generate a set of session keys with optionally using the given seed., The keys should be stored within the keystore exposed via runtime, externalities.,, The seed needs to be a valid `utf8` string.,, Returns the concatenated SCALE encoded public keys.
+
+___
+
+
+## stakingApi
+ 
+### erasStakersPageCount(era: `u32`, account: `SpCoreCryptoAccountId32`): `u32`
+- **interface**: `api.call.stakingApi.erasStakersPageCount`
+- **runtime**: `stakingApi_eras_stakers_page_count`
+- **summary**:  Returns the page count of exposures for a validator `account` in a given era.
+ 
+### nominationsQuota(balance: `u128`): `u32`
+- **interface**: `api.call.stakingApi.nominationsQuota`
+- **runtime**: `stakingApi_nominations_quota`
+- **summary**:  Returns the nominations quota for a nominator with a given balance.
+ 
+### pendingRewards(era: `u32`, account: `SpCoreCryptoAccountId32`): `bool`
+- **interface**: `api.call.stakingApi.pendingRewards`
+- **runtime**: `stakingApi_pending_rewards`
+- **summary**:  Returns true if validator `account` has pages to be claimed for the given era.
 
 ___
 
@@ -310,6 +444,21 @@ ___
 - **interface**: `api.call.transactionPaymentCallApi.queryWeightToFee`
 - **runtime**: `transactionPaymentCallApi_query_weight_to_fee`
 - **summary**:  Query the output of the current `WeightToFee` given some input.
+
+___
+
+
+## trustedQueryApi
+ 
+### isTrustedReserve(asset: `XcmVersionedAsset`, location: `XcmVersionedLocation`): `Result<bool, XcmRuntimeApisTrustedQueryError>`
+- **interface**: `api.call.trustedQueryApi.isTrustedReserve`
+- **runtime**: `trustedQueryApi_is_trusted_reserve`
+- **summary**:  Returns if the location is a trusted reserve for the asset.,, # Arguments, * `asset`: `VersionedAsset`., * `location`: `VersionedLocation`.
+ 
+### isTrustedTeleporter(asset: `XcmVersionedAsset`, location: `XcmVersionedLocation`): `Result<bool, XcmRuntimeApisTrustedQueryError>`
+- **interface**: `api.call.trustedQueryApi.isTrustedTeleporter`
+- **runtime**: `trustedQueryApi_is_trusted_teleporter`
+- **summary**:  Returns if the asset can be teleported to the location.,, # Arguments, * `asset`: `VersionedAsset`., * `location`: `VersionedLocation`.
 
 ___
 

--- a/docs/asset-hub-polkadot/storage.md
+++ b/docs/asset-hub-polkadot/storage.md
@@ -6,7 +6,13 @@ The following sections contain Storage methods are part of the default asset-hub
 
 (NOTE: These were generated from a static/snapshot view of a recent default asset-hub-polkadot runtime. Some items may not be available in older nodes, or in any customized implementations.)
 
+- **[ahMigrator](#ahmigrator)**
+
+- **[ahOps](#ahops)**
+
 - **[assetConversion](#assetconversion)**
+
+- **[assetRate](#assetrate)**
 
 - **[assets](#assets)**
 
@@ -18,27 +24,61 @@ The following sections contain Storage methods are part of the default asset-hub
 
 - **[balances](#balances)**
 
+- **[bounties](#bounties)**
+
+- **[childBounties](#childbounties)**
+
+- **[claims](#claims)**
+
 - **[collatorSelection](#collatorselection)**
+
+- **[convictionVoting](#convictionvoting)**
+
+- **[delegatedStaking](#delegatedstaking)**
 
 - **[foreignAssets](#foreignassets)**
 
+- **[indices](#indices)**
+
 - **[messageQueue](#messagequeue)**
+
+- **[multiBlockElection](#multiblockelection)**
+
+- **[multiBlockElectionSigned](#multiblockelectionsigned)**
+
+- **[multiBlockElectionVerifier](#multiblockelectionverifier)**
 
 - **[multisig](#multisig)**
 
 - **[nfts](#nfts)**
 
+- **[nominationPools](#nominationpools)**
+
 - **[parachainInfo](#parachaininfo)**
 
 - **[parachainSystem](#parachainsystem)**
+
+- **[parameters](#parameters)**
 
 - **[polkadotXcm](#polkadotxcm)**
 
 - **[poolAssets](#poolassets)**
 
+- **[preimage](#preimage)**
+
 - **[proxy](#proxy)**
 
+- **[referenda](#referenda)**
+
+- **[scheduler](#scheduler)**
+
 - **[session](#session)**
+
+- **[snowbridgeSystemFrontend](#snowbridgesystemfrontend)**
+
+- **[staking](#staking)**
+
+- **[stakingRcClient](#stakingrcclient)**
 
 - **[stateTrieMigration](#statetriemigration)**
 
@@ -52,12 +92,114 @@ The following sections contain Storage methods are part of the default asset-hub
 
 - **[transactionPayment](#transactionpayment)**
 
+- **[treasury](#treasury)**
+
 - **[uniques](#uniques)**
 
 - **[vesting](#vesting)**
 
+- **[voterList](#voterlist)**
+
+- **[whitelist](#whitelist)**
+
 - **[xcmpQueue](#xcmpqueue)**
 
+
+___
+
+
+## ahMigrator
+ 
+### ahBalancesBefore(): `PalletAhMigratorBalancesBefore`
+- **interface**: `api.query.ahMigrator.ahBalancesBefore`
+- **summary**:    Helper storage item to store the total balance / total issuance of native token at the start  of the migration. Since teleports are disabled during migration, the total issuance will not  change for other reason than the migration itself. 
+ 
+### ahMigrationStage(): `PalletAhMigratorMigrationStage`
+- **interface**: `api.query.ahMigrator.ahMigrationStage`
+- **summary**:    The Asset Hub migration state. 
+ 
+### dmpQueuePriorityConfig(): `PalletRcMigratorQueuePriority`
+- **interface**: `api.query.ahMigrator.dmpQueuePriorityConfig`
+- **summary**:    The priority of the DMP queue during migration. 
+
+   Controls how the DMP (Downward Message Passing) queue is processed relative to other queues  during the migration process. This helps ensure timely processing of migration messages.  The default priority pattern is defined in the pallet configuration, but can be overridden  by a storage value of this type. 
+ 
+### manager(): `Option<AccountId32>`
+- **interface**: `api.query.ahMigrator.manager`
+- **summary**:    An optional account id of a manager. 
+
+   This account id has similar privileges to [`Config::AdminOrigin`] except that it  can not set the manager account id via `set_manager` call. 
+ 
+### migrationEndBlock(): `Option<u32>`
+- **interface**: `api.query.ahMigrator.migrationEndBlock`
+- **summary**:    Block number when migration finished and extrinsics were unlocked. 
+
+   This is set when entering the `MigrationDone` stage hence when  `RcMigrationStage::is_finished()` becomes `true`. 
+ 
+### migrationStartBlock(): `Option<u32>`
+- **interface**: `api.query.ahMigrator.migrationStartBlock`
+- **summary**:    The block number at which the migration began and the pallet's extrinsics were locked. 
+
+   This value is set when entering the `WaitingForAh` stage, i.e., when  `RcMigrationStage::is_ongoing()` becomes `true`. 
+ 
+### rcAccounts(`AccountId32`): `Option<PalletRcMigratorAccountsAccount>`
+- **interface**: `api.query.ahMigrator.rcAccounts`
+- **summary**:    RC accounts that failed to migrate when were received on the Asset Hub. 
+
+   This is unlikely to happen, since we dry run the migration, but we keep it for completeness. 
+
+___
+
+
+## ahOps
+ 
+### rcCrowdloanContribution(`u32, u32, AccountId32`): `Option<(AccountId32,u128)>`
+- **interface**: `api.query.ahOps.rcCrowdloanContribution`
+- **summary**:    Amount of balance that a contributor made towards a crowdloan. 
+
+   `withdraw_crowdloan_contribution` can be permissionlessly called once the block number  passed to unlock the balance for a specific account. 
+
+   The keys are as follows: 
+
+  - Block number after which the balance can be unlocked.
+
+  - The para_id of the crowdloan.
+
+  - The account that made the contribution.
+
+   The value is (fund_pot, balance). The contribution pot is the second key in the  `RcCrowdloanContribution` storage. 
+ 
+### rcCrowdloanReserve(`u32, u32, AccountId32`): `Option<u128>`
+- **interface**: `api.query.ahOps.rcCrowdloanReserve`
+- **summary**:    The reserve that was taken to create a crowdloan. 
+
+   This is normally 500 DOT and can be refunded as last step after all  `RcCrowdloanContribution`s of this loan have been withdrawn. 
+
+   Keys: 
+
+  - Block number after which this can be unreserved
+
+  - The para_id of the crowdloan
+
+  - The account that will have the balance unreserved
+ 
+### rcLeaseReserve(`u32, u32, AccountId32`): `Option<u128>`
+- **interface**: `api.query.ahOps.rcLeaseReserve`
+- **summary**:    Amount of balance that was reserved for winning a lease auction. 
+
+   `unreserve_lease_deposit` can be permissionlessly called once the block number passed to  unreserve the deposit. It is implicitly called by `withdraw_crowdloan_contribution`. 
+
+   The account here can either be a crowdloan account or a solo bidder. If it is a crowdloan  account, then the summed up contributions for it in the contributions map will equate the  reserved balance here. 
+
+   The keys are as follows: 
+
+  - Block number after which the deposit can be unreserved.
+
+  - The para_id of the lease slot.
+
+  - The account that will have the balance unreserved.
+
+  - The balance to be unreserved.
 
 ___
 
@@ -68,9 +210,20 @@ ___
 - **interface**: `api.query.assetConversion.nextPoolAssetId`
 - **summary**:    Stores the `PoolAssetId` that is going to be used for the next lp token.  This gets incremented whenever a new lp pool is created. 
  
-### pools(`(StagingXcmV4Location,StagingXcmV4Location)`): `Option<PalletAssetConversionPoolInfo>`
+### pools(`(StagingXcmV5Location,StagingXcmV5Location)`): `Option<PalletAssetConversionPoolInfo>`
 - **interface**: `api.query.assetConversion.pools`
 - **summary**:    Map from `PoolAssetId` to `PoolInfo`. This establishes whether a pool has been officially  created rather than people sending tokens directly to a pool's public account. 
+
+___
+
+
+## assetRate
+ 
+### conversionRateToNative(`PolkadotRuntimeCommonImplsVersionedLocatableAsset`): `Option<u128>`
+- **interface**: `api.query.assetRate.conversionRateToNative`
+- **summary**:    Maps an asset to its fixed point representation in the native balance. 
+
+   E.g. `native_amount = asset_amount * ConversionRateToNative::<T>::get(asset_kind)` 
 
 ___
 
@@ -163,11 +316,11 @@ ___
 
    But this comes with tradeoffs, storing account balances in the system pallet stores  `frame_system` data alongside the account data contrary to storing account balances in the  `Balances` pallet, which uses a `StorageMap` to store balances data only.  NOTE: This is only used in the case that this pallet is used to store balances. 
  
-### freezes(`AccountId32`): `Vec<FrameSupportTokensMiscIdAmount>`
+### freezes(`AccountId32`): `Vec<FrameSupportTokensMiscIdAmountRuntimeFreezeReason>`
 - **interface**: `api.query.balances.freezes`
 - **summary**:    Freeze locks on account balances. 
  
-### holds(`AccountId32`): `Vec<{"id":"AssetHubPolkadotRuntimeRuntimeHoldReason","amount":"u128"}>`
+### holds(`AccountId32`): `Vec<FrameSupportTokensMiscIdAmountRuntimeHoldReason>`
 - **interface**: `api.query.balances.holds`
 - **summary**:    Holds on account balances. 
  
@@ -190,6 +343,87 @@ ___
 ### totalIssuance(): `u128`
 - **interface**: `api.query.balances.totalIssuance`
 - **summary**:    The total units issued in the system. 
+
+___
+
+
+## bounties
+ 
+### bounties(`u32`): `Option<PalletBountiesBounty>`
+- **interface**: `api.query.bounties.bounties`
+- **summary**:    Bounties that have been made. 
+ 
+### bountyApprovals(): `Vec<u32>`
+- **interface**: `api.query.bounties.bountyApprovals`
+- **summary**:    Bounty indices that have been approved but not yet funded. 
+ 
+### bountyCount(): `u32`
+- **interface**: `api.query.bounties.bountyCount`
+- **summary**:    Number of bounty proposals that have been made. 
+ 
+### bountyDescriptions(`u32`): `Option<Bytes>`
+- **interface**: `api.query.bounties.bountyDescriptions`
+- **summary**:    The description of each bounty. 
+
+___
+
+
+## childBounties
+ 
+### childBounties(`u32, u32`): `Option<PalletChildBountiesChildBounty>`
+- **interface**: `api.query.childBounties.childBounties`
+- **summary**:    Child bounties that have been added. 
+ 
+### childBountyCount(): `u32`
+- **interface**: `api.query.childBounties.childBountyCount`
+- **summary**:    DEPRECATED: Replaced with `ParentTotalChildBounties` storage item keeping dedicated counts  for each parent bounty. Number of total child bounties. Will be removed in May 2025. 
+ 
+### childBountyDescriptionsV1(`u32, u32`): `Option<Bytes>`
+- **interface**: `api.query.childBounties.childBountyDescriptionsV1`
+- **summary**:    The description of each child-bounty. Indexed by `(parent_id, child_id)`. 
+
+   This item replaces the `ChildBountyDescriptions` storage item from the V0 storage version. 
+ 
+### childrenCuratorFees(`u32`): `u128`
+- **interface**: `api.query.childBounties.childrenCuratorFees`
+- **summary**:    The cumulative child-bounty curator fee for each parent bounty. 
+ 
+### parentChildBounties(`u32`): `u32`
+- **interface**: `api.query.childBounties.parentChildBounties`
+- **summary**:    Number of active child bounties per parent bounty.  Map of parent bounty index to number of child bounties. 
+ 
+### parentTotalChildBounties(`u32`): `u32`
+- **interface**: `api.query.childBounties.parentTotalChildBounties`
+- **summary**:    Number of total child bounties per parent bounty, including completed bounties. 
+ 
+### v0ToV1ChildBountyIds(`u32`): `Option<(u32,u32)>`
+- **interface**: `api.query.childBounties.v0ToV1ChildBountyIds`
+- **summary**:    The mapping of the child bounty ids from storage version `V0` to the new `V1` version. 
+
+   The `V0` ids based on total child bounty count [`ChildBountyCount`]`. The `V1` version ids  based on the child bounty count per parent bounty [`ParentTotalChildBounties`].  The item intended solely for client convenience and not used in the pallet's core logic. 
+
+___
+
+
+## claims
+ 
+### claims(`EthereumAddress`): `Option<u128>`
+- **interface**: `api.query.claims.claims`
+ 
+### preclaims(`AccountId32`): `Option<EthereumAddress>`
+- **interface**: `api.query.claims.preclaims`
+- **summary**:    Pre-claimed Ethereum accounts, by the Account ID that they are claimed to. 
+ 
+### signing(`EthereumAddress`): `Option<PolkadotRuntimeCommonClaimsStatementKind>`
+- **interface**: `api.query.claims.signing`
+- **summary**:    The statement kind that must be signed, if any. 
+ 
+### total(): `u128`
+- **interface**: `api.query.claims.total`
+ 
+### vesting(`EthereumAddress`): `Option<(u128,u128,u32)>`
+- **interface**: `api.query.claims.vesting`
+- **summary**:    Vesting schedule for a claim.  First balance is the total amount that should be held for vesting.  Second balance is how much should be unlocked per block.  The block number is when the vesting should start. 
 
 ___
 
@@ -225,31 +459,76 @@ ___
 ___
 
 
+## convictionVoting
+ 
+### classLocksFor(`AccountId32`): `Vec<(u16,u128)>`
+- **interface**: `api.query.convictionVoting.classLocksFor`
+- **summary**:    The voting classes which have a non-zero lock requirement and the lock amounts which they  require. The actual amount locked on behalf of this pallet should always be the maximum of  this list. 
+ 
+### votingFor(`AccountId32, u16`): `PalletConvictionVotingVoteVoting`
+- **interface**: `api.query.convictionVoting.votingFor`
+- **summary**:    All voting for a particular voter in a particular voting class. We store the balance for the  number of votes that we have recorded. 
+
+___
+
+
+## delegatedStaking
+ 
+### agents(`AccountId32`): `Option<PalletDelegatedStakingAgentLedger>`
+- **interface**: `api.query.delegatedStaking.agents`
+- **summary**:    Map of `Agent` to their `Ledger`. 
+ 
+### counterForAgents(): `u32`
+- **interface**: `api.query.delegatedStaking.counterForAgents`
+- **summary**:    Counter for the related counted storage map 
+ 
+### counterForDelegators(): `u32`
+- **interface**: `api.query.delegatedStaking.counterForDelegators`
+- **summary**:    Counter for the related counted storage map 
+ 
+### delegators(`AccountId32`): `Option<PalletDelegatedStakingDelegation>`
+- **interface**: `api.query.delegatedStaking.delegators`
+- **summary**:    Map of Delegators to their `Delegation`. 
+
+   Implementation note: We are not using a double map with `delegator` and `agent` account  as keys since we want to restrict delegators to delegate only to one account at a time. 
+
+___
+
+
 ## foreignAssets
  
-### account(`StagingXcmV4Location, AccountId32`): `Option<PalletAssetsAssetAccount>`
+### account(`StagingXcmV5Location, AccountId32`): `Option<PalletAssetsAssetAccount>`
 - **interface**: `api.query.foreignAssets.account`
 - **summary**:    The holdings of a specific account for a specific asset. 
  
-### approvals(`StagingXcmV4Location, AccountId32, AccountId32`): `Option<PalletAssetsApproval>`
+### approvals(`StagingXcmV5Location, AccountId32, AccountId32`): `Option<PalletAssetsApproval>`
 - **interface**: `api.query.foreignAssets.approvals`
 - **summary**:    Approved balance transfers. First balance is the amount approved for transfer. Second  is the amount of `T::Currency` reserved for storing this.  First key is the asset ID, second key is the owner and third key is the delegate. 
  
-### asset(`StagingXcmV4Location`): `Option<PalletAssetsAssetDetails>`
+### asset(`StagingXcmV5Location`): `Option<PalletAssetsAssetDetails>`
 - **interface**: `api.query.foreignAssets.asset`
 - **summary**:    Details of an asset. 
  
-### metadata(`StagingXcmV4Location`): `{"deposit":"u128","name":"Bytes","symbol":"Bytes","decimals":"u8","isFrozen":"bool"}`
+### metadata(`StagingXcmV5Location`): `{"deposit":"u128","name":"Bytes","symbol":"Bytes","decimals":"u8","isFrozen":"bool"}`
 - **interface**: `api.query.foreignAssets.metadata`
 - **summary**:    Metadata of an asset. 
  
-### nextAssetId(): `Option<StagingXcmV4Location>`
+### nextAssetId(): `Option<StagingXcmV5Location>`
 - **interface**: `api.query.foreignAssets.nextAssetId`
 - **summary**:    The asset ID enforced for the next asset creation, if any present. Otherwise, this storage  item has no effect. 
 
    This can be useful for setting up constraints for IDs of the new assets. For example, by  providing an initial [`NextAssetId`] and using the [`crate::AutoIncAssetId`] callback, an  auto-increment model can be applied to all new asset IDs. 
 
    The initial next asset ID can be set using the [`GenesisConfig`] or the  [SetNextAssetId](`migration::next_asset_id::SetNextAssetId`) migration. 
+
+___
+
+
+## indices
+ 
+### accounts(`u32`): `Option<(AccountId32,u128,bool)>`
+- **interface**: `api.query.indices.accounts`
+- **summary**:    The lookup from index to account. 
 
 ___
 
@@ -267,6 +546,120 @@ ___
 ### serviceHead(): `Option<CumulusPrimitivesCoreAggregateMessageOrigin>`
 - **interface**: `api.query.messageQueue.serviceHead`
 - **summary**:    The origin at which we should begin servicing. 
+
+___
+
+
+## multiBlockElection
+ 
+### currentPhase(): `PalletElectionProviderMultiBlockPhase`
+- **interface**: `api.query.multiBlockElection.currentPhase`
+- **summary**:    Current phase. 
+ 
+### desiredTargets(`u32`): `Option<u32>`
+- **interface**: `api.query.multiBlockElection.desiredTargets`
+- **summary**:    Desired number of targets to elect for this round. 
+ 
+### pagedTargetSnapshot(`u32, u32`): `Option<Vec<AccountId32>>`
+- **interface**: `api.query.multiBlockElection.pagedTargetSnapshot`
+- **summary**:    Paginated target snapshot. 
+
+   For the time being, since we assume one pages of targets, at most ONE key will exist. 
+ 
+### pagedTargetSnapshotHash(`u32, u32`): `Option<H256>`
+- **interface**: `api.query.multiBlockElection.pagedTargetSnapshotHash`
+- **summary**:    Same as [`PagedTargetSnapshot`], but it will store the hash of the snapshot. 
+
+   The hash is generated using [`frame_system::Config::Hashing`]. 
+ 
+### pagedVoterSnapshot(`u32, u32`): `Option<Vec<(AccountId32,u64,Vec<AccountId32>)>>`
+- **interface**: `api.query.multiBlockElection.pagedVoterSnapshot`
+- **summary**:    Paginated voter snapshot. At most [`T::Pages`] keys will exist. 
+ 
+### pagedVoterSnapshotHash(`u32, u32`): `Option<H256>`
+- **interface**: `api.query.multiBlockElection.pagedVoterSnapshotHash`
+- **summary**:    Same as [`PagedVoterSnapshot`], but it will store the hash of the snapshot. 
+
+   The hash is generated using [`frame_system::Config::Hashing`]. 
+ 
+### round(): `u32`
+- **interface**: `api.query.multiBlockElection.round`
+- **summary**:    Internal counter for the number of rounds. 
+
+   This is useful for de-duplication of transactions submitted to the pool, and general  diagnostics of the pallet. 
+
+   This is merely incremented once per every time that an upstream `elect` is called. 
+
+___
+
+
+## multiBlockElectionSigned
+ 
+### invulnerables(): `Vec<AccountId32>`
+- **interface**: `api.query.multiBlockElectionSigned.invulnerables`
+- **summary**:    Accounts whitelisted by governance to always submit their solutions. 
+
+   They are different in that: 
+
+   * They always pay a fixed deposit for submission, specified by  [`Config::InvulnerableDeposit`]. They pay no page deposit. 
+
+  * If _ejected_ by better solution from [`SortedScores`], they will get their full deposit back. 
+
+  * They always get their tx-fee back even if they are _discarded_.
+ 
+### sortedScores(`u32`): `Vec<(AccountId32,SpNposElectionsElectionScore)>`
+- **interface**: `api.query.multiBlockElectionSigned.sortedScores`
+ 
+### submissionMetadataStorage(`u32, AccountId32`): `Option<PalletElectionProviderMultiBlockSignedSubmissionMetadata>`
+- **interface**: `api.query.multiBlockElectionSigned.submissionMetadataStorage`
+- **summary**:    Map from account to the metadata of their submission. 
+
+   invariant: for any Key1 of type `AccountId` in [`Submissions`], this storage map also has a  value. 
+ 
+### submissionStorage(`u32, AccountId32, u32`): `Option<AssetHubPolkadotRuntimeStakingNposCompactSolution16>`
+- **interface**: `api.query.multiBlockElectionSigned.submissionStorage`
+- **summary**:    Triple map from (round, account, page) to a solution page. 
+
+___
+
+
+## multiBlockElectionVerifier
+ 
+### minimumScore(): `Option<SpNposElectionsElectionScore>`
+- **interface**: `api.query.multiBlockElectionVerifier.minimumScore`
+- **summary**:    The minimum score that each solution must attain in order to be considered feasible. 
+ 
+### queuedSolutionBackings(`u32, u32`): `Option<Vec<(AccountId32,PalletElectionProviderMultiBlockVerifierImplsPartialBackings)>>`
+- **interface**: `api.query.multiBlockElectionVerifier.queuedSolutionBackings`
+- **summary**:    The `(amount, count)` of backings, divided per page. 
+
+   This is stored because in the last block of verification we need them to compute the score,  and check `MaxBackersPerWinnerFinal`. 
+
+   This can only ever live for the invalid variant of the solution. Once it is valid, we don't  need this information anymore; the score is already computed once in  [`QueuedSolutionScore`], and the backing counts are checked. 
+ 
+### queuedSolutionScore(`u32`): `Option<SpNposElectionsElectionScore>`
+- **interface**: `api.query.multiBlockElectionVerifier.queuedSolutionScore`
+- **summary**:    The score of the valid variant of [`QueuedSolution`]. 
+
+   This only ever lives for the `valid` variant. 
+ 
+### queuedSolutionX(`u32, u32`): `Option<FrameElectionProviderSupportBoundedSupports>`
+- **interface**: `api.query.multiBlockElectionVerifier.queuedSolutionX`
+- **summary**:    The `X` variant of the current queued solution. Might be the valid one or not. 
+
+   The two variants of this storage item is to avoid the need of copying. Recall that once a  `VerifyingSolution` is being processed, it needs to write its partial supports *somewhere*.  Writing theses supports on top of a *good* queued supports is wrong, since we might bail.  Writing them to a bugger and copying at the ned is slightly better, but expensive. This flag  system is best of both worlds. 
+ 
+### queuedSolutionY(`u32, u32`): `Option<FrameElectionProviderSupportBoundedSupports>`
+- **interface**: `api.query.multiBlockElectionVerifier.queuedSolutionY`
+- **summary**:    The `Y` variant of the current queued solution. Might be the valid one or not. 
+ 
+### queuedValidVariant(`u32`): `PalletElectionProviderMultiBlockVerifierImplsValidSolution`
+- **interface**: `api.query.multiBlockElectionVerifier.queuedValidVariant`
+- **summary**:    Pointer to the variant of [`QueuedSolutionX`] or [`QueuedSolutionY`] that is currently  valid. 
+ 
+### statusStorage(): `PalletElectionProviderMultiBlockVerifierImplsStatus`
+- **interface**: `api.query.multiBlockElectionVerifier.statusStorage`
+- **summary**:    Storage item for [`Status`]. 
 
 ___
 
@@ -345,6 +738,105 @@ ___
 ___
 
 
+## nominationPools
+ 
+### bondedPools(`u32`): `Option<PalletNominationPoolsBondedPoolInner>`
+- **interface**: `api.query.nominationPools.bondedPools`
+- **summary**:    Storage for bonded pools. 
+ 
+### claimPermissions(`AccountId32`): `PalletNominationPoolsClaimPermission`
+- **interface**: `api.query.nominationPools.claimPermissions`
+- **summary**:    Map from a pool member account to their opted claim permission. 
+ 
+### counterForBondedPools(): `u32`
+- **interface**: `api.query.nominationPools.counterForBondedPools`
+- **summary**:    Counter for the related counted storage map 
+ 
+### counterForMetadata(): `u32`
+- **interface**: `api.query.nominationPools.counterForMetadata`
+- **summary**:    Counter for the related counted storage map 
+ 
+### counterForPoolMembers(): `u32`
+- **interface**: `api.query.nominationPools.counterForPoolMembers`
+- **summary**:    Counter for the related counted storage map 
+ 
+### counterForReversePoolIdLookup(): `u32`
+- **interface**: `api.query.nominationPools.counterForReversePoolIdLookup`
+- **summary**:    Counter for the related counted storage map 
+ 
+### counterForRewardPools(): `u32`
+- **interface**: `api.query.nominationPools.counterForRewardPools`
+- **summary**:    Counter for the related counted storage map 
+ 
+### counterForSubPoolsStorage(): `u32`
+- **interface**: `api.query.nominationPools.counterForSubPoolsStorage`
+- **summary**:    Counter for the related counted storage map 
+ 
+### globalMaxCommission(): `Option<Perbill>`
+- **interface**: `api.query.nominationPools.globalMaxCommission`
+- **summary**:    The maximum commission that can be charged by a pool. Used on commission payouts to bound  pool commissions that are > `GlobalMaxCommission`, necessary if a future  `GlobalMaxCommission` is lower than some current pool commissions. 
+ 
+### lastPoolId(): `u32`
+- **interface**: `api.query.nominationPools.lastPoolId`
+- **summary**:    Ever increasing number of all pools created so far. 
+ 
+### maxPoolMembers(): `Option<u32>`
+- **interface**: `api.query.nominationPools.maxPoolMembers`
+- **summary**:    Maximum number of members that can exist in the system. If `None`, then the count  members are not bound on a system wide basis. 
+ 
+### maxPoolMembersPerPool(): `Option<u32>`
+- **interface**: `api.query.nominationPools.maxPoolMembersPerPool`
+- **summary**:    Maximum number of members that may belong to pool. If `None`, then the count of  members is not bound on a per pool basis. 
+ 
+### maxPools(): `Option<u32>`
+- **interface**: `api.query.nominationPools.maxPools`
+- **summary**:    Maximum number of nomination pools that can exist. If `None`, then an unbounded number of  pools can exist. 
+ 
+### metadata(`u32`): `Bytes`
+- **interface**: `api.query.nominationPools.metadata`
+- **summary**:    Metadata for the pool. 
+ 
+### minCreateBond(): `u128`
+- **interface**: `api.query.nominationPools.minCreateBond`
+- **summary**:    Minimum bond required to create a pool. 
+
+   This is the amount that the depositor must put as their initial stake in the pool, as an  indication of "skin in the game". 
+
+   This is the value that will always exist in the staking ledger of the pool bonded account  while all other accounts leave. 
+ 
+### minJoinBond(): `u128`
+- **interface**: `api.query.nominationPools.minJoinBond`
+- **summary**:    Minimum amount to bond to join a pool. 
+ 
+### poolMembers(`AccountId32`): `Option<PalletNominationPoolsPoolMember>`
+- **interface**: `api.query.nominationPools.poolMembers`
+- **summary**:    Active members. 
+
+   TWOX-NOTE: SAFE since `AccountId` is a secure hash. 
+ 
+### reversePoolIdLookup(`AccountId32`): `Option<u32>`
+- **interface**: `api.query.nominationPools.reversePoolIdLookup`
+- **summary**:    A reverse lookup from the pool's account id to its id. 
+
+   This is only used for slashing and on automatic withdraw update. In all other instances, the  pool id is used, and the accounts are deterministically derived from it. 
+ 
+### rewardPools(`u32`): `Option<PalletNominationPoolsRewardPool>`
+- **interface**: `api.query.nominationPools.rewardPools`
+- **summary**:    Reward pools. This is where there rewards for each pool accumulate. When a members payout is  claimed, the balance comes out of the reward pool. Keyed by the bonded pools account. 
+ 
+### subPoolsStorage(`u32`): `Option<PalletNominationPoolsSubPools>`
+- **interface**: `api.query.nominationPools.subPoolsStorage`
+- **summary**:    Groups of unbonding pools. Each group of unbonding pools belongs to a  bonded pool, hence the name sub-pools. Keyed by the bonded pools account. 
+ 
+### totalValueLocked(): `u128`
+- **interface**: `api.query.nominationPools.totalValueLocked`
+- **summary**:    The sum of funds across all pools. 
+
+   This might be lower but never higher than the sum of `total_balance` of all [`PoolMembers`]  because calling `pool_withdraw_unbonded` might decrease the total stake of the pool's  `bonded_account` without adjusting the pallet-internal `UnbondingPool`'s. 
+
+___
+
+
 ## parachainInfo
  
 ### parachainId(): `u32`
@@ -390,8 +882,6 @@ ___
 ### hrmpWatermark(): `u32`
 - **interface**: `api.query.parachainSystem.hrmpWatermark`
 - **summary**:    HRMP watermark that was set in a block. 
-
-   This will be cleared in `on_initialize` of each new block. 
  
 ### lastDmqMqcHead(): `H256`
 - **interface**: `api.query.parachainSystem.lastDmqMqcHead`
@@ -404,6 +894,18 @@ ___
 - **summary**:    The message queue chain heads we have observed per each channel incoming channel. 
 
    This value is loaded before and saved after processing inbound downward messages carried  by the system inherent. 
+ 
+### lastProcessedDownwardMessage(): `Option<CumulusPalletParachainSystemParachainInherentInboundMessageId>`
+- **interface**: `api.query.parachainSystem.lastProcessedDownwardMessage`
+- **summary**:    The last processed downward message. 
+
+   We need to keep track of this to filter the messages that have been already processed. 
+ 
+### lastProcessedHrmpMessage(): `Option<CumulusPalletParachainSystemParachainInherentInboundMessageId>`
+- **interface**: `api.query.parachainSystem.lastProcessedHrmpMessage`
+- **summary**:    The last processed HRMP message. 
+
+   We need to keep track of this to filter the messages that have been already processed. 
  
 ### lastRelayChainBlockNumber(): `u32`
 - **interface**: `api.query.parachainSystem.lastRelayChainBlockNumber`
@@ -488,6 +990,15 @@ ___
 ### validationData(): `Option<PolkadotPrimitivesV8PersistedValidationData>`
 - **interface**: `api.query.parachainSystem.validationData`
 - **summary**:    The [`PersistedValidationData`] set for this block.  This value is expected to be set only once per block and it's never stored  in the trie. 
+
+___
+
+
+## parameters
+ 
+### parameters(`AssetHubPolkadotRuntimeRuntimeParametersKey`): `Option<AssetHubPolkadotRuntimeRuntimeParametersValue>`
+- **interface**: `api.query.parameters.parameters`
+- **summary**:    Stored parameters. 
 
 ___
 
@@ -592,15 +1103,83 @@ ___
 ___
 
 
+## preimage
+ 
+### preimageFor(`(H256,u32)`): `Option<Bytes>`
+- **interface**: `api.query.preimage.preimageFor`
+ 
+### requestStatusFor(`H256`): `Option<PalletPreimageRequestStatus>`
+- **interface**: `api.query.preimage.requestStatusFor`
+- **summary**:    The request status of a given hash. 
+ 
+### statusFor(`H256`): `Option<PalletPreimageOldRequestStatus>`
+- **interface**: `api.query.preimage.statusFor`
+- **summary**:    The request status of a given hash. 
+
+___
+
+
 ## proxy
  
 ### announcements(`AccountId32`): `(Vec<PalletProxyAnnouncement>,u128)`
 - **interface**: `api.query.proxy.announcements`
 - **summary**:    The announcements made by the proxy (key). 
  
-### proxies(`AccountId32`): `(Vec<PalletProxyProxyDefinition>,u128)`
+### proxies(`AccountId32`): `(Vec<PalletProxyProxyDefinitionAssetHubPolkadotRuntimeProxyType>,u128)`
 - **interface**: `api.query.proxy.proxies`
 - **summary**:    The set of account proxies. Maps the account which has delegated to the accounts  which are being delegated to, together with the amount held on deposit. 
+
+___
+
+
+## referenda
+ 
+### decidingCount(`u16`): `u32`
+- **interface**: `api.query.referenda.decidingCount`
+- **summary**:    The number of referenda being decided currently. 
+ 
+### metadataOf(`u32`): `Option<H256>`
+- **interface**: `api.query.referenda.metadataOf`
+- **summary**:    The metadata is a general information concerning the referendum.  The `Hash` refers to the preimage of the `Preimages` provider which can be a JSON  dump or IPFS hash of a JSON file. 
+
+   Consider a garbage collection for a metadata of finished referendums to `unrequest` (remove)  large preimages. 
+ 
+### referendumCount(): `u32`
+- **interface**: `api.query.referenda.referendumCount`
+- **summary**:    The next free referendum index, aka the number of referenda started so far. 
+ 
+### referendumInfoFor(`u32`): `Option<PalletReferendaReferendumInfoOriginCaller>`
+- **interface**: `api.query.referenda.referendumInfoFor`
+- **summary**:    Information concerning any given referendum. 
+ 
+### trackQueue(`u16`): `Vec<(u32,u128)>`
+- **interface**: `api.query.referenda.trackQueue`
+- **summary**:    The sorted list of referenda ready to be decided but not yet being decided, ordered by  conviction-weighted approvals. 
+
+   This should be empty if `DecidingCount` is less than `TrackInfo::max_deciding`. 
+
+___
+
+
+## scheduler
+ 
+### agenda(`u32`): `Vec<Option<PalletSchedulerScheduled>>`
+- **interface**: `api.query.scheduler.agenda`
+- **summary**:    Items to be executed, indexed by the block number that they should be executed on. 
+ 
+### incompleteSince(): `Option<u32>`
+- **interface**: `api.query.scheduler.incompleteSince`
+- **summary**:    Block number at which the agenda began incomplete execution. 
+ 
+### lookup(`[u8;32]`): `Option<(u32,u32)>`
+- **interface**: `api.query.scheduler.lookup`
+- **summary**:    Lookup from a name to the block number and index of the task. 
+
+   For v3 -> v4 the previously unbounded identities are Blake2-256 hashed to form the v4  identities. 
+ 
+### retries(`(u32,u32)`): `Option<PalletSchedulerRetryConfig>`
+- **interface**: `api.query.scheduler.retries`
+- **summary**:    Retry configurations for items to be executed, indexed by task address. 
 
 ___
 
@@ -636,6 +1215,295 @@ ___
 ### validators(): `Vec<AccountId32>`
 - **interface**: `api.query.session.validators`
 - **summary**:    The current set of validators. 
+
+___
+
+
+## snowbridgeSystemFrontend
+ 
+### exportOperatingMode(): `SnowbridgeCoreOperatingModeBasicOperatingMode`
+- **interface**: `api.query.snowbridgeSystemFrontend.exportOperatingMode`
+- **summary**:    The current operating mode for exporting to Ethereum. 
+
+___
+
+
+## staking
+ 
+### activeEra(): `Option<PalletStakingAsyncActiveEraInfo>`
+- **interface**: `api.query.staking.activeEra`
+- **summary**:    The active era information, it holds index and start. 
+
+   The active era is the era being currently rewarded. Validator set of this era must be  equal to what is RC's session pallet. 
+ 
+### bonded(`AccountId32`): `Option<AccountId32>`
+- **interface**: `api.query.staking.bonded`
+- **summary**:    Map from all locked "stash" accounts to the controller account. 
+
+   TWOX-NOTE: SAFE since `AccountId` is a secure hash. 
+ 
+### bondedEras(): `Vec<(u32,u32)>`
+- **interface**: `api.query.staking.bondedEras`
+- **summary**:    A mapping from still-bonded eras to the first session index of that era. 
+
+   Must contains information for eras for the range:  `[active_era - bounding_duration; active_era]` 
+ 
+### canceledSlashPayout(): `u128`
+- **interface**: `api.query.staking.canceledSlashPayout`
+- **summary**:    The amount of currency given to reporters of a slash event which was  canceled by extraordinary circumstances (e.g. governance). 
+ 
+### cancelledSlashes(`u32`): `Vec<(AccountId32,Perbill)>`
+- **interface**: `api.query.staking.cancelledSlashes`
+- **summary**:    Cancelled slashes by era and validator with maximum slash fraction to be cancelled. 
+
+   When slashes are cancelled by governance, this stores the era and the validators  whose slashes should be cancelled, along with the maximum slash fraction that should  be cancelled for each validator. 
+ 
+### chillThreshold(): `Option<Percent>`
+- **interface**: `api.query.staking.chillThreshold`
+- **summary**:    The threshold for when users can start calling `chill_other` for other validators /  nominators. The threshold is compared to the actual number of validators / nominators  (`CountFor*`) in the system compared to the configured max (`Max*Count`). 
+ 
+### claimedRewards(`u32, AccountId32`): `Vec<u32>`
+- **interface**: `api.query.staking.claimedRewards`
+- **summary**:    History of claimed paged rewards by era and validator. 
+
+   This is keyed by era and validator stash which maps to the set of page indexes which have  been claimed. 
+
+   It is removed after [`Config::HistoryDepth`] eras. 
+ 
+### counterForNominators(): `u32`
+- **interface**: `api.query.staking.counterForNominators`
+- **summary**:    Counter for the related counted storage map 
+ 
+### counterForValidators(): `u32`
+- **interface**: `api.query.staking.counterForValidators`
+- **summary**:    Counter for the related counted storage map 
+ 
+### counterForVirtualStakers(): `u32`
+- **interface**: `api.query.staking.counterForVirtualStakers`
+- **summary**:    Counter for the related counted storage map 
+ 
+### currentEra(): `Option<u32>`
+- **interface**: `api.query.staking.currentEra`
+- **summary**:    The current planned era index. 
+
+   This is the latest planned era, depending on how the Session pallet queues the validator  set, it might be active or not. 
+ 
+### electableStashes(): `BTreeSet<AccountId32>`
+- **interface**: `api.query.staking.electableStashes`
+- **summary**:    A bounded list of the "electable" stashes that resulted from a successful election. 
+ 
+### eraPruningState(`u32`): `Option<PalletStakingAsyncPalletPruningStep>`
+- **interface**: `api.query.staking.eraPruningState`
+- **summary**:    Tracks the current step of era pruning process for each era being lazily pruned. 
+ 
+### erasRewardPoints(`u32`): `PalletStakingAsyncEraRewardPoints`
+- **interface**: `api.query.staking.erasRewardPoints`
+- **summary**:    Rewards for the last [`Config::HistoryDepth`] eras.  If reward hasn't been set or has been removed then 0 reward is returned. 
+ 
+### erasStakersOverview(`u32, AccountId32`): `Option<SpStakingPagedExposureMetadata>`
+- **interface**: `api.query.staking.erasStakersOverview`
+- **summary**:    Summary of validator exposure at a given era. 
+
+   This contains the total stake in support of the validator and their own stake. In addition,  it can also be used to get the number of nominators backing this validator and the number of  exposure pages they are divided into. The page count is useful to determine the number of  pages of rewards that needs to be claimed. 
+
+   This is keyed first by the era index to allow bulk deletion and then the stash account.  Should only be accessed through `Eras`. 
+
+   Is it removed after [`Config::HistoryDepth`] eras.  If stakers hasn't been set or has been removed then empty overview is returned. 
+ 
+### erasStakersPaged(`u32, AccountId32, u32`): `Option<PalletStakingAsyncPalletBoundedExposurePage>`
+- **interface**: `api.query.staking.erasStakersPaged`
+- **summary**:    Paginated exposure of a validator at given era. 
+
+   This is keyed first by the era index to allow bulk deletion, then stash account and finally  the page. Should only be accessed through `Eras`. 
+
+   This is cleared after [`Config::HistoryDepth`] eras. 
+ 
+### erasTotalStake(`u32`): `u128`
+- **interface**: `api.query.staking.erasTotalStake`
+- **summary**:    The total amount staked for the last [`Config::HistoryDepth`] eras.  If total hasn't been set or has been removed then 0 stake is returned. 
+ 
+### erasValidatorPrefs(`u32, AccountId32`): `PalletStakingAsyncValidatorPrefs`
+- **interface**: `api.query.staking.erasValidatorPrefs`
+- **summary**:    Exposure of validator at era with the preferences of validators. 
+
+   This is keyed first by the era index to allow bulk deletion and then the stash account. 
+
+   Is it removed after [`Config::HistoryDepth`] eras. 
+ 
+### erasValidatorReward(`u32`): `Option<u128>`
+- **interface**: `api.query.staking.erasValidatorReward`
+- **summary**:    The total validator era payout for the last [`Config::HistoryDepth`] eras. 
+
+   Eras that haven't finished yet or has been removed doesn't have reward. 
+ 
+### forceEra(): `PalletStakingAsyncForcing`
+- **interface**: `api.query.staking.forceEra`
+- **summary**:    Mode of era forcing. 
+ 
+### invulnerables(): `Vec<AccountId32>`
+- **interface**: `api.query.staking.invulnerables`
+- **summary**:    Any validators that may never be slashed or forcibly kicked. It's a Vec since they're  easy to initialize and the performance hit is minimal (we expect no more than four  invulnerables) and restricted to testnets. 
+ 
+### ledger(`AccountId32`): `Option<PalletStakingAsyncLedgerStakingLedger>`
+- **interface**: `api.query.staking.ledger`
+- **summary**:    Map from all (unlocked) "controller" accounts to the info regarding the staking. 
+
+   Note: All the reads and mutations to this storage *MUST* be done through the methods exposed  by [`StakingLedger`] to ensure data and lock consistency. 
+ 
+### maxNominatorsCount(): `Option<u32>`
+- **interface**: `api.query.staking.maxNominatorsCount`
+- **summary**:    The maximum nominator count before we stop allowing new validators to join. 
+
+   When this value is not set, no limits are enforced. 
+ 
+### maxStakedRewards(): `Option<Percent>`
+- **interface**: `api.query.staking.maxStakedRewards`
+- **summary**:    Maximum staked rewards, i.e. the percentage of the era inflation that  is used for stake rewards.  See [Era payout](./index.html#era-payout). 
+ 
+### maxValidatorsCount(): `Option<u32>`
+- **interface**: `api.query.staking.maxValidatorsCount`
+- **summary**:    The maximum validator count before we stop allowing new validators to join. 
+
+   When this value is not set, no limits are enforced. 
+ 
+### minCommission(): `Perbill`
+- **interface**: `api.query.staking.minCommission`
+- **summary**:    The minimum amount of commission that validators can set. 
+
+   If set to `0`, no limit exists. 
+ 
+### minimumActiveStake(): `u128`
+- **interface**: `api.query.staking.minimumActiveStake`
+- **summary**:    The minimum active nominator stake of the last successful election. 
+ 
+### minNominatorBond(): `u128`
+- **interface**: `api.query.staking.minNominatorBond`
+- **summary**:    The minimum active bond to become and maintain the role of a nominator. 
+ 
+### minValidatorBond(): `u128`
+- **interface**: `api.query.staking.minValidatorBond`
+- **summary**:    The minimum active bond to become and maintain the role of a validator. 
+ 
+### nextElectionPage(): `Option<u32>`
+- **interface**: `api.query.staking.nextElectionPage`
+- **summary**:    Keeps track of an ongoing multi-page election solution request. 
+
+   If `Some(_)``, it is the next page that we intend to elect. If `None`, we are not in the  election process. 
+
+   This is only set in multi-block elections. Should always be `None` otherwise. 
+ 
+### nominators(`AccountId32`): `Option<PalletStakingAsyncNominations>`
+- **interface**: `api.query.staking.nominators`
+- **summary**:    The map from nominator stash key to their nomination preferences, namely the validators that  they wish to support. 
+
+   Note that the keys of this storage map might become non-decodable in case the  account's [`NominationsQuota::MaxNominations`] configuration is decreased.  In this rare case, these nominators  are still existent in storage, their key is correct and retrievable (i.e. `contains_key`  indicates that they exist), but their value cannot be decoded. Therefore, the non-decodable  nominators will effectively not-exist, until they re-submit their preferences such that it  is within the bounds of the newly set `Config::MaxNominations`. 
+
+   This implies that `::iter_keys().count()` and `::iter().count()` might return different  values for this map. Moreover, the main `::count()` is aligned with the former, namely the  number of keys that exist. 
+
+   Lastly, if any of the nominators become non-decodable, they can be chilled immediately via  [`Call::chill_other`] dispatchable by anyone. 
+
+   TWOX-NOTE: SAFE since `AccountId` is a secure hash. 
+ 
+### offenceQueue(`u32, AccountId32`): `Option<PalletStakingAsyncSlashingOffenceRecord>`
+- **interface**: `api.query.staking.offenceQueue`
+- **summary**:    Stores reported offences in a queue until they are processed in subsequent blocks. 
+
+   Each offence is recorded under the corresponding era index and the offending validator's  account. If an offence spans multiple pages, only one page is processed at a time. Offences  are handled sequentially, with their associated slashes computed and stored in  `UnappliedSlashes`. These slashes are then applied in a future era as determined by  `SlashDeferDuration`. 
+
+   Any offences tied to an era older than `BondingDuration` are automatically dropped.  Processing always prioritizes the oldest era first. 
+ 
+### offenceQueueEras(): `Option<Vec<u32>>`
+- **interface**: `api.query.staking.offenceQueueEras`
+- **summary**:    Tracks the eras that contain offences in `OffenceQueue`, sorted from **earliest to latest**. 
+
+   - This ensures efficient retrieval of the oldest offence without iterating through  `OffenceQueue`. 
+
+  - When a new offence is added to `OffenceQueue`, its era is **inserted in sorted order** if not already present. 
+
+  - When all offences for an era are processed, it is **removed** from this list.
+
+  - The maximum length of this vector is bounded by `BondingDuration`.
+
+   This eliminates the need for expensive iteration and sorting when fetching the next offence  to process. 
+ 
+### payee(`AccountId32`): `Option<PalletStakingAsyncRewardDestination>`
+- **interface**: `api.query.staking.payee`
+- **summary**:    Where the reward payment should be made. Keyed by stash. 
+
+   TWOX-NOTE: SAFE since `AccountId` is a secure hash. 
+ 
+### processingOffence(): `Option<(u32,AccountId32,PalletStakingAsyncSlashingOffenceRecord)>`
+- **interface**: `api.query.staking.processingOffence`
+- **summary**:    Tracks the currently processed offence record from the `OffenceQueue`. 
+
+   - When processing offences, an offence record is **popped** from the oldest era in  `OffenceQueue` and stored here. 
+
+  - The function `process_offence` reads from this storage, processing one page of exposure at a time. 
+
+  - After processing a page, the `exposure_page` count is **decremented** until it reaches zero. 
+
+  - Once fully processed, the offence record is removed from this storage.
+
+   This ensures that offences are processed incrementally, preventing excessive computation  in a single block while maintaining correct slashing behavior. 
+ 
+### slashRewardFraction(): `Perbill`
+- **interface**: `api.query.staking.slashRewardFraction`
+- **summary**:    The percentage of the slash that is distributed to reporters. 
+
+   The rest of the slashed value is handled by the `Slash`. 
+ 
+### unappliedSlashes(`u32, (AccountId32,Perbill,u32)`): `Option<PalletStakingAsyncUnappliedSlash>`
+- **interface**: `api.query.staking.unappliedSlashes`
+- **summary**:    All unapplied slashes that are queued for later. 
+ 
+### validatorCount(): `u32`
+- **interface**: `api.query.staking.validatorCount`
+- **summary**:    The ideal number of active validators. 
+ 
+### validators(`AccountId32`): `PalletStakingAsyncValidatorPrefs`
+- **interface**: `api.query.staking.validators`
+- **summary**:    The map from (wannabe) validator stash key to the preferences of that validator. 
+
+   TWOX-NOTE: SAFE since `AccountId` is a secure hash. 
+ 
+### validatorSlashInEra(`u32, AccountId32`): `Option<(Perbill,u128)>`
+- **interface**: `api.query.staking.validatorSlashInEra`
+- **summary**:    All slashing events on validators, mapped by era to the highest slash proportion  and slash value of the era. 
+ 
+### virtualStakers(`AccountId32`): `Option<Null>`
+- **interface**: `api.query.staking.virtualStakers`
+- **summary**:    Stakers whose funds are managed by other pallets. 
+
+   This pallet does not apply any locks on them, therefore they are only virtually bonded. They  are expected to be keyless accounts and hence should not be allowed to mutate their ledger  directly via this pallet. Instead, these accounts are managed by other pallets and accessed  via low level apis. We keep track of them to do minimal integrity checks. 
+ 
+### voterSnapshotStatus(): `PalletStakingAsyncSnapshotStatus`
+- **interface**: `api.query.staking.voterSnapshotStatus`
+- **summary**:    Voter snapshot progress status. 
+
+   If the status is `Ongoing`, it keeps a cursor of the last voter retrieved to proceed when  creating the next snapshot page. 
+
+___
+
+
+## stakingRcClient
+ 
+### incompleteSessionReport(): `Option<PalletStakingAsyncRcClientSessionReport>`
+- **interface**: `api.query.stakingRcClient.incompleteSessionReport`
+- **summary**:    An incomplete incoming session report that we have not acted upon yet. 
+ 
+### lastSessionReportEndingIndex(): `Option<u32>`
+- **interface**: `api.query.stakingRcClient.lastSessionReportEndingIndex`
+- **summary**:    The last session report's `end_index` that we have acted upon. 
+
+   This allows this pallet to ensure a sequentially increasing sequence of session reports  passed to staking. 
+
+   Note that with the XCM being the backbone of communication, we have a guarantee on the  ordering of messages. As long as the RC sends session reports in order, we _eventually_  receive them in the same correct order as well. 
+ 
+### outgoingValidatorSet(): `Option<(PalletStakingAsyncRcClientValidatorSetReport,u32)>`
+- **interface**: `api.query.stakingRcClient.outgoingValidatorSet`
+- **summary**:    A validator set that is outgoing, and should be sent. 
+
+   This will be attempted to be sent, possibly on every `on_initialize` call, until it is sent,  or the second value reaches zero, at which point we drop it. 
 
 ___
 
@@ -836,6 +1704,45 @@ ___
 ___
 
 
+## treasury
+ 
+### approvals(): `Vec<u32>`
+- **interface**: `api.query.treasury.approvals`
+- **summary**:    DEPRECATED: associated with `spend_local` call and will be removed in May 2025.  Refer to <https://github.com/paritytech/polkadot-sdk/pull/5961> for migration to `spend`. 
+
+   Proposal indices that have been approved but not yet awarded. 
+ 
+### deactivated(): `u128`
+- **interface**: `api.query.treasury.deactivated`
+- **summary**:    The amount which has been reported as inactive to Currency. 
+ 
+### lastSpendPeriod(): `Option<u32>`
+- **interface**: `api.query.treasury.lastSpendPeriod`
+- **summary**:    The blocknumber for the last triggered spend period. 
+ 
+### proposalCount(): `u32`
+- **interface**: `api.query.treasury.proposalCount`
+- **summary**:    DEPRECATED: associated with `spend_local` call and will be removed in May 2025.  Refer to <https://github.com/paritytech/polkadot-sdk/pull/5961> for migration to `spend`. 
+
+   Number of proposals that have been made. 
+ 
+### proposals(`u32`): `Option<PalletTreasuryProposal>`
+- **interface**: `api.query.treasury.proposals`
+- **summary**:    DEPRECATED: associated with `spend_local` call and will be removed in May 2025.  Refer to <https://github.com/paritytech/polkadot-sdk/pull/5961> for migration to `spend`. 
+
+   Proposals that have been made. 
+ 
+### spendCount(): `u32`
+- **interface**: `api.query.treasury.spendCount`
+- **summary**:    The count of spends that have been made. 
+ 
+### spends(`u32`): `Option<PalletTreasurySpendStatus>`
+- **interface**: `api.query.treasury.spends`
+- **summary**:    Spends that have been approved and being processed. 
+
+___
+
+
 ## uniques
  
 ### account(`AccountId32, u32, u32`): `Option<Null>`
@@ -892,6 +1799,45 @@ ___
 ### vesting(`AccountId32`): `Option<Vec<PalletVestingVestingInfo>>`
 - **interface**: `api.query.vesting.vesting`
 - **summary**:    Information regarding the vesting of a given account. 
+
+___
+
+
+## voterList
+ 
+### counterForListNodes(): `u32`
+- **interface**: `api.query.voterList.counterForListNodes`
+- **summary**:    Counter for the related counted storage map 
+ 
+### listBags(`u64`): `Option<PalletBagsListListBag>`
+- **interface**: `api.query.voterList.listBags`
+- **summary**:    A bag stored in storage. 
+
+   Stores a `Bag` struct, which stores head and tail pointers to itself. 
+ 
+### listNodes(`AccountId32`): `Option<PalletBagsListListNode>`
+- **interface**: `api.query.voterList.listNodes`
+- **summary**:    A single node, within some bag. 
+
+   Nodes store links forward and back within their respective bags. 
+ 
+### lock(): `Option<Null>`
+- **interface**: `api.query.voterList.lock`
+- **summary**:    Lock all updates to this pallet. 
+
+   If any nodes needs updating, removal or addition due to a temporary lock, the  [`Call::rebag`] can be used. 
+ 
+### nextNodeAutoRebagged(): `Option<AccountId32>`
+- **interface**: `api.query.voterList.nextNodeAutoRebagged`
+- **summary**:    Pointer that remembers the next node that will be auto-rebagged.  When `None`, the next scan will start from the list head again. 
+
+___
+
+
+## whitelist
+ 
+### whitelistedCall(`H256`): `Option<Null>`
+- **interface**: `api.query.whitelist.whitelistedCall`
 
 ___
 

--- a/docs/kusama/constants.md
+++ b/docs/kusama/constants.md
@@ -42,10 +42,6 @@ The following sections contain the module constants, also known as parameter typ
 
 - **[multisig](#multisig)**
 
-- **[nis](#nis)**
-
-- **[nisCounterpartBalances](#niscounterpartbalances)**
-
 - **[nominationPools](#nominationpools)**
 
 - **[onDemandAssignmentProvider](#ondemandassignmentprovider)**
@@ -61,6 +57,8 @@ The following sections contain the module constants, also known as parameter typ
 - **[registrar](#registrar)**
 
 - **[scheduler](#scheduler)**
+
+- **[session](#session)**
 
 - **[slots](#slots)**
 
@@ -312,9 +310,15 @@ ___
 - **interface**: `api.consts.electionProviderMultiPhase.betterSignedThreshold`
 - **summary**:    The minimum amount of improvement to the solution score that defines a solution as  "better" in the Signed phase. 
  
+### maxBackersPerWinner: `u32`
+- **interface**: `api.consts.electionProviderMultiPhase.maxBackersPerWinner`
+- **summary**:    Maximum number of voters that can support a winner in an election solution. 
+
+   This is needed to ensure election computation is bounded. 
+ 
 ### maxWinners: `u32`
 - **interface**: `api.consts.electionProviderMultiPhase.maxWinners`
-- **summary**:    The maximum number of winners that can be elected by this `ElectionProvider`  implementation. 
+- **summary**:    Maximum number of winners that an election supports. 
 
    Note: This must always be greater or equal to `T::DataProvider::desired_targets()`. 
  
@@ -479,88 +483,6 @@ ___
 ### maxSignatories: `u32`
 - **interface**: `api.consts.multisig.maxSignatories`
 - **summary**:    The maximum amount of signatories allowed in the multisig. 
-
-___
-
-
-## nis
- 
-### basePeriod: `u32`
-- **interface**: `api.consts.nis.basePeriod`
-- **summary**:    The base period for the duration queues. This is the common multiple across all  supported freezing durations that can be bid upon. 
- 
-### fifoQueueLen: `u32`
-- **interface**: `api.consts.nis.fifoQueueLen`
-- **summary**:    Portion of the queue which is free from ordering and just a FIFO. 
-
-   Must be no greater than `MaxQueueLen`. 
- 
-### intakePeriod: `u32`
-- **interface**: `api.consts.nis.intakePeriod`
-- **summary**:    The number of blocks between consecutive attempts to dequeue bids and create receipts. 
-
-   A larger value results in fewer storage hits each block, but a slower period to get to  the target. 
- 
-### maxIntakeWeight: `SpWeightsWeightV2Weight`
-- **interface**: `api.consts.nis.maxIntakeWeight`
-- **summary**:    The maximum amount of bids that can consolidated into receipts in a single intake. A  larger value here means less of the block available for transactions should there be a  glut of bids. 
- 
-### maxQueueLen: `u32`
-- **interface**: `api.consts.nis.maxQueueLen`
-- **summary**:    Maximum number of items that may be in each duration queue. 
-
-   Must be larger than zero. 
- 
-### minBid: `u128`
-- **interface**: `api.consts.nis.minBid`
-- **summary**:    The minimum amount of funds that may be placed in a bid. Note that this  does not actually limit the amount which may be represented in a receipt since bids may  be split up by the system. 
-
-   It should be at least big enough to ensure that there is no possible storage spam attack  or queue-filling attack. 
- 
-### minReceipt: `Perquintill`
-- **interface**: `api.consts.nis.minReceipt`
-- **summary**:    The minimum amount of funds which may intentionally be left remaining under a single  receipt. 
- 
-### palletId: `FrameSupportPalletId`
-- **interface**: `api.consts.nis.palletId`
-- **summary**:    The treasury's pallet id, used for deriving its sovereign account ID. 
- 
-### queueCount: `u32`
-- **interface**: `api.consts.nis.queueCount`
-- **summary**:    Number of duration queues in total. This sets the maximum duration supported, which is  this value multiplied by `Period`. 
- 
-### thawThrottle: `(Perquintill,u32)`
-- **interface**: `api.consts.nis.thawThrottle`
-- **summary**:    The maximum proportion which may be thawed and the period over which it is reset. 
-
-___
-
-
-## nisCounterpartBalances
- 
-### existentialDeposit: `u128`
-- **interface**: `api.consts.nisCounterpartBalances.existentialDeposit`
-- **summary**:    The minimum amount required to keep an account open. MUST BE GREATER THAN ZERO! 
-
-   If you *really* need it to be zero, you can enable the feature `insecure_zero_ed` for  this pallet. However, you do so at your own risk: this will open up a major DoS vector.  In case you have multiple sources of provider references, you may also get unexpected  behaviour if you set this to zero. 
-
-   Bottom line: Do yourself a favour and make it at least one! 
- 
-### maxFreezes: `u32`
-- **interface**: `api.consts.nisCounterpartBalances.maxFreezes`
-- **summary**:    The maximum number of individual freeze locks that can exist on an account at any time. 
- 
-### maxLocks: `u32`
-- **interface**: `api.consts.nisCounterpartBalances.maxLocks`
-- **summary**:    The maximum number of locks that should exist on an account.  Not strictly enforced, but used for weight estimation. 
-
-   Use of locks is deprecated in favour of freezes. See `https://github.com/paritytech/substrate/pull/12951/` 
- 
-### maxReserves: `u32`
-- **interface**: `api.consts.nisCounterpartBalances.maxReserves`
-- **summary**:    The maximum number of named reserves that can exist on an account. 
-
-   Use of reserves is deprecated in favour of holds. See `https://github.com/paritytech/substrate/pull/12951/` 
 
 ___
 
@@ -734,6 +656,15 @@ ___
 ___
 
 
+## session
+ 
+### keyDeposit: `u128`
+- **interface**: `api.consts.session.keyDeposit`
+- **summary**:    The amount to be held when setting keys. 
+
+___
+
+
 ## slots
  
 ### leaseOffset: `u32`
@@ -751,11 +682,11 @@ ___
  
 ### challengePeriod: `u32`
 - **interface**: `api.consts.society.challengePeriod`
-- **summary**:    The number of blocks between membership challenges. 
+- **summary**:    The number of [Config::BlockNumberProvider] blocks between membership challenges. 
  
 ### claimPeriod: `u32`
 - **interface**: `api.consts.society.claimPeriod`
-- **summary**:    The number of blocks on which new candidates can claim their membership and be the  named head. 
+- **summary**:    The number of [Config::BlockNumberProvider] blocks on which new candidates can claim  their membership and be the named head. 
  
 ### graceStrikes: `u32`
 - **interface**: `api.consts.society.graceStrikes`
@@ -783,7 +714,7 @@ ___
  
 ### votingPeriod: `u32`
 - **interface**: `api.consts.society.votingPeriod`
-- **summary**:    The number of blocks on which new candidates should be voted on. Together with  `ClaimPeriod`, this sums to the number of blocks between candidate intake periods. 
+- **summary**:    The number of [Config::BlockNumberProvider] blocks on which new candidates should be  voted on. Together with  `ClaimPeriod`, this sums to the number of blocks between candidate intake periods. 
 
 ___
 
@@ -821,6 +752,10 @@ ___
 - **summary**:    The maximum number of `unlocking` chunks a [`StakingLedger`] can  have. Effectively determines how many unique eras a staker may be  unbonding in. 
 
    Note: `MaxUnlockingChunks` is used as the upper bound for the  `BoundedVec` item `StakingLedger.unlocking`. Setting this value  lower than the existing value can lead to inconsistencies in the  `StakingLedger` and will need to be handled properly in a runtime  migration. The test `reducing_max_unlocking_chunks_abrupt` shows  this effect. 
+ 
+### maxValidatorSet: `u32`
+- **interface**: `api.consts.staking.maxValidatorSet`
+- **summary**:    The absolute maximum of winner validators this pallet should return. 
  
 ### sessionsPerEra: `u32`
 - **interface**: `api.consts.staking.sessionsPerEra`
@@ -983,6 +918,12 @@ ___
    #### Migration 
 
    In the event that this list ever changes, a copy of the old bags list must be retained.  With that `List::migrate` can be called, which will perform the appropriate migration. 
+ 
+### maxAutoRebagPerBlock: `u32`
+- **interface**: `api.consts.voterList.maxAutoRebagPerBlock`
+- **summary**:    Maximum number of accounts that may be re-bagged automatically in `on_idle`. 
+
+   A value of `0` (obtained by configuring `type MaxAutoRebagPerBlock = ();`) disables  the feature. 
 
 ___
 
@@ -992,3 +933,15 @@ ___
 ### advertisedXcmVersion: `u32`
 - **interface**: `api.consts.xcmPallet.advertisedXcmVersion`
 - **summary**:    The latest supported version that we advertise. Generally just set it to  `pallet_xcm::CurrentXcmVersion`. 
+ 
+### maxLockers: `u32`
+- **interface**: `api.consts.xcmPallet.maxLockers`
+- **summary**:    The maximum number of local XCM locks that a single account may have. 
+ 
+### maxRemoteLockConsumers: `u32`
+- **interface**: `api.consts.xcmPallet.maxRemoteLockConsumers`
+- **summary**:    The maximum number of consumers a single remote lock may have. 
+ 
+### universalLocation: `StagingXcmV5Junctions`
+- **interface**: `api.consts.xcmPallet.universalLocation`
+- **summary**:    This chain's Universal Location. 

--- a/docs/kusama/errors.md
+++ b/docs/kusama/errors.md
@@ -52,10 +52,6 @@ This page lists the errors that can be encountered in the different modules.
 
 - **[multisig](#multisig)**
 
-- **[nis](#nis)**
-
-- **[nisCounterpartBalances](#niscounterpartbalances)**
-
 - **[nominationPools](#nominationpools)**
 
 - **[onDemandAssignmentProvider](#ondemandassignmentprovider)**
@@ -74,6 +70,8 @@ This page lists the errors that can be encountered in the different modules.
 
 - **[proxy](#proxy)**
 
+- **[rcMigrator](#rcmigrator)**
+
 - **[recovery](#recovery)**
 
 - **[referenda](#referenda)**
@@ -89,6 +87,8 @@ This page lists the errors that can be encountered in the different modules.
 - **[society](#society)**
 
 - **[staking](#staking)**
+
+- **[stakingAhClient](#stakingahclient)**
 
 - **[system](#system)**
 
@@ -286,6 +286,10 @@ ___
 ### InvalidValue
 - **interface**: `api.errors.bounties.InvalidValue.is`
 - **summary**:    Invalid bounty value. 
+ 
+### NotProposer
+- **interface**: `api.errors.bounties.NotProposer.is`
+- **summary**:    User is not the proposer of the bounty. 
  
 ### PendingPayout
 - **interface**: `api.errors.bounties.PendingPayout.is`
@@ -1058,124 +1062,6 @@ ___
 ___
 
 
-## nis
- 
-### AlreadyCommunal
-- **interface**: `api.errors.nis.AlreadyCommunal.is`
-- **summary**:    The receipt is already communal. 
- 
-### AlreadyFunded
-- **interface**: `api.errors.nis.AlreadyFunded.is`
-- **summary**:    There are enough funds for what is required. 
- 
-### AlreadyPrivate
-- **interface**: `api.errors.nis.AlreadyPrivate.is`
-- **summary**:    The receipt is already private. 
- 
-### AmountTooSmall
-- **interface**: `api.errors.nis.AmountTooSmall.is`
-- **summary**:    The amount of the bid is less than the minimum allowed. 
- 
-### BidTooLow
-- **interface**: `api.errors.nis.BidTooLow.is`
-- **summary**:    The queue for the bid's duration is full and the amount bid is too low to get in  through replacing an existing bid. 
- 
-### DurationTooBig
-- **interface**: `api.errors.nis.DurationTooBig.is`
-- **summary**:    The duration is the bid is greater than the number of queues. 
- 
-### DurationTooSmall
-- **interface**: `api.errors.nis.DurationTooSmall.is`
-- **summary**:    The duration of the bid is less than one. 
- 
-### MakesDust
-- **interface**: `api.errors.nis.MakesDust.is`
-- **summary**:    The operation would result in a receipt worth an insignificant value. 
- 
-### NotExpired
-- **interface**: `api.errors.nis.NotExpired.is`
-- **summary**:    Bond not yet at expiry date. 
- 
-### NotOwner
-- **interface**: `api.errors.nis.NotOwner.is`
-- **summary**:    Not the owner of the receipt. 
- 
-### PortionTooBig
-- **interface**: `api.errors.nis.PortionTooBig.is`
-- **summary**:    The portion supplied is beyond the value of the receipt. 
- 
-### Throttled
-- **interface**: `api.errors.nis.Throttled.is`
-- **summary**:    The thaw throttle has been reached for this period. 
- 
-### Unfunded
-- **interface**: `api.errors.nis.Unfunded.is`
-- **summary**:    Not enough funds are held to pay out. 
- 
-### UnknownBid
-- **interface**: `api.errors.nis.UnknownBid.is`
-- **summary**:    The given bid for retraction is not found. 
- 
-### UnknownReceipt
-- **interface**: `api.errors.nis.UnknownReceipt.is`
-- **summary**:    Receipt index is unknown. 
-
-___
-
-
-## nisCounterpartBalances
- 
-### DeadAccount
-- **interface**: `api.errors.nisCounterpartBalances.DeadAccount.is`
-- **summary**:    Beneficiary account must pre-exist. 
- 
-### DeltaZero
-- **interface**: `api.errors.nisCounterpartBalances.DeltaZero.is`
-- **summary**:    The delta cannot be zero. 
- 
-### ExistentialDeposit
-- **interface**: `api.errors.nisCounterpartBalances.ExistentialDeposit.is`
-- **summary**:    Value too low to create account due to existential deposit. 
- 
-### ExistingVestingSchedule
-- **interface**: `api.errors.nisCounterpartBalances.ExistingVestingSchedule.is`
-- **summary**:    A vesting schedule already exists for this account. 
- 
-### Expendability
-- **interface**: `api.errors.nisCounterpartBalances.Expendability.is`
-- **summary**:    Transfer/payment would kill account. 
- 
-### InsufficientBalance
-- **interface**: `api.errors.nisCounterpartBalances.InsufficientBalance.is`
-- **summary**:    Balance too low to send value. 
- 
-### IssuanceDeactivated
-- **interface**: `api.errors.nisCounterpartBalances.IssuanceDeactivated.is`
-- **summary**:    The issuance cannot be modified since it is already deactivated. 
- 
-### LiquidityRestrictions
-- **interface**: `api.errors.nisCounterpartBalances.LiquidityRestrictions.is`
-- **summary**:    Account liquidity restrictions prevent withdrawal. 
- 
-### TooManyFreezes
-- **interface**: `api.errors.nisCounterpartBalances.TooManyFreezes.is`
-- **summary**:    Number of freezes exceed `MaxFreezes`. 
- 
-### TooManyHolds
-- **interface**: `api.errors.nisCounterpartBalances.TooManyHolds.is`
-- **summary**:    Number of holds exceed `VariantCountOf<T::RuntimeHoldReason>`. 
- 
-### TooManyReserves
-- **interface**: `api.errors.nisCounterpartBalances.TooManyReserves.is`
-- **summary**:    Number of named reserves exceed `MaxReserves`. 
- 
-### VestingBalance
-- **interface**: `api.errors.nisCounterpartBalances.VestingBalance.is`
-- **summary**:    Vesting balance too high to send value. 
-
-___
-
-
 ## nominationPools
  
 ### AccountBelongsToOtherPool
@@ -1468,9 +1354,17 @@ ___
 - **interface**: `api.errors.paras.CannotUpgradeCode.is`
 - **summary**:    Parachain cannot currently schedule a code upgrade. 
  
+### InvalidBlockNumber
+- **interface**: `api.errors.paras.InvalidBlockNumber.is`
+- **summary**:    Invalid block number. 
+ 
 ### InvalidCode
 - **interface**: `api.errors.paras.InvalidCode.is`
 - **summary**:    Invalid validation code size. 
+ 
+### NothingAuthorized
+- **interface**: `api.errors.paras.NothingAuthorized.is`
+- **summary**:    No upgrade authorized. 
  
 ### NotRegistered
 - **interface**: `api.errors.paras.NotRegistered.is`
@@ -1499,6 +1393,10 @@ ___
 ### PvfCheckValidatorIndexOutOfBounds
 - **interface**: `api.errors.paras.PvfCheckValidatorIndexOutOfBounds.is`
 - **summary**:    Claimed validator index is out of bounds. 
+ 
+### Unauthorized
+- **interface**: `api.errors.paras.Unauthorized.is`
+- **summary**:    The submitted code is not authorized. 
 
 ___
 
@@ -1643,6 +1541,83 @@ ___
 ### Unproxyable
 - **interface**: `api.errors.proxy.Unproxyable.is`
 - **summary**:    A call which is incompatible with the proxy type's filter was attempted. 
+
+___
+
+
+## rcMigrator
+ 
+### AccountReferenced
+- **interface**: `api.errors.rcMigrator.AccountReferenced.is`
+- **summary**:    The account is referenced by some other pallet. It might have freezes or holds. 
+ 
+### AhUmpQueuePriorityAlreadySet
+- **interface**: `api.errors.rcMigrator.AhUmpQueuePriorityAlreadySet.is`
+- **summary**:    The AH UMP queue priority configuration is already set. 
+ 
+### BadXcmVersion
+- **interface**: `api.errors.rcMigrator.BadXcmVersion.is`
+- **summary**:    The XCM version is invalid. 
+ 
+### BalanceOverflow
+- **interface**: `api.errors.rcMigrator.BalanceOverflow.is`
+- **summary**:    Balance accounting overflow. 
+ 
+### BalanceUnderflow
+- **interface**: `api.errors.rcMigrator.BalanceUnderflow.is`
+- **summary**:    Balance accounting underflow. 
+ 
+### EraEndsTooSoon
+- **interface**: `api.errors.rcMigrator.EraEndsTooSoon.is`
+- **summary**:    Indicates that there is not enough time for staking to lock. 
+
+   Schedule the migration at least two sessions before the current era ends. 
+ 
+### FailedToWithdrawAccount
+- **interface**: `api.errors.rcMigrator.FailedToWithdrawAccount.is`
+- **summary**:    Failed to withdraw account from RC for migration to AH. 
+ 
+### InvalidOrigin
+- **interface**: `api.errors.rcMigrator.InvalidOrigin.is`
+- **summary**:    The origin is invalid. 
+ 
+### InvalidParameter
+- **interface**: `api.errors.rcMigrator.InvalidParameter.is`
+- **summary**:    Invalid parameter. 
+ 
+### InvalidQueryResponse
+- **interface**: `api.errors.rcMigrator.InvalidQueryResponse.is`
+- **summary**:    The query response is invalid. 
+ 
+### InvalidStageTransition
+- **interface**: `api.errors.rcMigrator.InvalidStageTransition.is`
+- **summary**:    The stage transition is invalid. 
+ 
+### OutOfWeight
+- **interface**: `api.errors.rcMigrator.OutOfWeight.is`
+ 
+### PastBlockNumber
+- **interface**: `api.errors.rcMigrator.PastBlockNumber.is`
+- **summary**:    Indicates that the specified block number is in the past. 
+ 
+### QueryNotFound
+- **interface**: `api.errors.rcMigrator.QueryNotFound.is`
+- **summary**:    The xcm query was not found. 
+ 
+### Unreachable
+- **interface**: `api.errors.rcMigrator.Unreachable.is`
+ 
+### UnreachableStage
+- **interface**: `api.errors.rcMigrator.UnreachableStage.is`
+- **summary**:    The migration stage is not reachable from the current stage. 
+ 
+### XcmError
+- **interface**: `api.errors.rcMigrator.XcmError.is`
+- **summary**:    Failed to send XCM message to AH. 
+ 
+### XcmSendError
+- **interface**: `api.errors.rcMigrator.XcmSendError.is`
+- **summary**:    Failed to send XCM message. 
 
 ___
 
@@ -1967,6 +1942,10 @@ ___
 - **interface**: `api.errors.society.NoDefender.is`
 - **summary**:    There is no defender currently. 
  
+### NoDeposit
+- **interface**: `api.errors.society.NoDeposit.is`
+- **summary**:    There is no deposit associated with a bid. 
+ 
 ### NoPayout
 - **interface**: `api.errors.society.NoPayout.is`
 - **summary**:    Nothing to payout. 
@@ -2175,6 +2154,15 @@ ___
 ___
 
 
+## stakingAhClient
+ 
+### Blocked
+- **interface**: `api.errors.stakingAhClient.Blocked.is`
+- **summary**:    Could not process incoming message because incoming messages are blocked. 
+
+___
+
+
 ## system
  
 ### CallFiltered
@@ -2306,6 +2294,10 @@ ___
 ### List
 - **interface**: `api.errors.voterList.List.is`
 - **summary**:    A error in the list interface implementation. 
+ 
+### Locked
+- **interface**: `api.errors.voterList.Locked.is`
+- **summary**:    Could not update a node, because the pallet is locked. 
 
 ___
 
@@ -2404,6 +2396,10 @@ ___
 ### LocalExecutionIncomplete
 - **interface**: `api.errors.xcmPallet.LocalExecutionIncomplete.is`
 - **summary**:    Local XCM execution incomplete. 
+ 
+### LocalExecutionIncompleteWithError
+- **interface**: `api.errors.xcmPallet.LocalExecutionIncompleteWithError.is`
+- **summary**:    Local XCM execution incomplete with the actual XCM error and the index of the  instruction that caused the error. 
  
 ### LockNotFound
 - **interface**: `api.errors.xcmPallet.LockNotFound.is`

--- a/docs/kusama/events.md
+++ b/docs/kusama/events.md
@@ -36,6 +36,8 @@ Events are emitted for certain operations on the runtime. The following sections
 
 - **[grandpa](#grandpa)**
 
+- **[historical](#historical)**
+
 - **[hrmp](#hrmp)**
 
 - **[indices](#indices)**
@@ -43,10 +45,6 @@ Events are emitted for certain operations on the runtime. The following sections
 - **[messageQueue](#messagequeue)**
 
 - **[multisig](#multisig)**
-
-- **[nis](#nis)**
-
-- **[nisCounterpartBalances](#niscounterpartbalances)**
 
 - **[nominationPools](#nominationpools)**
 
@@ -66,6 +64,8 @@ Events are emitted for certain operations on the runtime. The following sections
 
 - **[proxy](#proxy)**
 
+- **[rcMigrator](#rcmigrator)**
+
 - **[recovery](#recovery)**
 
 - **[referenda](#referenda)**
@@ -81,6 +81,8 @@ Events are emitted for certain operations on the runtime. The following sections
 - **[society](#society)**
 
 - **[staking](#staking)**
+
+- **[stakingAhClient](#stakingahclient)**
 
 - **[system](#system)**
 
@@ -223,6 +225,10 @@ ___
 - **interface**: `api.events.balances.Transfer.is`
 - **summary**:    Transfer succeeded. 
  
+### Unexpected(`PalletBalancesUnexpectedKind`)
+- **interface**: `api.events.balances.Unexpected.is`
+- **summary**:    An unexpected/defensive event was triggered. 
+ 
 ### Unlocked(`AccountId32`, `u128`)
 - **interface**: `api.events.balances.Unlocked.is`
 - **summary**:    Some balance was unlocked. 
@@ -287,6 +293,10 @@ ___
 ### CuratorUnassigned(`u32`)
 - **interface**: `api.events.bounties.CuratorUnassigned.is`
 - **summary**:    A bounty curator is unassigned. 
+ 
+### DepositPoked(`u32`, `AccountId32`, `u128`, `u128`)
+- **interface**: `api.events.bounties.DepositPoked.is`
+- **summary**:    A bounty deposit has been poked. 
 
 ___
 
@@ -594,6 +604,19 @@ ___
 ___
 
 
+## historical
+ 
+### RootsPruned(`u32`)
+- **interface**: `api.events.historical.RootsPruned.is`
+- **summary**:    The merkle roots of up to this session index were pruned 
+ 
+### RootStored(`u32`)
+- **interface**: `api.events.historical.RootStored.is`
+- **summary**:    The merkle root of the validators of the said session were stored 
+
+___
+
+
 ## hrmp
  
 ### ChannelClosed(`u32`, `PolkadotParachainPrimitivesPrimitivesHrmpChannelId`)
@@ -690,132 +713,6 @@ ___
 ### NewMultisig(`AccountId32`, `AccountId32`, `[u8;32]`)
 - **interface**: `api.events.multisig.NewMultisig.is`
 - **summary**:    A new multisig operation has begun. 
-
-___
-
-
-## nis
- 
-### BidDropped(`AccountId32`, `u128`, `u32`)
-- **interface**: `api.events.nis.BidDropped.is`
-- **summary**:    A bid was dropped from a queue because of another, more substantial, bid was present. 
- 
-### BidPlaced(`AccountId32`, `u128`, `u32`)
-- **interface**: `api.events.nis.BidPlaced.is`
-- **summary**:    A bid was successfully placed. 
- 
-### BidRetracted(`AccountId32`, `u128`, `u32`)
-- **interface**: `api.events.nis.BidRetracted.is`
-- **summary**:    A bid was successfully removed (before being accepted). 
- 
-### Funded(`u128`)
-- **interface**: `api.events.nis.Funded.is`
-- **summary**:    An automatic funding of the deficit was made. 
- 
-### Issued(`u32`, `u32`, `AccountId32`, `Perquintill`, `u128`)
-- **interface**: `api.events.nis.Issued.is`
-- **summary**:    A bid was accepted. The balance may not be released until expiry. 
- 
-### Thawed(`u32`, `AccountId32`, `Perquintill`, `u128`, `bool`)
-- **interface**: `api.events.nis.Thawed.is`
-- **summary**:    An receipt has been (at least partially) thawed. 
- 
-### Transferred(`AccountId32`, `AccountId32`, `u32`)
-- **interface**: `api.events.nis.Transferred.is`
-- **summary**:    A receipt was transferred. 
-
-___
-
-
-## nisCounterpartBalances
- 
-### BalanceSet(`AccountId32`, `u128`)
-- **interface**: `api.events.nisCounterpartBalances.BalanceSet.is`
-- **summary**:    A balance was set by root. 
- 
-### Burned(`AccountId32`, `u128`)
-- **interface**: `api.events.nisCounterpartBalances.Burned.is`
-- **summary**:    Some amount was burned from an account. 
- 
-### Deposit(`AccountId32`, `u128`)
-- **interface**: `api.events.nisCounterpartBalances.Deposit.is`
-- **summary**:    Some amount was deposited (e.g. for transaction fees). 
- 
-### DustLost(`AccountId32`, `u128`)
-- **interface**: `api.events.nisCounterpartBalances.DustLost.is`
-- **summary**:    An account was removed whose balance was non-zero but below ExistentialDeposit,  resulting in an outright loss. 
- 
-### Endowed(`AccountId32`, `u128`)
-- **interface**: `api.events.nisCounterpartBalances.Endowed.is`
-- **summary**:    An account was created with some free balance. 
- 
-### Frozen(`AccountId32`, `u128`)
-- **interface**: `api.events.nisCounterpartBalances.Frozen.is`
-- **summary**:    Some balance was frozen. 
- 
-### Issued(`u128`)
-- **interface**: `api.events.nisCounterpartBalances.Issued.is`
-- **summary**:    Total issuance was increased by `amount`, creating a credit to be balanced. 
- 
-### Locked(`AccountId32`, `u128`)
-- **interface**: `api.events.nisCounterpartBalances.Locked.is`
-- **summary**:    Some balance was locked. 
- 
-### Minted(`AccountId32`, `u128`)
-- **interface**: `api.events.nisCounterpartBalances.Minted.is`
-- **summary**:    Some amount was minted into an account. 
- 
-### Rescinded(`u128`)
-- **interface**: `api.events.nisCounterpartBalances.Rescinded.is`
-- **summary**:    Total issuance was decreased by `amount`, creating a debt to be balanced. 
- 
-### Reserved(`AccountId32`, `u128`)
-- **interface**: `api.events.nisCounterpartBalances.Reserved.is`
-- **summary**:    Some balance was reserved (moved from free to reserved). 
- 
-### ReserveRepatriated(`AccountId32`, `AccountId32`, `u128`, `FrameSupportTokensMiscBalanceStatus`)
-- **interface**: `api.events.nisCounterpartBalances.ReserveRepatriated.is`
-- **summary**:    Some balance was moved from the reserve of the first account to the second account.  Final argument indicates the destination balance type. 
- 
-### Restored(`AccountId32`, `u128`)
-- **interface**: `api.events.nisCounterpartBalances.Restored.is`
-- **summary**:    Some amount was restored into an account. 
- 
-### Slashed(`AccountId32`, `u128`)
-- **interface**: `api.events.nisCounterpartBalances.Slashed.is`
-- **summary**:    Some amount was removed from the account (e.g. for misbehavior). 
- 
-### Suspended(`AccountId32`, `u128`)
-- **interface**: `api.events.nisCounterpartBalances.Suspended.is`
-- **summary**:    Some amount was suspended from an account (it can be restored later). 
- 
-### Thawed(`AccountId32`, `u128`)
-- **interface**: `api.events.nisCounterpartBalances.Thawed.is`
-- **summary**:    Some balance was thawed. 
- 
-### TotalIssuanceForced(`u128`, `u128`)
-- **interface**: `api.events.nisCounterpartBalances.TotalIssuanceForced.is`
-- **summary**:    The `TotalIssuance` was forcefully changed. 
- 
-### Transfer(`AccountId32`, `AccountId32`, `u128`)
-- **interface**: `api.events.nisCounterpartBalances.Transfer.is`
-- **summary**:    Transfer succeeded. 
- 
-### Unlocked(`AccountId32`, `u128`)
-- **interface**: `api.events.nisCounterpartBalances.Unlocked.is`
-- **summary**:    Some balance was unlocked. 
- 
-### Unreserved(`AccountId32`, `u128`)
-- **interface**: `api.events.nisCounterpartBalances.Unreserved.is`
-- **summary**:    Some balance was unreserved (moved from reserved to free). 
- 
-### Upgraded(`AccountId32`)
-- **interface**: `api.events.nisCounterpartBalances.Upgraded.is`
-- **summary**:    An account was upgraded. 
- 
-### Withdraw(`AccountId32`, `u128`)
-- **interface**: `api.events.nisCounterpartBalances.Withdraw.is`
-- **summary**:    Some amount was withdrawn from the account (e.g. for transaction fees). 
 
 ___
 
@@ -993,6 +890,10 @@ ___
 - **interface**: `api.events.paras.ActionQueued.is`
 - **summary**:    A para has been queued to execute pending actions. `para_id` 
  
+### CodeAuthorized(`u32`, `H256`, `u32`)
+- **interface**: `api.events.paras.CodeAuthorized.is`
+- **summary**:    A new code hash has been authorized for a Para. 
+ 
 ### CodeUpgradeScheduled(`u32`)
 - **interface**: `api.events.paras.CodeUpgradeScheduled.is`
 - **summary**:    A code upgrade has been scheduled for a Para. `para_id` 
@@ -1020,6 +921,10 @@ ___
 ### PvfCheckStarted(`H256`, `u32`)
 - **interface**: `api.events.paras.PvfCheckStarted.is`
 - **summary**:    The given para either initiated or subscribed to a PVF check for the given validation  code. `code_hash` `para_id` 
+ 
+### UpgradeCooldownRemoved(`u32`)
+- **interface**: `api.events.paras.UpgradeCooldownRemoved.is`
+- **summary**:    The upgrade cooldown was removed. 
 
 ___
 
@@ -1083,6 +988,99 @@ ___
 ### PureCreated(`AccountId32`, `AccountId32`, `KusamaRuntimeConstantsProxyProxyType`, `u16`)
 - **interface**: `api.events.proxy.PureCreated.is`
 - **summary**:    A pure account has been created by new proxy with given  disambiguation index and proxy type. 
+ 
+### PureKilled(`AccountId32`, `AccountId32`, `KusamaRuntimeConstantsProxyProxyType`, `u16`)
+- **interface**: `api.events.proxy.PureKilled.is`
+- **summary**:    A pure proxy was killed by its spawner. 
+
+___
+
+
+## rcMigrator
+ 
+### AccountsPreserved(`Vec<AccountId32>`)
+- **interface**: `api.events.rcMigrator.AccountsPreserved.is`
+- **summary**:    The accounts to be preserved on Relay Chain were set. 
+ 
+### AhUmpQueuePriorityConfigSet(`PalletRcMigratorQueuePriority`, `PalletRcMigratorQueuePriority`)
+- **interface**: `api.events.rcMigrator.AhUmpQueuePriorityConfigSet.is`
+- **summary**:    The AH UMP queue priority config was set. 
+ 
+### AhUmpQueuePrioritySet(`bool`, `u32`, `u32`)
+- **interface**: `api.events.rcMigrator.AhUmpQueuePrioritySet.is`
+- **summary**:    Whether the AH UMP queue was prioritized for the next block. 
+ 
+### AssetHubMigrationFinished()
+- **interface**: `api.events.rcMigrator.AssetHubMigrationFinished.is`
+- **summary**:    The Asset Hub Migration finished. 
+
+   This event is equivalent to `StageTransition { new: MigrationDone, .. }` but is easier  to understand. The finishing is immediate and affects all events happening  afterwards. 
+ 
+### AssetHubMigrationStarted()
+- **interface**: `api.events.rcMigrator.AssetHubMigrationStarted.is`
+- **summary**:    The Asset Hub Migration started and is active until `AssetHubMigrationFinished` is  emitted. 
+
+   This event is equivalent to `StageTransition { new: Initializing, .. }` but is easier  to understand. The activation is immediate and affects all events happening  afterwards. 
+ 
+### CancellerSet(`Option<AccountId32>`, `Option<AccountId32>`)
+- **interface**: `api.events.rcMigrator.CancellerSet.is`
+- **summary**:    The canceller account id was set. 
+ 
+### ManagerMultisigDispatched(`Result<Null, SpRuntimeDispatchError>`)
+- **interface**: `api.events.rcMigrator.ManagerMultisigDispatched.is`
+- **summary**:    The manager multisig dispatched something. 
+ 
+### ManagerMultisigVoted(`u32`)
+- **interface**: `api.events.rcMigrator.ManagerMultisigVoted.is`
+- **summary**:    The manager multisig received a vote. 
+ 
+### ManagerSet(`Option<AccountId32>`, `Option<AccountId32>`)
+- **interface**: `api.events.rcMigrator.ManagerSet.is`
+- **summary**:    The manager account id was set. 
+ 
+### MigratedBalanceConsumed(`u128`, `u128`)
+- **interface**: `api.events.rcMigrator.MigratedBalanceConsumed.is`
+- **summary**:    The RC kept balance was consumed. 
+ 
+### MigratedBalanceRecordSet(`u128`, `u128`)
+- **interface**: `api.events.rcMigrator.MigratedBalanceRecordSet.is`
+- **summary**:    The total issuance was recorded. 
+ 
+### MigrationCancelled()
+- **interface**: `api.events.rcMigrator.MigrationCancelled.is`
+- **summary**:    The migration was cancelled. 
+ 
+### MigrationPaused(`PalletRcMigratorMigrationStage`)
+- **interface**: `api.events.rcMigrator.MigrationPaused.is`
+- **summary**:    The migration was paused. 
+ 
+### PureAccountsIndexed(`u32`)
+- **interface**: `api.events.rcMigrator.PureAccountsIndexed.is`
+- **summary**:    Some pure accounts were indexed for possibly receiving free `Any` proxies. 
+ 
+### QueryResponseReceived(`u64`, `XcmV3MaybeErrorCode`)
+- **interface**: `api.events.rcMigrator.QueryResponseReceived.is`
+- **summary**:    A query response has been received. 
+ 
+### StageTransition(`PalletRcMigratorMigrationStage`, `PalletRcMigratorMigrationStage`)
+- **interface**: `api.events.rcMigrator.StageTransition.is`
+- **summary**:    A stage transition has occurred. 
+ 
+### StakingElectionsPaused()
+- **interface**: `api.events.rcMigrator.StakingElectionsPaused.is`
+- **summary**:    The staking elections were paused. 
+ 
+### UnprocessedMsgBufferSet(`u32`, `u32`)
+- **interface**: `api.events.rcMigrator.UnprocessedMsgBufferSet.is`
+- **summary**:    The unprocessed message buffer size has been set. 
+ 
+### XcmResendAttempt(`u64`, `Option<XcmV3TraitsSendError>`)
+- **interface**: `api.events.rcMigrator.XcmResendAttempt.is`
+- **summary**:    A XCM message has been resent. 
+ 
+### XcmSent(`StagingXcmV5Location`, `StagingXcmV5Location`, `StagingXcmV5Xcm`, `[u8;32]`)
+- **interface**: `api.events.rcMigrator.XcmSent.is`
+- **summary**:    An XCM message was sent. 
 
 ___
 
@@ -1092,6 +1090,10 @@ ___
 ### AccountRecovered(`AccountId32`, `AccountId32`)
 - **interface**: `api.events.recovery.AccountRecovered.is`
 - **summary**:    Lost account has been successfully recovered by rescuer account. 
+ 
+### DepositPoked(`AccountId32`, `PalletRecoveryDepositKind`, `u128`, `u128`)
+- **interface**: `api.events.recovery.DepositPoked.is`
+- **summary**:    A deposit has been updated. 
  
 ### RecoveryClosed(`AccountId32`, `AccountId32`)
 - **interface**: `api.events.recovery.RecoveryClosed.is`
@@ -1247,6 +1249,10 @@ ___
 
 ## session
  
+### NewQueued()
+- **interface**: `api.events.session.NewQueued.is`
+- **summary**:    The `NewSession` event in the current block also implies a new validator set to be  queued. 
+ 
 ### NewSession(`u32`)
 - **interface**: `api.events.session.NewSession.is`
 - **summary**:    New session has happened. Note that the argument is the session index, not the  block number as the type might suggest. 
@@ -1300,6 +1306,10 @@ ___
 ### Deposit(`u128`)
 - **interface**: `api.events.society.Deposit.is`
 - **summary**:    Some funds were deposited into the society account. 
+ 
+### DepositPoked(`AccountId32`, `u128`, `u128`)
+- **interface**: `api.events.society.DepositPoked.is`
+- **summary**:    A deposit was poked / adjusted. 
  
 ### Elevated(`AccountId32`, `u32`)
 - **interface**: `api.events.society.Elevated.is`
@@ -1427,6 +1437,29 @@ ___
 ### Withdrawn(`AccountId32`, `u128`)
 - **interface**: `api.events.staking.Withdrawn.is`
 - **summary**:    An account has called `withdraw_unbonded` and removed unbonding chunks worth `Balance`  from the unlocking queue. 
+
+___
+
+
+## stakingAhClient
+ 
+### CouldNotMergeAndDropped()
+- **interface**: `api.events.stakingAhClient.CouldNotMergeAndDropped.is`
+- **summary**:    We could not merge, and therefore dropped a buffered message. 
+
+   Note that this event is more resembling an error, but we use an event because in this  pallet we need to mutate storage upon some failures. 
+ 
+### SetTooSmallAndDropped()
+- **interface**: `api.events.stakingAhClient.SetTooSmallAndDropped.is`
+- **summary**:    The validator set received is way too small, as per  [`Config::MinimumValidatorSetSize`]. 
+ 
+### Unexpected(`PalletStakingAsyncAhClientUnexpectedKind`)
+- **interface**: `api.events.stakingAhClient.Unexpected.is`
+- **summary**:    Something occurred that should never happen under normal operation. Logged as an event  for fail-safe observability. 
+ 
+### ValidatorSetReceived(`u32`, `u32`, `Option<u32>`, `bool`)
+- **interface**: `api.events.stakingAhClient.ValidatorSetReceived.is`
+- **summary**:    A new validator set has been received. 
 
 ___
 
@@ -1572,6 +1605,10 @@ ___
 ### VestingCompleted(`AccountId32`)
 - **interface**: `api.events.vesting.VestingCompleted.is`
 - **summary**:    An \[account\] has become fully vested. 
+ 
+### VestingCreated(`AccountId32`, `u32`)
+- **interface**: `api.events.vesting.VestingCreated.is`
+- **summary**:    A vesting schedule has been created. 
  
 ### VestingUpdated(`AccountId32`, `u128`)
 - **interface**: `api.events.vesting.VestingUpdated.is`

--- a/docs/kusama/extrinsics.md
+++ b/docs/kusama/extrinsics.md
@@ -50,10 +50,6 @@ The following sections contain Extrinsics methods are part of the default Kusama
 
 - **[multisig](#multisig)**
 
-- **[nis](#nis)**
-
-- **[nisCounterpartBalances](#niscounterpartbalances)**
-
 - **[nominationPools](#nominationpools)**
 
 - **[onDemandAssignmentProvider](#ondemandassignmentprovider)**
@@ -76,6 +72,8 @@ The following sections contain Extrinsics methods are part of the default Kusama
 
 - **[proxy](#proxy)**
 
+- **[rcMigrator](#rcmigrator)**
+
 - **[recovery](#recovery)**
 
 - **[referenda](#referenda)**
@@ -91,6 +89,8 @@ The following sections contain Extrinsics methods are part of the default Kusama
 - **[society](#society)**
 
 - **[staking](#staking)**
+
+- **[stakingAhClient](#stakingahclient)**
 
 - **[system](#system)**
 
@@ -396,6 +396,24 @@ ___
    #### Complexity 
 
   - O(1).
+ 
+### pokeDeposit(bounty_id: `Compact<u32>`)
+- **interface**: `api.tx.bounties.pokeDeposit`
+- **summary**:    Poke the deposit reserved for creating a bounty proposal. 
+
+   This can be used by accounts to update their reserved amount. 
+
+   The dispatch origin for this call must be _Signed_. 
+
+   Parameters: 
+
+  - `bounty_id`: The bounty id for which to adjust the deposit.
+
+   If the deposit is updated, the difference will be reserved/unreserved from the  proposer's account. 
+
+   The transaction is made free if the deposit is updated and paid otherwise. 
+
+   Emits `DepositPoked` if the deposit is updated. 
  
 ### proposeBounty(value: `Compact<u128>`, description: `Bytes`)
 - **interface**: `api.tx.bounties.proposeBounty`
@@ -1076,7 +1094,7 @@ ___
 
 ## electionProviderMultiPhase
  
-### governanceFallback(maybe_max_voters: `Option<u32>`, maybe_max_targets: `Option<u32>`)
+### governanceFallback()
 - **interface**: `api.tx.electionProviderMultiPhase.governanceFallback`
 - **summary**:    Trigger the governance fallback. 
 
@@ -1780,142 +1798,6 @@ ___
 ___
 
 
-## nis
- 
-### communify(index: `Compact<u32>`)
-- **interface**: `api.tx.nis.communify`
-- **summary**:    Make a private receipt communal and create fungible counterparts for its owner. 
- 
-### fundDeficit()
-- **interface**: `api.tx.nis.fundDeficit`
-- **summary**:    Ensure we have sufficient funding for all potential payouts. 
-
-   - `origin`: Must be accepted by `FundOrigin`. 
- 
-### placeBid(amount: `Compact<u128>`, duration: `u32`)
-- **interface**: `api.tx.nis.placeBid`
-- **summary**:    Place a bid. 
-
-   Origin must be Signed, and account must have at least `amount` in free balance. 
-
-   - `amount`: The amount of the bid; these funds will be reserved, and if/when  consolidated, removed. Must be at least `MinBid`. 
-
-  - `duration`: The number of periods before which the newly consolidated bid may be thawed. Must be greater than 1 and no more than `QueueCount`. 
-
-   Complexities: 
-
-  - `Queues[duration].len()` (just take max).
- 
-### privatize(index: `Compact<u32>`)
-- **interface**: `api.tx.nis.privatize`
-- **summary**:    Make a communal receipt private and burn fungible counterparts from its owner. 
- 
-### retractBid(amount: `Compact<u128>`, duration: `u32`)
-- **interface**: `api.tx.nis.retractBid`
-- **summary**:    Retract a previously placed bid. 
-
-   Origin must be Signed, and the account should have previously issued a still-active bid  of `amount` for `duration`. 
-
-   - `amount`: The amount of the previous bid. 
-
-  - `duration`: The duration of the previous bid.
- 
-### thawCommunal(index: `Compact<u32>`)
-- **interface**: `api.tx.nis.thawCommunal`
-- **summary**:    Reduce or remove an outstanding receipt, placing the according proportion of funds into  the account of the owner. 
-
-   - `origin`: Must be Signed and the account must be the owner of the fungible counterpart  for receipt `index`. 
-
-  - `index`: The index of the receipt.
- 
-### thawPrivate(index: `Compact<u32>`, maybe_proportion: `Option<Perquintill>`)
-- **interface**: `api.tx.nis.thawPrivate`
-- **summary**:    Reduce or remove an outstanding receipt, placing the according proportion of funds into  the account of the owner. 
-
-   - `origin`: Must be Signed and the account must be the owner of the receipt `index` as  well as any fungible counterpart. 
-
-  - `index`: The index of the receipt.
-
-  - `portion`: If `Some`, then only the given portion of the receipt should be thawed. If `None`, then all of it should be. 
-
-___
-
-
-## nisCounterpartBalances
- 
-### burn(value: `Compact<u128>`, keep_alive: `bool`)
-- **interface**: `api.tx.nisCounterpartBalances.burn`
-- **summary**:    Burn the specified liquid free balance from the origin account. 
-
-   If the origin's account ends up below the existential deposit as a result  of the burn and `keep_alive` is false, the account will be reaped. 
-
-   Unlike sending funds to a _burn_ address, which merely makes the funds inaccessible,  this `burn` operation will reduce total issuance by the amount _burned_. 
- 
-### forceAdjustTotalIssuance(direction: `PalletBalancesAdjustmentDirection`, delta: `Compact<u128>`)
-- **interface**: `api.tx.nisCounterpartBalances.forceAdjustTotalIssuance`
-- **summary**:    Adjust the total issuance in a saturating way. 
-
-   Can only be called by root and always needs a positive `delta`. 
-
-   #### Example 
- 
-### forceSetBalance(who: `MultiAddress`, new_free: `Compact<u128>`)
-- **interface**: `api.tx.nisCounterpartBalances.forceSetBalance`
-- **summary**:    Set the regular balance of a given account. 
-
-   The dispatch origin for this call is `root`. 
- 
-### forceTransfer(source: `MultiAddress`, dest: `MultiAddress`, value: `Compact<u128>`)
-- **interface**: `api.tx.nisCounterpartBalances.forceTransfer`
-- **summary**:    Exactly as `transfer_allow_death`, except the origin must be root and the source account  may be specified. 
- 
-### forceUnreserve(who: `MultiAddress`, amount: `u128`)
-- **interface**: `api.tx.nisCounterpartBalances.forceUnreserve`
-- **summary**:    Unreserve some balance from a user by force. 
-
-   Can only be called by ROOT. 
- 
-### transferAll(dest: `MultiAddress`, keep_alive: `bool`)
-- **interface**: `api.tx.nisCounterpartBalances.transferAll`
-- **summary**:    Transfer the entire transferable balance from the caller account. 
-
-   NOTE: This function only attempts to transfer _transferable_ balances. This means that  any locked, reserved, or existential deposits (when `keep_alive` is `true`), will not be  transferred by this function. To ensure that this function results in a killed account,  you might need to prepare the account by removing any reference counters, storage  deposits, etc... 
-
-   The dispatch origin of this call must be Signed. 
-
-   - `dest`: The recipient of the transfer. 
-
-  - `keep_alive`: A boolean to determine if the `transfer_all` operation should send all of the funds the account has, causing the sender account to be killed (false), or  transfer everything except at least the existential deposit, which will guarantee to  keep the sender account alive (true). 
- 
-### transferAllowDeath(dest: `MultiAddress`, value: `Compact<u128>`)
-- **interface**: `api.tx.nisCounterpartBalances.transferAllowDeath`
-- **summary**:    Transfer some liquid free balance to another account. 
-
-   `transfer_allow_death` will set the `FreeBalance` of the sender and receiver.  If the sender's account is below the existential deposit as a result  of the transfer, the account will be reaped. 
-
-   The dispatch origin for this call must be `Signed` by the transactor. 
- 
-### transferKeepAlive(dest: `MultiAddress`, value: `Compact<u128>`)
-- **interface**: `api.tx.nisCounterpartBalances.transferKeepAlive`
-- **summary**:    Same as the [`transfer_allow_death`] call, but with a check that the transfer will not  kill the origin account. 
-
-   99% of the time you want [`transfer_allow_death`] instead. 
-
-   [`transfer_allow_death`]: struct.Pallet.html#method.transfer 
- 
-### upgradeAccounts(who: `Vec<AccountId32>`)
-- **interface**: `api.tx.nisCounterpartBalances.upgradeAccounts`
-- **summary**:    Upgrade a specified account. 
-
-   - `origin`: Must be `Signed`. 
-
-  - `who`: The account to be upgraded.
-
-   This will waive the transaction fee if at least all but 10% of the accounts needed to  be upgraded. (We let some not have to be upgraded just in order to allow for the  possibility of churn). 
-
-___
-
-
 ## nominationPools
  
 ### adjustPoolDeposit(pool_id: `u32`)
@@ -2325,6 +2207,20 @@ ___
 
    This function is mainly meant to be used for upgrading parachains that do not follow  the go-ahead signal while the PVF pre-checking feature is enabled. 
  
+### applyAuthorizedForceSetCurrentCode(para: `u32`, new_code: `Bytes`)
+- **interface**: `api.tx.paras.applyAuthorizedForceSetCurrentCode`
+- **summary**:    Applies the already authorized current code for the parachain,  triggering the same functionality as `force_set_current_code`. 
+ 
+### authorizeForceSetCurrentCodeHash(para: `u32`, new_code_hash: `H256`, valid_period: `u32`)
+- **interface**: `api.tx.paras.authorizeForceSetCurrentCodeHash`
+- **summary**:    Sets the storage for the authorized current code hash of the parachain.  If not applied, it will be removed at the `System::block_number() + valid_period` block. 
+
+   This can be useful, when triggering `Paras::force_set_current_code(para, code)`  from a different chain than the one where the `Paras` pallet is deployed. 
+
+   The main purpose is to avoid transferring the entire `code` Wasm blob between chains.  Instead, we authorize `code_hash` with `root`, which can later be applied by  `Paras::apply_authorized_force_set_current_code(para, code)` by anyone. 
+
+   Authorizations are stored in an **overwriting manner**. 
+ 
 ### forceNoteNewHead(para: `u32`, new_head: `Bytes`)
 - **interface**: `api.tx.paras.forceNoteNewHead`
 - **summary**:    Note a new block head for para within the context of the current block. 
@@ -2358,6 +2254,12 @@ ___
 - **summary**:    Remove the validation code from the storage iff the reference count is 0. 
 
    This is better than removing the storage directly, because it will not remove the code  that was suddenly got used by some parachain while this dispatchable was pending  dispatching. 
+ 
+### removeUpgradeCooldown(para: `u32`)
+- **interface**: `api.tx.paras.removeUpgradeCooldown`
+- **summary**:    Remove an upgrade cooldown for a parachain. 
+
+   The cost for removing the cooldown earlier depends on the time left for the cooldown  multiplied by [`Config::CooldownRemovalMultiplier`]. The paid tokens are burned. 
 
 ___
 
@@ -2377,7 +2279,7 @@ ___
 
 ## parasSlashing
  
-### reportDisputeLostUnsigned(dispute_proof: `PolkadotPrimitivesV8SlashingDisputeProof`, key_owner_proof: `SpSessionMembershipProof`)
+### reportDisputeLostUnsigned(dispute_proof: `PolkadotPrimitivesVstagingDisputeProof`, key_owner_proof: `SpSessionMembershipProof`)
 - **interface**: `api.tx.parasSlashing.reportDisputeLostUnsigned`
 
 ___
@@ -2478,19 +2380,19 @@ ___
 
    WARNING: **All access to this account will be lost.** Any funds held in it will be  inaccessible. 
 
-   Requires a `Signed` origin, and the sender account must have been created by a call to  `pure` with corresponding parameters. 
+   Requires a `Signed` origin, and the sender account must have been created by a call to  `create_pure` with corresponding parameters. 
 
-   - `spawner`: The account that originally called `pure` to create this account. 
+   - `spawner`: The account that originally called `create_pure` to create this account. 
 
-  - `index`: The disambiguation index originally passed to `pure`. Probably `0`.
+  - `index`: The disambiguation index originally passed to `create_pure`. Probably `0`.
 
-  - `proxy_type`: The proxy type originally passed to `pure`.
+  - `proxy_type`: The proxy type originally passed to `create_pure`.
 
-  - `height`: The height of the chain when the call to `pure` was processed.
+  - `height`: The height of the chain when the call to `create_pure` was processed.
 
-  - `ext_index`: The extrinsic index in which the call to `pure` was processed.
+  - `ext_index`: The extrinsic index in which the call to `create_pure` was processed.
 
-   Fails with `NoPermission` in case the caller is not a previously created pure  account whose `pure` call has corresponding parameters. 
+   Fails with `NoPermission` in case the caller is not a previously created pure  account whose `create_pure` call has corresponding parameters. 
  
 ### pokeDeposit()
 - **interface**: `api.tx.proxy.pokeDeposit`
@@ -2566,7 +2468,7 @@ ___
 
    The dispatch origin for this call must be _Signed_. 
 
-   WARNING: This may be called on accounts created by `pure`, however if done, then  the unreserved fees will be inaccessible. **All access to this account will be lost.** 
+   WARNING: This may be called on accounts created by `create_pure`, however if done, then  the unreserved fees will be inaccessible. **All access to this account will be lost.** 
  
 ### removeProxy(delegate: `MultiAddress`, proxy_type: `KusamaRuntimeConstantsProxyProxyType`, delay: `u32`)
 - **interface**: `api.tx.proxy.removeProxy`
@@ -2579,6 +2481,103 @@ ___
   - `proxy`: The account that the `caller` would like to remove as a proxy.
 
   - `proxy_type`: The permissions currently enabled for the removed proxy account.
+
+___
+
+
+## rcMigrator
+ 
+### cancelMigration()
+- **interface**: `api.tx.rcMigrator.cancelMigration`
+- **summary**:    Cancel the migration. 
+
+   Migration can only be cancelled if it is in the [`MigrationStage::Scheduled`] state. 
+ 
+### forceSetStage(stage: `PalletRcMigratorMigrationStage`)
+- **interface**: `api.tx.rcMigrator.forceSetStage`
+- **summary**:    Set the migration stage. 
+
+   This call is intended for emergency use only and is guarded by the  [`Config::AdminOrigin`]. 
+ 
+### pauseMigration()
+- **interface**: `api.tx.rcMigrator.pauseMigration`
+- **summary**:    Pause the migration. 
+ 
+### preserveAccounts(accounts: `Vec<AccountId32>`)
+- **interface**: `api.tx.rcMigrator.preserveAccounts`
+- **summary**:    Set the accounts to be preserved on Relay Chain during the migration. 
+
+   The accounts must have no consumers references. 
+ 
+### receiveQueryResponse(query_id: `u64`, response: `StagingXcmV5Response`)
+- **interface**: `api.tx.rcMigrator.receiveQueryResponse`
+- **summary**:    Receive a query response from the Asset Hub for a previously sent xcm message. 
+ 
+### resendXcm(query_id: `u64`)
+- **interface**: `api.tx.rcMigrator.resendXcm`
+- **summary**:    Resend a previously sent and unconfirmed XCM message. 
+ 
+### scheduleMigration(start: `FrameSupportScheduleDispatchTime`, warm_up: `FrameSupportScheduleDispatchTime`, cool_off: `FrameSupportScheduleDispatchTime`, unsafe_ignore_staking_lock_check: `bool`)
+- **interface**: `api.tx.rcMigrator.scheduleMigration`
+- **summary**:    Schedule the migration to start at a given moment. 
+
+   #### Parameters: 
+
+  - `start`: The block number at which the migration will start. `DispatchTime` calculated at the moment of the extrinsic execution. 
+
+  - `warm_up`: Duration or timepoint that will be used to prepare for the migration. Calls are filtered during this period. It is intended to give enough time for UMP and DMP  queues to empty. `DispatchTime` calculated at the moment of the transition to the  warm-up stage. 
+
+  - `cool_off`: The block number at which the post migration cool-off period will end. The `DispatchTime` calculated at the moment of the transition to the cool-off stage. 
+
+  - `unsafe_ignore_staking_lock_check`: ONLY FOR TESTING. Ignore the check whether the scheduled time point is far enough in the future. 
+
+   Note: If the staking election for next era is already complete, and the next  validator set is queued in `pallet-session`, we want to avoid starting the data  migration at this point as it can lead to some missed validator rewards. To address  this, we stop staking election at the start of migration and must wait atleast 1  session (set via warm_up) before starting the data migration. 
+
+   Read [`MigrationStage::Scheduled`] documentation for more details. 
+ 
+### sendXcmMessage(dest: `XcmVersionedLocation`, message: `XcmVersionedXcm`)
+- **interface**: `api.tx.rcMigrator.sendXcmMessage`
+- **summary**:    XCM send call identical to the [`pallet_xcm::Pallet::send`] call but with the  [Config::SendXcm] router which will be able to send messages to the Asset Hub during  the migration. 
+ 
+### setAhUmpQueuePriority(new: `PalletRcMigratorQueuePriority`)
+- **interface**: `api.tx.rcMigrator.setAhUmpQueuePriority`
+- **summary**:    Set the AH UMP queue priority configuration. 
+
+   Can only be called by the `AdminOrigin`. 
+ 
+### setCanceller(new: `Option<AccountId32>`)
+- **interface**: `api.tx.rcMigrator.setCanceller`
+- **summary**:    Set the canceller account id. 
+
+   The canceller can only stop scheduled migration. 
+ 
+### setManager(new: `Option<AccountId32>`)
+- **interface**: `api.tx.rcMigrator.setManager`
+- **summary**:    Set the manager account id. 
+
+   The manager has the similar to [`Config::AdminOrigin`] privileges except that it  can not set the manager account id via `set_manager` call. 
+ 
+### setUnprocessedMsgBuffer(new: `Option<u32>`)
+- **interface**: `api.tx.rcMigrator.setUnprocessedMsgBuffer`
+- **summary**:    Set the unprocessed message buffer size. 
+
+   `None` means to use the configuration value. 
+ 
+### startDataMigration()
+- **interface**: `api.tx.rcMigrator.startDataMigration`
+- **summary**:    Start the data migration. 
+
+   This is typically called by the Asset Hub to indicate it's readiness to receive the  migration data. 
+ 
+### voteManagerMultisig(payload: `PalletRcMigratorManagerMultisigVote`, sig: `SpRuntimeMultiSignature`)
+- **interface**: `api.tx.rcMigrator.voteManagerMultisig`
+- **summary**:    Vote on behalf of any of the members in `MultisigMembers`. 
+
+   Unsigned extrinsic, requiring the `payload` to be signed. 
+
+   Upon each call, a new entry is created in `ManagerMultisigs` map the `payload.call` to  be dispatched. Once `MultisigThreshold` is reached, the entire map is deleted, and we  move on to the next round. 
+
+   The round system ensures that signatures from older round cannot be reused. 
 
 ___
 
@@ -2656,6 +2655,30 @@ ___
    Parameters: 
 
   - `account`: The lost account that you want to recover. This account needs to be recoverable (i.e. have a recovery configuration). 
+ 
+### pokeDeposit(maybe_account: `Option<MultiAddress>`)
+- **interface**: `api.tx.recovery.pokeDeposit`
+- **summary**:    Poke deposits for recovery configurations and / or active recoveries. 
+
+   This can be used by accounts to possibly lower their locked amount. 
+
+   The dispatch origin for this call must be _Signed_. 
+
+   Parameters: 
+
+  - `maybe_account`: Optional recoverable account for which you have an active recovery and want to adjust the deposit for the active recovery. 
+
+   This function checks both recovery configuration deposit and active recovery deposits  of the caller: 
+
+  - If the caller has created a recovery configuration, checks and adjusts its deposit
+
+  - If the caller has initiated any active recoveries, and provides the account in `maybe_account`, checks and adjusts those deposits 
+
+   If any deposit is updated, the difference will be reserved/unreserved from the caller's  account. 
+
+   The transaction is made free if any deposit is updated and paid otherwise. 
+
+   Emits `DepositPoked` if any deposit is updated.  Multiple events may be emitted in case both types of deposits are updated. 
  
 ### removeRecovery()
 - **interface**: `api.tx.recovery.removeRecovery`
@@ -3107,6 +3130,16 @@ ___
 
    The dispatch origin for this call must be _Signed_ and a member with  payouts remaining. 
  
+### pokeDeposit()
+- **interface**: `api.tx.society.pokeDeposit`
+- **summary**:    Poke the deposit reserved when bidding. 
+
+   The dispatch origin for this call must be _Signed_ and must be the bidder. 
+
+   The transaction fee is waived if the deposit is changed after poking/reconsideration. 
+
+   Emits `DepositPoked` if successful. 
+ 
 ### punishSkeptic()
 - **interface**: `api.tx.society.punishSkeptic`
 - **summary**:    Punish the skeptic with a strike if they did not vote on a candidate. Callable by the  candidate. 
@@ -3230,7 +3263,7 @@ ___
 
    Can be called by the `T::AdminOrigin`. 
 
-   Parameters: era and indices of the slashes for that era to kill. 
+   Parameters: era and indices of the slashes for that era to kill.  They **must** be sorted in ascending order, *and* unique. 
  
 ### chill()
 - **interface**: `api.tx.staking.chill`
@@ -3566,6 +3599,8 @@ ___
 - **interface**: `api.tx.staking.unbond`
 - **summary**:    Schedule a portion of the stash to be unlocked ready for transfer out after the bond  period ends. If this leaves an amount actively bonded less than  [`asset::existential_deposit`], then it is increased to the full amount. 
 
+   The stash may be chilled if the ledger total amount falls to 0 after unbonding. 
+
    The dispatch origin for this call must be _Signed_ by the controller, not the stash. 
 
    Once the unlock period is done, you can call `withdraw_unbonded` to actually move  the funds out of management ready for transfer. 
@@ -3611,6 +3646,22 @@ ___
    - `num_slashing_spans` indicates the number of metadata slashing spans to clear when  this call results in a complete removal of all the data related to the stash account.  In this case, the `num_slashing_spans` must be larger or equal to the number of  slashing spans associated with the stash account in the [`SlashingSpans`] storage type,  otherwise the call will fail. The call weight is directly proportional to  `num_slashing_spans`. 
 
    #### Complexity  O(S) where S is the number of slashing spans to remove  NOTE: Weight annotation is the kill scenario, we refund otherwise. 
+
+___
+
+
+## stakingAhClient
+ 
+### forceOnMigrationEnd()
+- **interface**: `api.tx.stakingAhClient.forceOnMigrationEnd`
+- **summary**:    manually do what this pallet was meant to do at the end of the migration. 
+ 
+### setMode(mode: `PalletStakingAsyncAhClientOperatingMode`)
+- **interface**: `api.tx.stakingAhClient.setMode`
+- **summary**:    Allows governance to force set the operating mode of the pallet. 
+ 
+### validatorSet(report: `PalletStakingAsyncRcClientValidatorSetReport`)
+- **interface**: `api.tx.stakingAhClient.validatorSet`
 
 ___
 

--- a/docs/kusama/storage.md
+++ b/docs/kusama/storage.md
@@ -64,10 +64,6 @@ The following sections contain Storage methods are part of the default Kusama ru
 
 - **[multisig](#multisig)**
 
-- **[nis](#nis)**
-
-- **[nisCounterpartBalances](#niscounterpartbalances)**
-
 - **[nominationPools](#nominationpools)**
 
 - **[offences](#offences)**
@@ -96,6 +92,8 @@ The following sections contain Storage methods are part of the default Kusama ru
 
 - **[proxy](#proxy)**
 
+- **[rcMigrator](#rcmigrator)**
+
 - **[recovery](#recovery)**
 
 - **[referenda](#referenda)**
@@ -111,6 +109,8 @@ The following sections contain Storage methods are part of the default Kusama ru
 - **[society](#society)**
 
 - **[staking](#staking)**
+
+- **[stakingAhClient](#stakingahclient)**
 
 - **[substrate](#substrate)**
 
@@ -295,11 +295,11 @@ ___
 
    But this comes with tradeoffs, storing account balances in the system pallet stores  `frame_system` data alongside the account data contrary to storing account balances in the  `Balances` pallet, which uses a `StorageMap` to store balances data only.  NOTE: This is only used in the case that this pallet is used to store balances. 
  
-### freezes(`AccountId32`): `Vec<{"id":"StagingKusamaRuntimeRuntimeFreezeReason","amount":"u128"}>`
+### freezes(`AccountId32`): `Vec<FrameSupportTokensMiscIdAmountRuntimeFreezeReason>`
 - **interface**: `api.query.balances.freezes`
 - **summary**:    Freeze locks on account balances. 
  
-### holds(`AccountId32`): `Vec<{"id":"StagingKusamaRuntimeRuntimeHoldReason","amount":"u128"}>`
+### holds(`AccountId32`): `Vec<FrameSupportTokensMiscIdAmountRuntimeHoldReason>`
 - **interface**: `api.query.balances.holds`
 - **summary**:    Holds on account balances. 
  
@@ -935,78 +935,6 @@ ___
 ___
 
 
-## nis
- 
-### queues(`u32`): `Vec<PalletNisBid>`
-- **interface**: `api.query.nis.queues`
-- **summary**:    The queues of bids. Indexed by duration (in `Period`s). 
- 
-### queueTotals(): `Vec<(u32,u128)>`
-- **interface**: `api.query.nis.queueTotals`
-- **summary**:    The totals of items and balances within each queue. Saves a lot of storage reads in the  case of sparsely packed queues. 
-
-   The vector is indexed by duration in `Period`s, offset by one, so information on the queue  whose duration is one `Period` would be storage `0`. 
- 
-### receipts(`u32`): `Option<PalletNisReceiptRecord>`
-- **interface**: `api.query.nis.receipts`
-- **summary**:    The currently outstanding receipts, indexed according to the order of creation. 
- 
-### summary(): `PalletNisSummaryRecord`
-- **interface**: `api.query.nis.summary`
-- **summary**:    Summary information over the general state. 
-
-___
-
-
-## nisCounterpartBalances
- 
-### account(`AccountId32`): `PalletBalancesAccountData`
-- **interface**: `api.query.nisCounterpartBalances.account`
-- **summary**:    The Balances pallet example of storing the balance of an account. 
-
-   #### Example 
-
-   ```nocompile  impl pallet_balances::Config for Runtime {  type AccountStore = StorageMapShim<Self::Account<Runtime>, frame_system::Provider<Runtime>, AccountId, Self::AccountData<Balance>>  }  ``` 
-
-   You can also store the balance of an account in the `System` pallet. 
-
-   #### Example 
-
-   ```nocompile  impl pallet_balances::Config for Runtime {  type AccountStore = System  }  ``` 
-
-   But this comes with tradeoffs, storing account balances in the system pallet stores  `frame_system` data alongside the account data contrary to storing account balances in the  `Balances` pallet, which uses a `StorageMap` to store balances data only.  NOTE: This is only used in the case that this pallet is used to store balances. 
- 
-### freezes(`AccountId32`): `Vec<FrameSupportTokensMiscIdAmount>`
-- **interface**: `api.query.nisCounterpartBalances.freezes`
-- **summary**:    Freeze locks on account balances. 
- 
-### holds(`AccountId32`): `Vec<{"id":"StagingKusamaRuntimeRuntimeHoldReason","amount":"u128"}>`
-- **interface**: `api.query.nisCounterpartBalances.holds`
-- **summary**:    Holds on account balances. 
- 
-### inactiveIssuance(): `u128`
-- **interface**: `api.query.nisCounterpartBalances.inactiveIssuance`
-- **summary**:    The total units of outstanding deactivated balance in the system. 
- 
-### locks(`AccountId32`): `Vec<PalletBalancesBalanceLock>`
-- **interface**: `api.query.nisCounterpartBalances.locks`
-- **summary**:    Any liquidity locks on some account balances.  NOTE: Should only be accessed when setting, changing and freeing a lock. 
-
-   Use of locks is deprecated in favour of freezes. See `https://github.com/paritytech/substrate/pull/12951/` 
- 
-### reserves(`AccountId32`): `Vec<PalletBalancesReserveData>`
-- **interface**: `api.query.nisCounterpartBalances.reserves`
-- **summary**:    Named reserves on some account balances. 
-
-   Use of reserves is deprecated in favour of holds. See `https://github.com/paritytech/substrate/pull/12951/` 
- 
-### totalIssuance(): `u128`
-- **interface**: `api.query.nisCounterpartBalances.totalIssuance`
-- **summary**:    The total units issued in the system. 
-
-___
-
-
 ## nominationPools
  
 ### bondedPools(`u32`): `Option<PalletNominationPoolsBondedPoolInner>`
@@ -1188,6 +1116,10 @@ ___
 ### actionsQueue(`u32`): `Vec<u32>`
 - **interface**: `api.query.paras.actionsQueue`
 - **summary**:    The actions to perform during the start of a specific session index. 
+ 
+### authorizedCodeHash(`u32`): `Option<PolkadotRuntimeParachainsParasAuthorizedCodeHashAndExpiry>`
+- **interface**: `api.query.paras.authorizedCodeHash`
+- **summary**:    The code hash authorizations for a para which will expire `expire_at` `BlockNumberFor<T>`. 
  
 ### codeByHash(`H256`): `Option<Bytes>`
 - **interface**: `api.query.paras.codeByHash`
@@ -1402,7 +1334,7 @@ ___
 
 ## parasSlashing
  
-### unappliedSlashes(`u32, H256`): `Option<PolkadotPrimitivesV8SlashingPendingSlashes>`
+### unappliedSlashes(`u32, H256`): `Option<PolkadotPrimitivesVstagingPendingSlashes>`
 - **interface**: `api.query.parasSlashing.unappliedSlashes`
 - **summary**:    Validators pending dispute slashes. 
  
@@ -1438,6 +1370,109 @@ ___
 ### proxies(`AccountId32`): `(Vec<PalletProxyProxyDefinition>,u128)`
 - **interface**: `api.query.proxy.proxies`
 - **summary**:    The set of account proxies. Maps the account which has delegated to the accounts  which are being delegated to, together with the amount held on deposit. 
+
+___
+
+
+## rcMigrator
+ 
+### ahUmpQueuePriorityConfig(): `PalletRcMigratorQueuePriority`
+- **interface**: `api.query.rcMigrator.ahUmpQueuePriorityConfig`
+- **summary**:    The priority of the Asset Hub UMP queue during migration. 
+
+   Controls how the Asset Hub UMP (Upward Message Passing) queue is processed relative to other  queues during the migration process. This helps ensure timely processing of migration  messages. The default priority pattern is defined in the pallet configuration, but can be  overridden by a storage value of this type. 
+ 
+### canceller(): `Option<AccountId32>`
+- **interface**: `api.query.rcMigrator.canceller`
+- **summary**:    An optional account id of a canceller. 
+
+   This account id can only stop scheduled migration. 
+ 
+### coolOffPeriod(): `Option<FrameSupportScheduleDispatchTime>`
+- **interface**: `api.query.rcMigrator.coolOffPeriod`
+- **summary**:    The duration of the post migration cool-off period. 
+
+   This is the duration of the cool-off period after the data migration is finished. During  this period, the migration will be still in ongoing state and the concerned extrinsics will  be locked. 
+ 
+### counterForPendingXcmMessages(): `u32`
+- **interface**: `api.query.rcMigrator.counterForPendingXcmMessages`
+- **summary**:    Counter for the related counted storage map 
+ 
+### counterForRcAccounts(): `u32`
+- **interface**: `api.query.rcMigrator.counterForRcAccounts`
+- **summary**:    Counter for the related counted storage map 
+ 
+### manager(): `Option<AccountId32>`
+- **interface**: `api.query.rcMigrator.manager`
+- **summary**:    An optional account id of a manager. 
+
+   This account id has similar privileges to [`Config::AdminOrigin`] except that it  can not set the manager account id via `set_manager` call. 
+ 
+### managerMultisigRound(): `u32`
+- **interface**: `api.query.rcMigrator.managerMultisigRound`
+ 
+### managerMultisigs(`Call`): `Vec<SpRuntimeMultiSigner>`
+- **interface**: `api.query.rcMigrator.managerMultisigs`
+ 
+### migrationEndBlock(): `Option<u32>`
+- **interface**: `api.query.rcMigrator.migrationEndBlock`
+- **summary**:    Block number when migration finished and extrinsics were unlocked. 
+
+   This is set when entering the `MigrationDone` stage hence when  `RcMigrationStage::is_finished()` becomes `true`. 
+ 
+### migrationStartBlock(): `Option<u32>`
+- **interface**: `api.query.rcMigrator.migrationStartBlock`
+- **summary**:    The block number at which the migration began and the pallet's extrinsics were locked. 
+
+   This value is set when entering the `WaitingForAh` stage, i.e., when  `RcMigrationStage::is_ongoing()` becomes `true`. 
+ 
+### pendingXcmMessages(`H256`): `Option<StagingXcmV5Xcm>`
+- **interface**: `api.query.rcMigrator.pendingXcmMessages`
+- **summary**:    The pending XCM messages. 
+
+   Contains data messages that have been sent to the Asset Hub but not yet confirmed. 
+
+   Unconfirmed messages can be resent by calling the [`Pallet::resend_xcm`] function. 
+ 
+### pendingXcmQueries(`u64`): `Option<H256>`
+- **interface**: `api.query.rcMigrator.pendingXcmQueries`
+- **summary**:    The pending XCM response queries and their XCM hash referencing the message in the  [`PendingXcmMessages`] storage. 
+
+   The `QueryId` is the identifier from the [`pallet_xcm`] query handler registry. The XCM  pallet will notify about the status of the message by calling the  [`Pallet::receive_query_response`] function with the `QueryId` and the  response. 
+ 
+### pureProxyCandidatesMigrated(`AccountId32`): `Option<bool>`
+- **interface**: `api.query.rcMigrator.pureProxyCandidatesMigrated`
+- **summary**:    Accounts that use the proxy pallet to delegate permissions and have no nonce. 
+
+   Boolean value is whether they have been migrated to the Asset Hub. Needed for idempotency. 
+ 
+### rcAccounts(`AccountId32`): `Option<PalletRcMigratorAccountsAccountState>`
+- **interface**: `api.query.rcMigrator.rcAccounts`
+- **summary**:    Helper storage item to obtain and store the known accounts that should be kept partially or  fully on Relay Chain. 
+ 
+### rcMigratedBalance(): `PalletRcMigratorAccountsMigratedBalances`
+- **interface**: `api.query.rcMigrator.rcMigratedBalance`
+- **summary**:    Helper storage item to store the total balance that should be kept on Relay Chain. 
+ 
+### rcMigratedBalanceArchive(): `PalletRcMigratorAccountsMigratedBalances`
+- **interface**: `api.query.rcMigrator.rcMigratedBalanceArchive`
+- **summary**:    Helper storage item to store the total balance that should be kept on Relay Chain after  it is consumed from the `RcMigratedBalance` storage item and sent to the Asset Hub. 
+
+   This let us to take the value from the `RcMigratedBalance` storage item and keep the  `SignalMigrationFinish` stage to be idempotent while preserving these values for tests and  later discoveries. 
+ 
+### rcMigrationStage(): `PalletRcMigratorMigrationStage`
+- **interface**: `api.query.rcMigrator.rcMigrationStage`
+- **summary**:    The Relay Chain migration state. 
+ 
+### unprocessedMsgBuffer(): `Option<u32>`
+- **interface**: `api.query.rcMigrator.unprocessedMsgBuffer`
+- **summary**:    Manual override for `type UnprocessedMsgBuffer: Get<u32>`. Look there for docs. 
+ 
+### warmUpPeriod(): `Option<FrameSupportScheduleDispatchTime>`
+- **interface**: `api.query.rcMigrator.warmUpPeriod`
+- **summary**:    The duration of the pre migration warm-up period. 
+
+   This is the duration of the warm-up period before the data migration starts. During this  period, the migration will be in ongoing state and the concerned extrinsics will be locked. 
 
 ___
 
@@ -1629,9 +1664,17 @@ ___
 - **interface**: `api.query.society.members`
 - **summary**:    The current members and their rank. Doesn't include `SuspendedMembers`. 
  
+### nextChallengeAt(): `Option<u32>`
+- **interface**: `api.query.society.nextChallengeAt`
+- **summary**:    Next challenge rotation scheduled with [Config::BlockNumberProvider]. 
+ 
 ### nextHead(): `Option<PalletSocietyIntakeRecord>`
 - **interface**: `api.query.society.nextHead`
 - **summary**:    At the end of the claim period, this contains the most recently approved members (along with  their bid and round ID) who is from the most recent round with the lowest bid. They will  become the new `Head`. 
+ 
+### nextIntakeAt(): `Option<u32>`
+- **interface**: `api.query.society.nextIntakeAt`
+- **summary**:    Next intake rotation scheduled with [Config::BlockNumberProvider]. 
  
 ### parameters(): `Option<PalletSocietyGroupParams>`
 - **interface**: `api.query.society.parameters`
@@ -1917,6 +1960,61 @@ ___
 ___
 
 
+## stakingAhClient
+ 
+### incompleteValidatorSetReport(): `Option<PalletStakingAsyncRcClientValidatorSetReport>`
+- **interface**: `api.query.stakingAhClient.incompleteValidatorSetReport`
+- **summary**:    An incomplete validator set report. 
+ 
+### mode(): `PalletStakingAsyncAhClientOperatingMode`
+- **interface**: `api.query.stakingAhClient.mode`
+- **summary**:    Indicates the current operating mode of the pallet. 
+
+   This value determines how the pallet behaves in response to incoming and outgoing messages,  particularly whether it should execute logic directly, defer it, or delegate it entirely. 
+ 
+### nextSessionChangesValidators(): `Option<u32>`
+- **interface**: `api.query.stakingAhClient.nextSessionChangesValidators`
+- **summary**:    A storage value that is set when a `new_session` gives a new validator set to the session  pallet, and is cleared on the next call. 
+
+   The inner u32 is the id of the said activated validator set. While not relevant here, good  to know this is the planning era index of staking-async on AH. 
+
+   Once cleared, we know a validator set has been activated, and therefore we can send a  timestamp to AH. 
+ 
+### offenceSendQueueCursor(): `u32`
+- **interface**: `api.query.stakingAhClient.offenceSendQueueCursor`
+- **summary**:    Internal storage item of [`OffenceSendQueue`]. Should not be used manually. 
+ 
+### offenceSendQueueOffences(`u32`): `Vec<(u32,PalletStakingAsyncRcClientOffence)>`
+- **interface**: `api.query.stakingAhClient.offenceSendQueueOffences`
+- **summary**:    Internal storage item of [`OffenceSendQueue`]. Should not be used manually. 
+ 
+### outgoingSessionReport(): `Option<(PalletStakingAsyncRcClientSessionReport,u32)>`
+- **interface**: `api.query.stakingAhClient.outgoingSessionReport`
+- **summary**:    A session report that is outgoing, and should be sent. 
+
+   This will be attempted to be sent, possibly on every `on_initialize` call, until it is sent,  or the second value reaches zero, at which point we drop it. 
+ 
+### validatorPoints(`AccountId32`): `u32`
+- **interface**: `api.query.stakingAhClient.validatorPoints`
+- **summary**:    All of the points of the validators. 
+
+   This is populated during a session, and is flushed and sent over via [`SendToAssetHub`]  at each session end. 
+ 
+### validatorSet(): `Option<(u32,Vec<AccountId32>)>`
+- **interface**: `api.query.stakingAhClient.validatorSet`
+- **summary**:    The queued validator sets for a given planning session index. 
+
+   This is received via a call from AssetHub. 
+ 
+### validatorSetAppliedAt(): `Option<u32>`
+- **interface**: `api.query.stakingAhClient.validatorSetAppliedAt`
+- **summary**:    The session index at which the latest elected validator set was applied. 
+
+   This is used to determine if an offence, given a session index, is in the current active era  or not. 
+
+___
+
+
 ## substrate
 
 _These are well-known keys that are always available to the runtime implementation of any Substrate-based network._
@@ -2150,6 +2248,16 @@ ___
 - **summary**:    A single node, within some bag. 
 
    Nodes store links forward and back within their respective bags. 
+ 
+### lock(): `Option<Null>`
+- **interface**: `api.query.voterList.lock`
+- **summary**:    Lock all updates to this pallet. 
+
+   If any nodes needs updating, removal or addition due to a temporary lock, the  [`Call::rebag`] can be used. 
+ 
+### nextNodeAutoRebagged(): `Option<AccountId32>`
+- **interface**: `api.query.voterList.nextNodeAutoRebagged`
+- **summary**:    Pointer that remembers the next node that will be auto-rebagged.  When `None`, the next scan will start from the list head again. 
 
 ___
 

--- a/docs/polkadot/constants.md
+++ b/docs/polkadot/constants.md
@@ -54,6 +54,8 @@ The following sections contain the module constants, also known as parameter typ
 
 - **[scheduler](#scheduler)**
 
+- **[session](#session)**
+
 - **[slots](#slots)**
 
 - **[staking](#staking)**
@@ -304,9 +306,15 @@ ___
 - **interface**: `api.consts.electionProviderMultiPhase.betterSignedThreshold`
 - **summary**:    The minimum amount of improvement to the solution score that defines a solution as  "better" in the Signed phase. 
  
+### maxBackersPerWinner: `u32`
+- **interface**: `api.consts.electionProviderMultiPhase.maxBackersPerWinner`
+- **summary**:    Maximum number of voters that can support a winner in an election solution. 
+
+   This is needed to ensure election computation is bounded. 
+ 
 ### maxWinners: `u32`
 - **interface**: `api.consts.electionProviderMultiPhase.maxWinners`
-- **summary**:    The maximum number of winners that can be elected by this `ElectionProvider`  implementation. 
+- **summary**:    Maximum number of winners that an election supports. 
 
    Note: This must always be greater or equal to `T::DataProvider::desired_targets()`. 
  
@@ -588,6 +596,15 @@ ___
 ___
 
 
+## session
+ 
+### keyDeposit: `u128`
+- **interface**: `api.consts.session.keyDeposit`
+- **summary**:    The amount to be held when setting keys. 
+
+___
+
+
 ## slots
  
 ### leaseOffset: `u32`
@@ -634,6 +651,10 @@ ___
 - **summary**:    The maximum number of `unlocking` chunks a [`StakingLedger`] can  have. Effectively determines how many unique eras a staker may be  unbonding in. 
 
    Note: `MaxUnlockingChunks` is used as the upper bound for the  `BoundedVec` item `StakingLedger.unlocking`. Setting this value  lower than the existing value can lead to inconsistencies in the  `StakingLedger` and will need to be handled properly in a runtime  migration. The test `reducing_max_unlocking_chunks_abrupt` shows  this effect. 
+ 
+### maxValidatorSet: `u32`
+- **interface**: `api.consts.staking.maxValidatorSet`
+- **summary**:    The absolute maximum of winner validators this pallet should return. 
  
 ### sessionsPerEra: `u32`
 - **interface**: `api.consts.staking.sessionsPerEra`
@@ -821,6 +842,12 @@ ___
    #### Migration 
 
    In the event that this list ever changes, a copy of the old bags list must be retained.  With that `List::migrate` can be called, which will perform the appropriate migration. 
+ 
+### maxAutoRebagPerBlock: `u32`
+- **interface**: `api.consts.voterList.maxAutoRebagPerBlock`
+- **summary**:    Maximum number of accounts that may be re-bagged automatically in `on_idle`. 
+
+   A value of `0` (obtained by configuring `type MaxAutoRebagPerBlock = ();`) disables  the feature. 
 
 ___
 
@@ -830,3 +857,15 @@ ___
 ### advertisedXcmVersion: `u32`
 - **interface**: `api.consts.xcmPallet.advertisedXcmVersion`
 - **summary**:    The latest supported version that we advertise. Generally just set it to  `pallet_xcm::CurrentXcmVersion`. 
+ 
+### maxLockers: `u32`
+- **interface**: `api.consts.xcmPallet.maxLockers`
+- **summary**:    The maximum number of local XCM locks that a single account may have. 
+ 
+### maxRemoteLockConsumers: `u32`
+- **interface**: `api.consts.xcmPallet.maxRemoteLockConsumers`
+- **summary**:    The maximum number of consumers a single remote lock may have. 
+ 
+### universalLocation: `StagingXcmV5Junctions`
+- **interface**: `api.consts.xcmPallet.universalLocation`
+- **summary**:    This chain's Universal Location. 

--- a/docs/polkadot/errors.md
+++ b/docs/polkadot/errors.md
@@ -66,6 +66,8 @@ This page lists the errors that can be encountered in the different modules.
 
 - **[proxy](#proxy)**
 
+- **[rcMigrator](#rcmigrator)**
+
 - **[referenda](#referenda)**
 
 - **[registrar](#registrar)**
@@ -77,6 +79,8 @@ This page lists the errors that can be encountered in the different modules.
 - **[slots](#slots)**
 
 - **[staking](#staking)**
+
+- **[stakingAhClient](#stakingahclient)**
 
 - **[stateTrieMigration](#statetriemigration)**
 
@@ -276,6 +280,10 @@ ___
 ### InvalidValue
 - **interface**: `api.errors.bounties.InvalidValue.is`
 - **summary**:    Invalid bounty value. 
+ 
+### NotProposer
+- **interface**: `api.errors.bounties.NotProposer.is`
+- **summary**:    User is not the proposer of the bounty. 
  
 ### PendingPayout
 - **interface**: `api.errors.bounties.PendingPayout.is`
@@ -1230,9 +1238,17 @@ ___
 - **interface**: `api.errors.paras.CannotUpgradeCode.is`
 - **summary**:    Parachain cannot currently schedule a code upgrade. 
  
+### InvalidBlockNumber
+- **interface**: `api.errors.paras.InvalidBlockNumber.is`
+- **summary**:    Invalid block number. 
+ 
 ### InvalidCode
 - **interface**: `api.errors.paras.InvalidCode.is`
 - **summary**:    Invalid validation code size. 
+ 
+### NothingAuthorized
+- **interface**: `api.errors.paras.NothingAuthorized.is`
+- **summary**:    No upgrade authorized. 
  
 ### NotRegistered
 - **interface**: `api.errors.paras.NotRegistered.is`
@@ -1261,6 +1277,10 @@ ___
 ### PvfCheckValidatorIndexOutOfBounds
 - **interface**: `api.errors.paras.PvfCheckValidatorIndexOutOfBounds.is`
 - **summary**:    Claimed validator index is out of bounds. 
+ 
+### Unauthorized
+- **interface**: `api.errors.paras.Unauthorized.is`
+- **summary**:    The submitted code is not authorized. 
 
 ___
 
@@ -1405,6 +1425,87 @@ ___
 ### Unproxyable
 - **interface**: `api.errors.proxy.Unproxyable.is`
 - **summary**:    A call which is incompatible with the proxy type's filter was attempted. 
+
+___
+
+
+## rcMigrator
+ 
+### AccountReferenced
+- **interface**: `api.errors.rcMigrator.AccountReferenced.is`
+- **summary**:    The account is referenced by some other pallet. It might have freezes or holds. 
+ 
+### AhUmpQueuePriorityAlreadySet
+- **interface**: `api.errors.rcMigrator.AhUmpQueuePriorityAlreadySet.is`
+- **summary**:    The AH UMP queue priority configuration is already set. 
+ 
+### BadXcmVersion
+- **interface**: `api.errors.rcMigrator.BadXcmVersion.is`
+- **summary**:    The XCM version is invalid. 
+ 
+### BalanceOverflow
+- **interface**: `api.errors.rcMigrator.BalanceOverflow.is`
+- **summary**:    Balance accounting overflow. 
+ 
+### BalanceUnderflow
+- **interface**: `api.errors.rcMigrator.BalanceUnderflow.is`
+- **summary**:    Balance accounting underflow. 
+ 
+### EraEndsTooSoon
+- **interface**: `api.errors.rcMigrator.EraEndsTooSoon.is`
+- **summary**:    Indicates that there is not enough time for staking to lock. 
+
+   Schedule the migration at least two sessions before the current era ends. 
+ 
+### FailedToWithdrawAccount
+- **interface**: `api.errors.rcMigrator.FailedToWithdrawAccount.is`
+- **summary**:    Failed to withdraw account from RC for migration to AH. 
+ 
+### InvalidOrigin
+- **interface**: `api.errors.rcMigrator.InvalidOrigin.is`
+- **summary**:    The origin is invalid. 
+ 
+### InvalidParameter
+- **interface**: `api.errors.rcMigrator.InvalidParameter.is`
+- **summary**:    Invalid parameter. 
+ 
+### InvalidQueryResponse
+- **interface**: `api.errors.rcMigrator.InvalidQueryResponse.is`
+- **summary**:    The query response is invalid. 
+ 
+### InvalidStageTransition
+- **interface**: `api.errors.rcMigrator.InvalidStageTransition.is`
+- **summary**:    The stage transition is invalid. 
+ 
+### OutOfWeight
+- **interface**: `api.errors.rcMigrator.OutOfWeight.is`
+ 
+### PastBlockNumber
+- **interface**: `api.errors.rcMigrator.PastBlockNumber.is`
+- **summary**:    Indicates that the specified block number is in the past. 
+ 
+### QueryNotFound
+- **interface**: `api.errors.rcMigrator.QueryNotFound.is`
+- **summary**:    The xcm query was not found. 
+ 
+### Unreachable
+- **interface**: `api.errors.rcMigrator.Unreachable.is`
+ 
+### UnreachableStage
+- **interface**: `api.errors.rcMigrator.UnreachableStage.is`
+- **summary**:    The migration stage is not reachable from the current stage. 
+ 
+### UnsignedValidationFailed
+- **interface**: `api.errors.rcMigrator.UnsignedValidationFailed.is`
+- **summary**:    Unsigned validation failed. 
+ 
+### XcmError
+- **interface**: `api.errors.rcMigrator.XcmError.is`
+- **summary**:    Failed to send XCM message to AH. 
+ 
+### XcmSendError
+- **interface**: `api.errors.rcMigrator.XcmSendError.is`
+- **summary**:    Failed to send XCM message. 
 
 ___
 
@@ -1735,6 +1836,15 @@ ___
 ___
 
 
+## stakingAhClient
+ 
+### Blocked
+- **interface**: `api.errors.stakingAhClient.Blocked.is`
+- **summary**:    Could not process incoming message because incoming messages are blocked. 
+
+___
+
+
 ## stateTrieMigration
  
 ### BadChildRoot
@@ -1897,6 +2007,10 @@ ___
 ### List
 - **interface**: `api.errors.voterList.List.is`
 - **summary**:    A error in the list interface implementation. 
+ 
+### Locked
+- **interface**: `api.errors.voterList.Locked.is`
+- **summary**:    Could not update a node, because the pallet is locked. 
 
 ___
 
@@ -1995,6 +2109,10 @@ ___
 ### LocalExecutionIncomplete
 - **interface**: `api.errors.xcmPallet.LocalExecutionIncomplete.is`
 - **summary**:    Local XCM execution incomplete. 
+ 
+### LocalExecutionIncompleteWithError
+- **interface**: `api.errors.xcmPallet.LocalExecutionIncompleteWithError.is`
+- **summary**:    Local XCM execution incomplete with the actual XCM error and the index of the  instruction that caused the error. 
  
 ### LockNotFound
 - **interface**: `api.errors.xcmPallet.LockNotFound.is`

--- a/docs/polkadot/events.md
+++ b/docs/polkadot/events.md
@@ -32,6 +32,8 @@ Events are emitted for certain operations on the runtime. The following sections
 
 - **[grandpa](#grandpa)**
 
+- **[historical](#historical)**
+
 - **[hrmp](#hrmp)**
 
 - **[indices](#indices)**
@@ -56,6 +58,8 @@ Events are emitted for certain operations on the runtime. The following sections
 
 - **[proxy](#proxy)**
 
+- **[rcMigrator](#rcmigrator)**
+
 - **[referenda](#referenda)**
 
 - **[registrar](#registrar)**
@@ -67,6 +71,8 @@ Events are emitted for certain operations on the runtime. The following sections
 - **[slots](#slots)**
 
 - **[staking](#staking)**
+
+- **[stakingAhClient](#stakingahclient)**
 
 - **[stateTrieMigration](#statetriemigration)**
 
@@ -211,6 +217,10 @@ ___
 - **interface**: `api.events.balances.Transfer.is`
 - **summary**:    Transfer succeeded. 
  
+### Unexpected(`PalletBalancesUnexpectedKind`)
+- **interface**: `api.events.balances.Unexpected.is`
+- **summary**:    An unexpected/defensive event was triggered. 
+ 
 ### Unlocked(`AccountId32`, `u128`)
 - **interface**: `api.events.balances.Unlocked.is`
 - **summary**:    Some balance was unlocked. 
@@ -275,6 +285,10 @@ ___
 ### CuratorUnassigned(`u32`)
 - **interface**: `api.events.bounties.CuratorUnassigned.is`
 - **summary**:    A bounty curator is unassigned. 
+ 
+### DepositPoked(`u32`, `AccountId32`, `u128`, `u128`)
+- **interface**: `api.events.bounties.DepositPoked.is`
+- **summary**:    A bounty deposit has been poked. 
 
 ___
 
@@ -486,6 +500,19 @@ ___
 ### Resumed()
 - **interface**: `api.events.grandpa.Resumed.is`
 - **summary**:    Current authority set has been resumed. 
+
+___
+
+
+## historical
+ 
+### RootsPruned(`u32`)
+- **interface**: `api.events.historical.RootsPruned.is`
+- **summary**:    The merkle roots of up to this session index were pruned 
+ 
+### RootStored(`u32`)
+- **interface**: `api.events.historical.RootStored.is`
+- **summary**:    The merkle root of the validators of the said session were stored 
 
 ___
 
@@ -752,6 +779,10 @@ ___
 - **interface**: `api.events.paras.ActionQueued.is`
 - **summary**:    A para has been queued to execute pending actions. `para_id` 
  
+### CodeAuthorized(`u32`, `H256`, `u32`)
+- **interface**: `api.events.paras.CodeAuthorized.is`
+- **summary**:    A new code hash has been authorized for a Para. 
+ 
 ### CodeUpgradeScheduled(`u32`)
 - **interface**: `api.events.paras.CodeUpgradeScheduled.is`
 - **summary**:    A code upgrade has been scheduled for a Para. `para_id` 
@@ -779,6 +810,10 @@ ___
 ### PvfCheckStarted(`H256`, `u32`)
 - **interface**: `api.events.paras.PvfCheckStarted.is`
 - **summary**:    The given para either initiated or subscribed to a PVF check for the given validation  code. `code_hash` `para_id` 
+ 
+### UpgradeCooldownRemoved(`u32`)
+- **interface**: `api.events.paras.UpgradeCooldownRemoved.is`
+- **summary**:    The upgrade cooldown was removed. 
 
 ___
 
@@ -842,6 +877,103 @@ ___
 ### PureCreated(`AccountId32`, `AccountId32`, `PolkadotRuntimeConstantsProxyProxyType`, `u16`)
 - **interface**: `api.events.proxy.PureCreated.is`
 - **summary**:    A pure account has been created by new proxy with given  disambiguation index and proxy type. 
+ 
+### PureKilled(`AccountId32`, `AccountId32`, `PolkadotRuntimeConstantsProxyProxyType`, `u16`)
+- **interface**: `api.events.proxy.PureKilled.is`
+- **summary**:    A pure proxy was killed by its spawner. 
+
+___
+
+
+## rcMigrator
+ 
+### AccountsPreserved(`Vec<AccountId32>`)
+- **interface**: `api.events.rcMigrator.AccountsPreserved.is`
+- **summary**:    The accounts to be preserved on Relay Chain were set. 
+ 
+### AhUmpQueuePriorityConfigSet(`PalletRcMigratorQueuePriority`, `PalletRcMigratorQueuePriority`)
+- **interface**: `api.events.rcMigrator.AhUmpQueuePriorityConfigSet.is`
+- **summary**:    The AH UMP queue priority config was set. 
+ 
+### AhUmpQueuePrioritySet(`bool`, `u32`, `u32`)
+- **interface**: `api.events.rcMigrator.AhUmpQueuePrioritySet.is`
+- **summary**:    Whether the AH UMP queue was prioritized for the next block. 
+ 
+### AssetHubMigrationFinished()
+- **interface**: `api.events.rcMigrator.AssetHubMigrationFinished.is`
+- **summary**:    The Asset Hub Migration finished. 
+
+   This event is equivalent to `StageTransition { new: MigrationDone, .. }` but is easier  to understand. The finishing is immediate and affects all events happening  afterwards. 
+ 
+### AssetHubMigrationStarted()
+- **interface**: `api.events.rcMigrator.AssetHubMigrationStarted.is`
+- **summary**:    The Asset Hub Migration started and is active until `AssetHubMigrationFinished` is  emitted. 
+
+   This event is equivalent to `StageTransition { new: Initializing, .. }` but is easier  to understand. The activation is immediate and affects all events happening  afterwards. 
+ 
+### CancellerSet(`Option<AccountId32>`, `Option<AccountId32>`)
+- **interface**: `api.events.rcMigrator.CancellerSet.is`
+- **summary**:    The canceller account id was set. 
+ 
+### ManagerMultisigDispatched(`Result<Null, SpRuntimeDispatchError>`)
+- **interface**: `api.events.rcMigrator.ManagerMultisigDispatched.is`
+- **summary**:    The manager multisig dispatched something. 
+ 
+### ManagerMultisigVoted(`u32`)
+- **interface**: `api.events.rcMigrator.ManagerMultisigVoted.is`
+- **summary**:    The manager multisig received a vote. 
+ 
+### ManagerSet(`Option<AccountId32>`, `Option<AccountId32>`)
+- **interface**: `api.events.rcMigrator.ManagerSet.is`
+- **summary**:    The manager account id was set. 
+ 
+### MigratedBalanceConsumed(`u128`, `u128`)
+- **interface**: `api.events.rcMigrator.MigratedBalanceConsumed.is`
+- **summary**:    The RC kept balance was consumed. 
+ 
+### MigratedBalanceRecordSet(`u128`, `u128`)
+- **interface**: `api.events.rcMigrator.MigratedBalanceRecordSet.is`
+- **summary**:    The total issuance was recorded. 
+ 
+### MigrationCancelled()
+- **interface**: `api.events.rcMigrator.MigrationCancelled.is`
+- **summary**:    The migration was cancelled. 
+ 
+### MigrationPaused(`PalletRcMigratorMigrationStage`)
+- **interface**: `api.events.rcMigrator.MigrationPaused.is`
+- **summary**:    The migration was paused. 
+ 
+### MigrationSettingsSet(`Option<PalletRcMigratorMigrationSettings>`, `Option<PalletRcMigratorMigrationSettings>`)
+- **interface**: `api.events.rcMigrator.MigrationSettingsSet.is`
+- **summary**:    The migration settings were set. 
+ 
+### PureAccountsIndexed(`u32`)
+- **interface**: `api.events.rcMigrator.PureAccountsIndexed.is`
+- **summary**:    Some pure accounts were indexed for possibly receiving free `Any` proxies. 
+ 
+### QueryResponseReceived(`u64`, `XcmV3MaybeErrorCode`)
+- **interface**: `api.events.rcMigrator.QueryResponseReceived.is`
+- **summary**:    A query response has been received. 
+ 
+### StageTransition(`PalletRcMigratorMigrationStage`, `PalletRcMigratorMigrationStage`)
+- **interface**: `api.events.rcMigrator.StageTransition.is`
+- **summary**:    A stage transition has occurred. 
+ 
+### StakingElectionsPaused()
+- **interface**: `api.events.rcMigrator.StakingElectionsPaused.is`
+- **summary**:    The staking elections were paused. 
+ 
+### UnprocessedMsgBufferSet(`u32`, `u32`)
+- **interface**: `api.events.rcMigrator.UnprocessedMsgBufferSet.is`
+- **summary**:    The unprocessed message buffer size has been set. 
+ 
+### XcmResendAttempt(`u64`, `Option<XcmV3TraitsSendError>`)
+- **interface**: `api.events.rcMigrator.XcmResendAttempt.is`
+- **summary**:    A XCM message has been resent. 
+ 
+### XcmSent(`StagingXcmV5Location`, `StagingXcmV5Location`, `StagingXcmV5Xcm`, `[u8;32]`)
+- **interface**: `api.events.rcMigrator.XcmSent.is`
+- **summary**:    An XCM message was sent. 
 
 ___
 
@@ -977,6 +1109,10 @@ ___
 
 ## session
  
+### NewQueued()
+- **interface**: `api.events.session.NewQueued.is`
+- **summary**:    The `NewSession` event in the current block also implies a new validator set to be  queued. 
+ 
 ### NewSession(`u32`)
 - **interface**: `api.events.session.NewSession.is`
 - **summary**:    New session has happened. Note that the argument is the session index, not the  block number as the type might suggest. 
@@ -1084,6 +1220,29 @@ ___
 ### Withdrawn(`AccountId32`, `u128`)
 - **interface**: `api.events.staking.Withdrawn.is`
 - **summary**:    An account has called `withdraw_unbonded` and removed unbonding chunks worth `Balance`  from the unlocking queue. 
+
+___
+
+
+## stakingAhClient
+ 
+### CouldNotMergeAndDropped()
+- **interface**: `api.events.stakingAhClient.CouldNotMergeAndDropped.is`
+- **summary**:    We could not merge, and therefore dropped a buffered message. 
+
+   Note that this event is more resembling an error, but we use an event because in this  pallet we need to mutate storage upon some failures. 
+ 
+### SetTooSmallAndDropped()
+- **interface**: `api.events.stakingAhClient.SetTooSmallAndDropped.is`
+- **summary**:    The validator set received is way too small, as per  [`Config::MinimumValidatorSetSize`]. 
+ 
+### Unexpected(`PalletStakingAsyncAhClientUnexpectedKind`)
+- **interface**: `api.events.stakingAhClient.Unexpected.is`
+- **summary**:    Something occurred that should never happen under normal operation. Logged as an event  for fail-safe observability. 
+ 
+### ValidatorSetReceived(`u32`, `u32`, `Option<u32>`, `bool`)
+- **interface**: `api.events.stakingAhClient.ValidatorSetReceived.is`
+- **summary**:    A new validator set has been received. 
 
 ___
 
@@ -1250,6 +1409,10 @@ ___
 ### VestingCompleted(`AccountId32`)
 - **interface**: `api.events.vesting.VestingCompleted.is`
 - **summary**:    An \[account\] has become fully vested. 
+ 
+### VestingCreated(`AccountId32`, `u32`)
+- **interface**: `api.events.vesting.VestingCreated.is`
+- **summary**:    A vesting schedule has been created. 
  
 ### VestingUpdated(`AccountId32`, `u128`)
 - **interface**: `api.events.vesting.VestingUpdated.is`

--- a/docs/polkadot/extrinsics.md
+++ b/docs/polkadot/extrinsics.md
@@ -66,6 +66,8 @@ The following sections contain Extrinsics methods are part of the default Polkad
 
 - **[proxy](#proxy)**
 
+- **[rcMigrator](#rcmigrator)**
+
 - **[referenda](#referenda)**
 
 - **[registrar](#registrar)**
@@ -77,6 +79,8 @@ The following sections contain Extrinsics methods are part of the default Polkad
 - **[slots](#slots)**
 
 - **[staking](#staking)**
+
+- **[stakingAhClient](#stakingahclient)**
 
 - **[stateTrieMigration](#statetriemigration)**
 
@@ -384,6 +388,24 @@ ___
    #### Complexity 
 
   - O(1).
+ 
+### pokeDeposit(bounty_id: `Compact<u32>`)
+- **interface**: `api.tx.bounties.pokeDeposit`
+- **summary**:    Poke the deposit reserved for creating a bounty proposal. 
+
+   This can be used by accounts to update their reserved amount. 
+
+   The dispatch origin for this call must be _Signed_. 
+
+   Parameters: 
+
+  - `bounty_id`: The bounty id for which to adjust the deposit.
+
+   If the deposit is updated, the difference will be reserved/unreserved from the  proposer's account. 
+
+   The transaction is made free if the deposit is updated and paid otherwise. 
+
+   Emits `DepositPoked` if the deposit is updated. 
  
 ### proposeBounty(value: `Compact<u128>`, description: `Bytes`)
 - **interface**: `api.tx.bounties.proposeBounty`
@@ -1064,7 +1086,7 @@ ___
 
 ## electionProviderMultiPhase
  
-### governanceFallback(maybe_max_voters: `Option<u32>`, maybe_max_targets: `Option<u32>`)
+### governanceFallback()
 - **interface**: `api.tx.electionProviderMultiPhase.governanceFallback`
 - **summary**:    Trigger the governance fallback. 
 
@@ -1978,6 +2000,20 @@ ___
 
    This function is mainly meant to be used for upgrading parachains that do not follow  the go-ahead signal while the PVF pre-checking feature is enabled. 
  
+### applyAuthorizedForceSetCurrentCode(para: `u32`, new_code: `Bytes`)
+- **interface**: `api.tx.paras.applyAuthorizedForceSetCurrentCode`
+- **summary**:    Applies the already authorized current code for the parachain,  triggering the same functionality as `force_set_current_code`. 
+ 
+### authorizeForceSetCurrentCodeHash(para: `u32`, new_code_hash: `H256`, valid_period: `u32`)
+- **interface**: `api.tx.paras.authorizeForceSetCurrentCodeHash`
+- **summary**:    Sets the storage for the authorized current code hash of the parachain.  If not applied, it will be removed at the `System::block_number() + valid_period` block. 
+
+   This can be useful, when triggering `Paras::force_set_current_code(para, code)`  from a different chain than the one where the `Paras` pallet is deployed. 
+
+   The main purpose is to avoid transferring the entire `code` Wasm blob between chains.  Instead, we authorize `code_hash` with `root`, which can later be applied by  `Paras::apply_authorized_force_set_current_code(para, code)` by anyone. 
+
+   Authorizations are stored in an **overwriting manner**. 
+ 
 ### forceNoteNewHead(para: `u32`, new_head: `Bytes`)
 - **interface**: `api.tx.paras.forceNoteNewHead`
 - **summary**:    Note a new block head for para within the context of the current block. 
@@ -2011,6 +2047,12 @@ ___
 - **summary**:    Remove the validation code from the storage iff the reference count is 0. 
 
    This is better than removing the storage directly, because it will not remove the code  that was suddenly got used by some parachain while this dispatchable was pending  dispatching. 
+ 
+### removeUpgradeCooldown(para: `u32`)
+- **interface**: `api.tx.paras.removeUpgradeCooldown`
+- **summary**:    Remove an upgrade cooldown for a parachain. 
+
+   The cost for removing the cooldown earlier depends on the time left for the cooldown  multiplied by [`Config::CooldownRemovalMultiplier`]. The paid tokens are burned. 
 
 ___
 
@@ -2030,7 +2072,7 @@ ___
 
 ## parasSlashing
  
-### reportDisputeLostUnsigned(dispute_proof: `PolkadotPrimitivesV8SlashingDisputeProof`, key_owner_proof: `SpSessionMembershipProof`)
+### reportDisputeLostUnsigned(dispute_proof: `PolkadotPrimitivesVstagingDisputeProof`, key_owner_proof: `SpSessionMembershipProof`)
 - **interface**: `api.tx.parasSlashing.reportDisputeLostUnsigned`
 
 ___
@@ -2131,19 +2173,19 @@ ___
 
    WARNING: **All access to this account will be lost.** Any funds held in it will be  inaccessible. 
 
-   Requires a `Signed` origin, and the sender account must have been created by a call to  `pure` with corresponding parameters. 
+   Requires a `Signed` origin, and the sender account must have been created by a call to  `create_pure` with corresponding parameters. 
 
-   - `spawner`: The account that originally called `pure` to create this account. 
+   - `spawner`: The account that originally called `create_pure` to create this account. 
 
-  - `index`: The disambiguation index originally passed to `pure`. Probably `0`.
+  - `index`: The disambiguation index originally passed to `create_pure`. Probably `0`.
 
-  - `proxy_type`: The proxy type originally passed to `pure`.
+  - `proxy_type`: The proxy type originally passed to `create_pure`.
 
-  - `height`: The height of the chain when the call to `pure` was processed.
+  - `height`: The height of the chain when the call to `create_pure` was processed.
 
-  - `ext_index`: The extrinsic index in which the call to `pure` was processed.
+  - `ext_index`: The extrinsic index in which the call to `create_pure` was processed.
 
-   Fails with `NoPermission` in case the caller is not a previously created pure  account whose `pure` call has corresponding parameters. 
+   Fails with `NoPermission` in case the caller is not a previously created pure  account whose `create_pure` call has corresponding parameters. 
  
 ### pokeDeposit()
 - **interface**: `api.tx.proxy.pokeDeposit`
@@ -2219,7 +2261,7 @@ ___
 
    The dispatch origin for this call must be _Signed_. 
 
-   WARNING: This may be called on accounts created by `pure`, however if done, then  the unreserved fees will be inaccessible. **All access to this account will be lost.** 
+   WARNING: This may be called on accounts created by `create_pure`, however if done, then  the unreserved fees will be inaccessible. **All access to this account will be lost.** 
  
 ### removeProxy(delegate: `MultiAddress`, proxy_type: `PolkadotRuntimeConstantsProxyProxyType`, delay: `u32`)
 - **interface**: `api.tx.proxy.removeProxy`
@@ -2232,6 +2274,107 @@ ___
   - `proxy`: The account that the `caller` would like to remove as a proxy.
 
   - `proxy_type`: The permissions currently enabled for the removed proxy account.
+
+___
+
+
+## rcMigrator
+ 
+### cancelMigration()
+- **interface**: `api.tx.rcMigrator.cancelMigration`
+- **summary**:    Cancel the migration. 
+
+   Migration can only be cancelled if it is in the [`MigrationStage::Scheduled`] state. 
+ 
+### forceSetStage(stage: `PalletRcMigratorMigrationStage`)
+- **interface**: `api.tx.rcMigrator.forceSetStage`
+- **summary**:    Set the migration stage. 
+
+   This call is intended for emergency use only and is guarded by the  [`Config::AdminOrigin`]. 
+ 
+### pauseMigration()
+- **interface**: `api.tx.rcMigrator.pauseMigration`
+- **summary**:    Pause the migration. 
+ 
+### preserveAccounts(accounts: `Vec<AccountId32>`)
+- **interface**: `api.tx.rcMigrator.preserveAccounts`
+- **summary**:    Set the accounts to be preserved on Relay Chain during the migration. 
+
+   The accounts must have no consumers references. 
+ 
+### receiveQueryResponse(query_id: `u64`, response: `StagingXcmV5Response`)
+- **interface**: `api.tx.rcMigrator.receiveQueryResponse`
+- **summary**:    Receive a query response from the Asset Hub for a previously sent xcm message. 
+ 
+### resendXcm(query_id: `u64`)
+- **interface**: `api.tx.rcMigrator.resendXcm`
+- **summary**:    Resend a previously sent and unconfirmed XCM message. 
+ 
+### scheduleMigration(start: `FrameSupportScheduleDispatchTime`, warm_up: `FrameSupportScheduleDispatchTime`, cool_off: `FrameSupportScheduleDispatchTime`, unsafe_ignore_staking_lock_check: `bool`)
+- **interface**: `api.tx.rcMigrator.scheduleMigration`
+- **summary**:    Schedule the migration to start at a given moment. 
+
+   #### Parameters: 
+
+  - `start`: The block number at which the migration will start. `DispatchTime` calculated at the moment of the extrinsic execution. 
+
+  - `warm_up`: Duration or timepoint that will be used to prepare for the migration. Calls are filtered during this period. It is intended to give enough time for UMP and DMP  queues to empty. `DispatchTime` calculated at the moment of the transition to the  warm-up stage. 
+
+  - `cool_off`: The block number at which the post migration cool-off period will end. The `DispatchTime` calculated at the moment of the transition to the cool-off stage. 
+
+  - `unsafe_ignore_staking_lock_check`: ONLY FOR TESTING. Ignore the check whether the scheduled time point is far enough in the future. 
+
+   Note: If the staking election for next era is already complete, and the next  validator set is queued in `pallet-session`, we want to avoid starting the data  migration at this point as it can lead to some missed validator rewards. To address  this, we stop staking election at the start of migration and must wait atleast 1  session (set via warm_up) before starting the data migration. 
+
+   Read [`MigrationStage::Scheduled`] documentation for more details. 
+ 
+### sendXcmMessage(dest: `XcmVersionedLocation`, message: `XcmVersionedXcm`)
+- **interface**: `api.tx.rcMigrator.sendXcmMessage`
+- **summary**:    XCM send call identical to the [`pallet_xcm::Pallet::send`] call but with the  [Config::SendXcm] router which will be able to send messages to the Asset Hub during  the migration. 
+ 
+### setAhUmpQueuePriority(new: `PalletRcMigratorQueuePriority`)
+- **interface**: `api.tx.rcMigrator.setAhUmpQueuePriority`
+- **summary**:    Set the AH UMP queue priority configuration. 
+
+   Can only be called by the `AdminOrigin`. 
+ 
+### setCanceller(new: `Option<AccountId32>`)
+- **interface**: `api.tx.rcMigrator.setCanceller`
+- **summary**:    Set the canceller account id. 
+
+   The canceller can only stop scheduled migration. 
+ 
+### setManager(new: `Option<AccountId32>`)
+- **interface**: `api.tx.rcMigrator.setManager`
+- **summary**:    Set the manager account id. 
+
+   The manager has the similar to [`Config::AdminOrigin`] privileges except that it  can not set the manager account id via `set_manager` call. 
+ 
+### setSettings(settings: `Option<PalletRcMigratorMigrationSettings>`)
+- **interface**: `api.tx.rcMigrator.setSettings`
+- **summary**:    Set the migration settings. Can only be done by admin or manager. 
+ 
+### setUnprocessedMsgBuffer(new: `Option<u32>`)
+- **interface**: `api.tx.rcMigrator.setUnprocessedMsgBuffer`
+- **summary**:    Set the unprocessed message buffer size. 
+
+   `None` means to use the configuration value. 
+ 
+### startDataMigration()
+- **interface**: `api.tx.rcMigrator.startDataMigration`
+- **summary**:    Start the data migration. 
+
+   This is typically called by the Asset Hub to indicate it's readiness to receive the  migration data. 
+ 
+### voteManagerMultisig(payload: `PalletRcMigratorManagerMultisigVote`, sig: `SpRuntimeMultiSignature`)
+- **interface**: `api.tx.rcMigrator.voteManagerMultisig`
+- **summary**:    Vote on behalf of any of the members in `MultisigMembers`. 
+
+   Unsigned extrinsic, requiring the `payload` to be signed. 
+
+   Upon each call, a new entry is created in `ManagerMultisigs` map the `payload.call` to  be dispatched. Once `MultisigThreshold` is reached, the entire map is deleted, and we  move on to the next round. 
+
+   The round system ensures that signatures from older round cannot be reused. 
 
 ___
 
@@ -2577,7 +2720,7 @@ ___
 
    Can be called by the `T::AdminOrigin`. 
 
-   Parameters: era and indices of the slashes for that era to kill. 
+   Parameters: era and indices of the slashes for that era to kill.  They **must** be sorted in ascending order, *and* unique. 
  
 ### chill()
 - **interface**: `api.tx.staking.chill`
@@ -2913,6 +3056,8 @@ ___
 - **interface**: `api.tx.staking.unbond`
 - **summary**:    Schedule a portion of the stash to be unlocked ready for transfer out after the bond  period ends. If this leaves an amount actively bonded less than  [`asset::existential_deposit`], then it is increased to the full amount. 
 
+   The stash may be chilled if the ledger total amount falls to 0 after unbonding. 
+
    The dispatch origin for this call must be _Signed_ by the controller, not the stash. 
 
    Once the unlock period is done, you can call `withdraw_unbonded` to actually move  the funds out of management ready for transfer. 
@@ -2958,6 +3103,22 @@ ___
    - `num_slashing_spans` indicates the number of metadata slashing spans to clear when  this call results in a complete removal of all the data related to the stash account.  In this case, the `num_slashing_spans` must be larger or equal to the number of  slashing spans associated with the stash account in the [`SlashingSpans`] storage type,  otherwise the call will fail. The call weight is directly proportional to  `num_slashing_spans`. 
 
    #### Complexity  O(S) where S is the number of slashing spans to remove  NOTE: Weight annotation is the kill scenario, we refund otherwise. 
+
+___
+
+
+## stakingAhClient
+ 
+### forceOnMigrationEnd()
+- **interface**: `api.tx.stakingAhClient.forceOnMigrationEnd`
+- **summary**:    manually do what this pallet was meant to do at the end of the migration. 
+ 
+### setMode(mode: `PalletStakingAsyncAhClientOperatingMode`)
+- **interface**: `api.tx.stakingAhClient.setMode`
+- **summary**:    Allows governance to force set the operating mode of the pallet. 
+ 
+### validatorSet(report: `PalletStakingAsyncRcClientValidatorSetReport`)
+- **interface**: `api.tx.stakingAhClient.validatorSet`
 
 ___
 

--- a/docs/polkadot/runtime.md
+++ b/docs/polkadot/runtime.md
@@ -38,6 +38,8 @@ The following section contains known runtime calls that may be available on spec
 
 - **[parachainHost](#parachainhost)**
 
+- **[runtimeViewFunction](#runtimeviewfunction)**
+
 - **[sessionKeys](#sessionkeys)**
 
 - **[stakingApi](#stakingapi)**
@@ -575,6 +577,16 @@ ___
 - **interface**: `api.call.parachainHost.validators`
 - **runtime**: `parachainHost_validators`
 - **summary**:  Get the current validators.
+
+___
+
+
+## runtimeViewFunction
+ 
+### executeViewFunction(query_id: `FrameSupportViewFunctionsViewFunctionId`, input: `Bytes`): `Result<Bytes, FrameSupportViewFunctionsViewFunctionDispatchError>`
+- **interface**: `api.call.runtimeViewFunction.executeViewFunction`
+- **runtime**: `runtimeViewFunction_execute_view_function`
+- **summary**:  Execute a view function query.
 
 ___
 

--- a/docs/polkadot/storage.md
+++ b/docs/polkadot/storage.md
@@ -86,6 +86,8 @@ The following sections contain Storage methods are part of the default Polkadot 
 
 - **[proxy](#proxy)**
 
+- **[rcMigrator](#rcmigrator)**
+
 - **[referenda](#referenda)**
 
 - **[registrar](#registrar)**
@@ -97,6 +99,8 @@ The following sections contain Storage methods are part of the default Polkadot 
 - **[slots](#slots)**
 
 - **[staking](#staking)**
+
+- **[stakingAhClient](#stakingahclient)**
 
 - **[stateTrieMigration](#statetriemigration)**
 
@@ -1039,6 +1043,10 @@ ___
 - **interface**: `api.query.paras.actionsQueue`
 - **summary**:    The actions to perform during the start of a specific session index. 
  
+### authorizedCodeHash(`u32`): `Option<PolkadotRuntimeParachainsParasAuthorizedCodeHashAndExpiry>`
+- **interface**: `api.query.paras.authorizedCodeHash`
+- **summary**:    The code hash authorizations for a para which will expire `expire_at` `BlockNumberFor<T>`. 
+ 
 ### codeByHash(`H256`): `Option<Bytes>`
 - **interface**: `api.query.paras.codeByHash`
 - **summary**:    Validation code stored by its hash. 
@@ -1252,7 +1260,7 @@ ___
 
 ## parasSlashing
  
-### unappliedSlashes(`u32, H256`): `Option<PolkadotPrimitivesV8SlashingPendingSlashes>`
+### unappliedSlashes(`u32, H256`): `Option<PolkadotPrimitivesVstagingPendingSlashes>`
 - **interface**: `api.query.parasSlashing.unappliedSlashes`
 - **summary**:    Validators pending dispute slashes. 
  
@@ -1288,6 +1296,123 @@ ___
 ### proxies(`AccountId32`): `(Vec<PalletProxyProxyDefinition>,u128)`
 - **interface**: `api.query.proxy.proxies`
 - **summary**:    The set of account proxies. Maps the account which has delegated to the accounts  which are being delegated to, together with the amount held on deposit. 
+
+___
+
+
+## rcMigrator
+ 
+### ahUmpQueuePriorityConfig(): `PalletRcMigratorQueuePriority`
+- **interface**: `api.query.rcMigrator.ahUmpQueuePriorityConfig`
+- **summary**:    The priority of the Asset Hub UMP queue during migration. 
+
+   Controls how the Asset Hub UMP (Upward Message Passing) queue is processed relative to other  queues during the migration process. This helps ensure timely processing of migration  messages. The default priority pattern is defined in the pallet configuration, but can be  overridden by a storage value of this type. 
+ 
+### canceller(): `Option<AccountId32>`
+- **interface**: `api.query.rcMigrator.canceller`
+- **summary**:    An optional account id of a canceller. 
+
+   This account id can only stop scheduled migration. 
+ 
+### coolOffPeriod(): `Option<FrameSupportScheduleDispatchTime>`
+- **interface**: `api.query.rcMigrator.coolOffPeriod`
+- **summary**:    The duration of the post migration cool-off period. 
+
+   This is the duration of the cool-off period after the data migration is finished. During  this period, the migration will be still in ongoing state and the concerned extrinsics will  be locked. 
+ 
+### counterForPendingXcmMessages(): `u32`
+- **interface**: `api.query.rcMigrator.counterForPendingXcmMessages`
+- **summary**:    Counter for the related counted storage map 
+ 
+### counterForRcAccounts(): `u32`
+- **interface**: `api.query.rcMigrator.counterForRcAccounts`
+- **summary**:    Counter for the related counted storage map 
+ 
+### manager(): `Option<AccountId32>`
+- **interface**: `api.query.rcMigrator.manager`
+- **summary**:    An optional account id of a manager. 
+
+   This account id has similar privileges to [`Config::AdminOrigin`] except that it  can not set the manager account id via `set_manager` call. 
+ 
+### managerMultisigRound(): `u32`
+- **interface**: `api.query.rcMigrator.managerMultisigRound`
+- **summary**:    The current round of the multisig voting. 
+
+   Votes are only valid for the current round. 
+ 
+### managerMultisigs(`Call`): `Vec<AccountId32>`
+- **interface**: `api.query.rcMigrator.managerMultisigs`
+- **summary**:    The multisig AccountIDs that votes to execute a specific call. 
+ 
+### managerVotesInCurrentRound(`AccountId32`): `u32`
+- **interface**: `api.query.rcMigrator.managerVotesInCurrentRound`
+- **summary**:    How often each participant voted in the current round. 
+
+   Will be cleared at the end of each round. 
+ 
+### migrationEndBlock(): `Option<u32>`
+- **interface**: `api.query.rcMigrator.migrationEndBlock`
+- **summary**:    Block number when migration finished and extrinsics were unlocked. 
+
+   This is set when entering the `MigrationDone` stage hence when  `RcMigrationStage::is_finished()` becomes `true`. 
+ 
+### migrationStartBlock(): `Option<u32>`
+- **interface**: `api.query.rcMigrator.migrationStartBlock`
+- **summary**:    The block number at which the migration began and the pallet's extrinsics were locked. 
+
+   This value is set when entering the `WaitingForAh` stage, i.e., when  `RcMigrationStage::is_ongoing()` becomes `true`. 
+ 
+### pendingXcmMessages(`(u64,H256)`): `Option<StagingXcmV5Xcm>`
+- **interface**: `api.query.rcMigrator.pendingXcmMessages`
+- **summary**:    The pending XCM messages. 
+
+   Contains data messages that have been sent to the Asset Hub but not yet confirmed. 
+
+   Unconfirmed messages can be resent by calling the [`Pallet::resend_xcm`] function. 
+ 
+### pendingXcmQueries(`u64`): `Option<H256>`
+- **interface**: `api.query.rcMigrator.pendingXcmQueries`
+- **summary**:    The pending XCM response queries and their XCM hash referencing the message in the  [`PendingXcmMessages`] storage. 
+
+   The `QueryId` is the identifier from the [`pallet_xcm`] query handler registry. The XCM  pallet will notify about the status of the message by calling the  [`Pallet::receive_query_response`] function with the `QueryId` and the  response. 
+ 
+### pureProxyCandidatesMigrated(`AccountId32`): `Option<bool>`
+- **interface**: `api.query.rcMigrator.pureProxyCandidatesMigrated`
+- **summary**:    Accounts that use the proxy pallet to delegate permissions and have no nonce. 
+
+   Boolean value is whether they have been migrated to the Asset Hub. Needed for idempotency. 
+ 
+### rcAccounts(`AccountId32`): `Option<PalletRcMigratorAccountsAccountState>`
+- **interface**: `api.query.rcMigrator.rcAccounts`
+- **summary**:    Helper storage item to obtain and store the known accounts that should be kept partially or  fully on Relay Chain. 
+ 
+### rcMigratedBalance(): `PalletRcMigratorAccountsMigratedBalances`
+- **interface**: `api.query.rcMigrator.rcMigratedBalance`
+- **summary**:    Helper storage item to store the total balance that should be kept on Relay Chain. 
+ 
+### rcMigratedBalanceArchive(): `PalletRcMigratorAccountsMigratedBalances`
+- **interface**: `api.query.rcMigrator.rcMigratedBalanceArchive`
+- **summary**:    Helper storage item to store the total balance that should be kept on Relay Chain after  it is consumed from the `RcMigratedBalance` storage item and sent to the Asset Hub. 
+
+   This let us to take the value from the `RcMigratedBalance` storage item and keep the  `SignalMigrationFinish` stage to be idempotent while preserving these values for tests and  later discoveries. 
+ 
+### rcMigrationStage(): `PalletRcMigratorMigrationStage`
+- **interface**: `api.query.rcMigrator.rcMigrationStage`
+- **summary**:    The Relay Chain migration state. 
+ 
+### settings(): `Option<PalletRcMigratorMigrationSettings>`
+- **interface**: `api.query.rcMigrator.settings`
+- **summary**:    The migration settings. 
+ 
+### unprocessedMsgBuffer(): `Option<u32>`
+- **interface**: `api.query.rcMigrator.unprocessedMsgBuffer`
+- **summary**:    Manual override for `type UnprocessedMsgBuffer: Get<u32>`. Look there for docs. 
+ 
+### warmUpPeriod(): `Option<FrameSupportScheduleDispatchTime>`
+- **interface**: `api.query.rcMigrator.warmUpPeriod`
+- **summary**:    The duration of the pre migration warm-up period. 
+
+   This is the duration of the warm-up period before the data migration starts. During this  period, the migration will be in ongoing state and the concerned extrinsics will be locked. 
 
 ___
 
@@ -1662,6 +1787,61 @@ ___
 ___
 
 
+## stakingAhClient
+ 
+### incompleteValidatorSetReport(): `Option<PalletStakingAsyncRcClientValidatorSetReport>`
+- **interface**: `api.query.stakingAhClient.incompleteValidatorSetReport`
+- **summary**:    An incomplete validator set report. 
+ 
+### mode(): `PalletStakingAsyncAhClientOperatingMode`
+- **interface**: `api.query.stakingAhClient.mode`
+- **summary**:    Indicates the current operating mode of the pallet. 
+
+   This value determines how the pallet behaves in response to incoming and outgoing messages,  particularly whether it should execute logic directly, defer it, or delegate it entirely. 
+ 
+### nextSessionChangesValidators(): `Option<u32>`
+- **interface**: `api.query.stakingAhClient.nextSessionChangesValidators`
+- **summary**:    A storage value that is set when a `new_session` gives a new validator set to the session  pallet, and is cleared on the next call. 
+
+   The inner u32 is the id of the said activated validator set. While not relevant here, good  to know this is the planning era index of staking-async on AH. 
+
+   Once cleared, we know a validator set has been activated, and therefore we can send a  timestamp to AH. 
+ 
+### offenceSendQueueCursor(): `u32`
+- **interface**: `api.query.stakingAhClient.offenceSendQueueCursor`
+- **summary**:    Internal storage item of [`OffenceSendQueue`]. Should not be used manually. 
+ 
+### offenceSendQueueOffences(`u32`): `Vec<(u32,PalletStakingAsyncRcClientOffence)>`
+- **interface**: `api.query.stakingAhClient.offenceSendQueueOffences`
+- **summary**:    Internal storage item of [`OffenceSendQueue`]. Should not be used manually. 
+ 
+### outgoingSessionReport(): `Option<(PalletStakingAsyncRcClientSessionReport,u32)>`
+- **interface**: `api.query.stakingAhClient.outgoingSessionReport`
+- **summary**:    A session report that is outgoing, and should be sent. 
+
+   This will be attempted to be sent, possibly on every `on_initialize` call, until it is sent,  or the second value reaches zero, at which point we drop it. 
+ 
+### validatorPoints(`AccountId32`): `u32`
+- **interface**: `api.query.stakingAhClient.validatorPoints`
+- **summary**:    All of the points of the validators. 
+
+   This is populated during a session, and is flushed and sent over via [`SendToAssetHub`]  at each session end. 
+ 
+### validatorSet(): `Option<(u32,Vec<AccountId32>)>`
+- **interface**: `api.query.stakingAhClient.validatorSet`
+- **summary**:    The queued validator sets for a given planning session index. 
+
+   This is received via a call from AssetHub. 
+ 
+### validatorSetAppliedAt(): `Option<u32>`
+- **interface**: `api.query.stakingAhClient.validatorSetAppliedAt`
+- **summary**:    The session index at which the latest elected validator set was applied. 
+
+   This is used to determine if an offence, given a session index, is in the current active era  or not. 
+
+___
+
+
 ## stateTrieMigration
  
 ### autoLimits(): `Option<PalletStateTrieMigrationMigrationLimits>`
@@ -1918,6 +2098,16 @@ ___
 - **summary**:    A single node, within some bag. 
 
    Nodes store links forward and back within their respective bags. 
+ 
+### lock(): `Option<Null>`
+- **interface**: `api.query.voterList.lock`
+- **summary**:    Lock all updates to this pallet. 
+
+   If any nodes needs updating, removal or addition due to a temporary lock, the  [`Call::rebag`] can be used. 
+ 
+### nextNodeAutoRebagged(): `Option<AccountId32>`
+- **interface**: `api.query.voterList.nextNodeAutoRebagged`
+- **summary**:    Pointer that remembers the next node that will be auto-rebagged.  When `None`, the next scan will start from the list head again. 
 
 ___
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@docusaurus/preset-classic": "2.4.3",
     "@mdx-js/react": "^1.6.22",
     "@polkadot/dev": "^0.83.3",
-    "@polkadot/typegen": "^16.4.6",
+    "@polkadot/typegen": "^16.5.1",
     "clsx": "^2.1.1",
     "comment-parser": "^1.4.1",
     "react": "^18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2806,74 +2806,74 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/api-augment@npm:16.4.6":
-  version: 16.4.6
-  resolution: "@polkadot/api-augment@npm:16.4.6"
+"@polkadot/api-augment@npm:16.5.1":
+  version: 16.5.1
+  resolution: "@polkadot/api-augment@npm:16.5.1"
   dependencies:
-    "@polkadot/api-base": "npm:16.4.6"
-    "@polkadot/rpc-augment": "npm:16.4.6"
-    "@polkadot/types": "npm:16.4.6"
-    "@polkadot/types-augment": "npm:16.4.6"
-    "@polkadot/types-codec": "npm:16.4.6"
-    "@polkadot/util": "npm:^13.5.6"
+    "@polkadot/api-base": "npm:16.5.1"
+    "@polkadot/rpc-augment": "npm:16.5.1"
+    "@polkadot/types": "npm:16.5.1"
+    "@polkadot/types-augment": "npm:16.5.1"
+    "@polkadot/types-codec": "npm:16.5.1"
+    "@polkadot/util": "npm:^13.5.7"
     tslib: "npm:^2.8.1"
-  checksum: 10/eeac05b87873e2abb86aead4c9003ce56cdf3ba33e496b569d71bc6cc62112100a080639f4da4adfd077fd2c3d5e098c0e538b69471a0a877a83c4440d72a922
+  checksum: 10/b019ba18f91455d883a6ffab54dba3b37673245b91726c45f4c3dac57b12c1ee8e8e6b8df898818beebc50349668c8bbfdd0b502769471c1aa11d2c27d4eccda
   languageName: node
   linkType: hard
 
-"@polkadot/api-base@npm:16.4.6":
-  version: 16.4.6
-  resolution: "@polkadot/api-base@npm:16.4.6"
+"@polkadot/api-base@npm:16.5.1":
+  version: 16.5.1
+  resolution: "@polkadot/api-base@npm:16.5.1"
   dependencies:
-    "@polkadot/rpc-core": "npm:16.4.6"
-    "@polkadot/types": "npm:16.4.6"
-    "@polkadot/util": "npm:^13.5.6"
+    "@polkadot/rpc-core": "npm:16.5.1"
+    "@polkadot/types": "npm:16.5.1"
+    "@polkadot/util": "npm:^13.5.7"
     rxjs: "npm:^7.8.1"
     tslib: "npm:^2.8.1"
-  checksum: 10/29f190545e73b8def9185a37486c97b4146e5a44ee7826f7f6bc658023ca336563b08703da5863bf2a06291c302f5ee9f640f09faed0fade995b48ca5787d738
+  checksum: 10/a1ece4d198437cde0c7fc50e92b4cd07c5711a5a755f5df39111b9d86f31019a31f43d3772a58e3fe3cf768a99133b17a940c580800bd29d9da751642676115c
   languageName: node
   linkType: hard
 
-"@polkadot/api-derive@npm:16.4.6":
-  version: 16.4.6
-  resolution: "@polkadot/api-derive@npm:16.4.6"
+"@polkadot/api-derive@npm:16.5.1":
+  version: 16.5.1
+  resolution: "@polkadot/api-derive@npm:16.5.1"
   dependencies:
-    "@polkadot/api": "npm:16.4.6"
-    "@polkadot/api-augment": "npm:16.4.6"
-    "@polkadot/api-base": "npm:16.4.6"
-    "@polkadot/rpc-core": "npm:16.4.6"
-    "@polkadot/types": "npm:16.4.6"
-    "@polkadot/types-codec": "npm:16.4.6"
-    "@polkadot/util": "npm:^13.5.6"
-    "@polkadot/util-crypto": "npm:^13.5.6"
+    "@polkadot/api": "npm:16.5.1"
+    "@polkadot/api-augment": "npm:16.5.1"
+    "@polkadot/api-base": "npm:16.5.1"
+    "@polkadot/rpc-core": "npm:16.5.1"
+    "@polkadot/types": "npm:16.5.1"
+    "@polkadot/types-codec": "npm:16.5.1"
+    "@polkadot/util": "npm:^13.5.7"
+    "@polkadot/util-crypto": "npm:^13.5.7"
     rxjs: "npm:^7.8.1"
     tslib: "npm:^2.8.1"
-  checksum: 10/677475de15d1a38af57fea144f1cabcde522bc3d3abe6652ba9fd6e7c788197b08fd8774fda1991d6ff51ffa88398f6acb0974bd0eaf1b57293609357383309f
+  checksum: 10/befa244073a684052f5c4316a43e38a4c28e7071c4c232a911bb1df5524d70c7259d9a67c1dc755611803066bfc60be8e13f849015a158b5d877e42de461e2ff
   languageName: node
   linkType: hard
 
-"@polkadot/api@npm:16.4.6":
-  version: 16.4.6
-  resolution: "@polkadot/api@npm:16.4.6"
+"@polkadot/api@npm:16.5.1":
+  version: 16.5.1
+  resolution: "@polkadot/api@npm:16.5.1"
   dependencies:
-    "@polkadot/api-augment": "npm:16.4.6"
-    "@polkadot/api-base": "npm:16.4.6"
-    "@polkadot/api-derive": "npm:16.4.6"
-    "@polkadot/keyring": "npm:^13.5.6"
-    "@polkadot/rpc-augment": "npm:16.4.6"
-    "@polkadot/rpc-core": "npm:16.4.6"
-    "@polkadot/rpc-provider": "npm:16.4.6"
-    "@polkadot/types": "npm:16.4.6"
-    "@polkadot/types-augment": "npm:16.4.6"
-    "@polkadot/types-codec": "npm:16.4.6"
-    "@polkadot/types-create": "npm:16.4.6"
-    "@polkadot/types-known": "npm:16.4.6"
-    "@polkadot/util": "npm:^13.5.6"
-    "@polkadot/util-crypto": "npm:^13.5.6"
+    "@polkadot/api-augment": "npm:16.5.1"
+    "@polkadot/api-base": "npm:16.5.1"
+    "@polkadot/api-derive": "npm:16.5.1"
+    "@polkadot/keyring": "npm:^13.5.7"
+    "@polkadot/rpc-augment": "npm:16.5.1"
+    "@polkadot/rpc-core": "npm:16.5.1"
+    "@polkadot/rpc-provider": "npm:16.5.1"
+    "@polkadot/types": "npm:16.5.1"
+    "@polkadot/types-augment": "npm:16.5.1"
+    "@polkadot/types-codec": "npm:16.5.1"
+    "@polkadot/types-create": "npm:16.5.1"
+    "@polkadot/types-known": "npm:16.5.1"
+    "@polkadot/util": "npm:^13.5.7"
+    "@polkadot/util-crypto": "npm:^13.5.7"
     eventemitter3: "npm:^5.0.1"
     rxjs: "npm:^7.8.1"
     tslib: "npm:^2.8.1"
-  checksum: 10/d5391f9bf21c3d6e27e640a03e1ab44c26e6ce9362abc6e2921533604374ba871b4c6891ea2c148e62a9753eed9700dc73de2ed72d31d1735c6ae67efe8f5aef
+  checksum: 10/63b11b5d41bab33a910e8ffc956dcbd8a86bf37aebd544e5dde652e435e3c73f16d498a70a8c445fd204c6fdf42c1ac9db0db7af1c506c1ff2120f0c50059983
   languageName: node
   linkType: hard
 
@@ -2973,70 +2973,70 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/keyring@npm:^13.5.6":
-  version: 13.5.6
-  resolution: "@polkadot/keyring@npm:13.5.6"
+"@polkadot/keyring@npm:^13.5.7":
+  version: 13.5.7
+  resolution: "@polkadot/keyring@npm:13.5.7"
   dependencies:
-    "@polkadot/util": "npm:13.5.6"
-    "@polkadot/util-crypto": "npm:13.5.6"
+    "@polkadot/util": "npm:13.5.7"
+    "@polkadot/util-crypto": "npm:13.5.7"
     tslib: "npm:^2.8.0"
   peerDependencies:
-    "@polkadot/util": 13.5.6
-    "@polkadot/util-crypto": 13.5.6
-  checksum: 10/c6b6ed89694eaf3ba082435d966a204d5fcc0de3cfcb57b1069aef8dd245e01fc5bf9372c256464e0b11eaf002fa40f5046a260f02eca8dff98d31da0739e3f3
+    "@polkadot/util": 13.5.7
+    "@polkadot/util-crypto": 13.5.7
+  checksum: 10/c19aaef9facb2e7af8b1e677767bab22c98cffaab07869f76563dedc658f0c5315c0f8d7cc063179611cfed33181639b4728f76b71092d9d170a860677c673af
   languageName: node
   linkType: hard
 
-"@polkadot/networks@npm:13.5.6, @polkadot/networks@npm:^13.5.6":
-  version: 13.5.6
-  resolution: "@polkadot/networks@npm:13.5.6"
+"@polkadot/networks@npm:13.5.7, @polkadot/networks@npm:^13.5.7":
+  version: 13.5.7
+  resolution: "@polkadot/networks@npm:13.5.7"
   dependencies:
-    "@polkadot/util": "npm:13.5.6"
+    "@polkadot/util": "npm:13.5.7"
     "@substrate/ss58-registry": "npm:^1.51.0"
     tslib: "npm:^2.8.0"
-  checksum: 10/3f1063588db7872477ee4949f2841a8f98e46a759482d3476887f0e96ec0aa5aff2e9cc954093b0b3b9ee162568c1aaedce2fdbce6dabcc002c60b55926889e5
+  checksum: 10/3a9cf6ae053b81ede50d2a1c6bf6d65bd6de712316784a1b7a2f51cc4afc26b14e1b9d1c4a6904425655edf7f6de0e7e6b6936e42ec7fc19d983cefc44b05291
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-augment@npm:16.4.6":
-  version: 16.4.6
-  resolution: "@polkadot/rpc-augment@npm:16.4.6"
+"@polkadot/rpc-augment@npm:16.5.1":
+  version: 16.5.1
+  resolution: "@polkadot/rpc-augment@npm:16.5.1"
   dependencies:
-    "@polkadot/rpc-core": "npm:16.4.6"
-    "@polkadot/types": "npm:16.4.6"
-    "@polkadot/types-codec": "npm:16.4.6"
-    "@polkadot/util": "npm:^13.5.6"
+    "@polkadot/rpc-core": "npm:16.5.1"
+    "@polkadot/types": "npm:16.5.1"
+    "@polkadot/types-codec": "npm:16.5.1"
+    "@polkadot/util": "npm:^13.5.7"
     tslib: "npm:^2.8.1"
-  checksum: 10/ef2559b4807bc8340f5ec14725924fe5a4946c387b05c73f3c7353297a5487e55f1027d659bea4b3dacb3b8d3c5f578a06d541722fba3a712caac08a7a3d61f4
+  checksum: 10/55213239976740df317b3007d37a4c60ff52d027ed2e169062889c208964aa8cb0d14629d11b95be43a7d8eebb11e1a94aee51e5100bf4e46fe608a892007618
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-core@npm:16.4.6":
-  version: 16.4.6
-  resolution: "@polkadot/rpc-core@npm:16.4.6"
+"@polkadot/rpc-core@npm:16.5.1":
+  version: 16.5.1
+  resolution: "@polkadot/rpc-core@npm:16.5.1"
   dependencies:
-    "@polkadot/rpc-augment": "npm:16.4.6"
-    "@polkadot/rpc-provider": "npm:16.4.6"
-    "@polkadot/types": "npm:16.4.6"
-    "@polkadot/util": "npm:^13.5.6"
+    "@polkadot/rpc-augment": "npm:16.5.1"
+    "@polkadot/rpc-provider": "npm:16.5.1"
+    "@polkadot/types": "npm:16.5.1"
+    "@polkadot/util": "npm:^13.5.7"
     rxjs: "npm:^7.8.1"
     tslib: "npm:^2.8.1"
-  checksum: 10/b0d6afcb389b335ada3d5306463dad6fb79985bccd2bca541de422ceb537ed576ea876529560f06693be095e4fd5db3fda07723da0e6105d40b0427540e4b8e4
+  checksum: 10/22d0066676c4222c3e6f27e6ab9d00f5b8193bd73bba1cbd4cad116d7abb3a13c4f811e18573aa3f3ff9b4858b13faf18777a5292df1098dea962ba0209048b0
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-provider@npm:16.4.6":
-  version: 16.4.6
-  resolution: "@polkadot/rpc-provider@npm:16.4.6"
+"@polkadot/rpc-provider@npm:16.5.1":
+  version: 16.5.1
+  resolution: "@polkadot/rpc-provider@npm:16.5.1"
   dependencies:
-    "@polkadot/keyring": "npm:^13.5.6"
-    "@polkadot/types": "npm:16.4.6"
-    "@polkadot/types-support": "npm:16.4.6"
-    "@polkadot/util": "npm:^13.5.6"
-    "@polkadot/util-crypto": "npm:^13.5.6"
-    "@polkadot/x-fetch": "npm:^13.5.6"
-    "@polkadot/x-global": "npm:^13.5.6"
-    "@polkadot/x-ws": "npm:^13.5.6"
+    "@polkadot/keyring": "npm:^13.5.7"
+    "@polkadot/types": "npm:16.5.1"
+    "@polkadot/types-support": "npm:16.5.1"
+    "@polkadot/util": "npm:^13.5.7"
+    "@polkadot/util-crypto": "npm:^13.5.7"
+    "@polkadot/x-fetch": "npm:^13.5.7"
+    "@polkadot/x-global": "npm:^13.5.7"
+    "@polkadot/x-ws": "npm:^13.5.7"
     "@substrate/connect": "npm:0.8.11"
     eventemitter3: "npm:^5.0.1"
     mock-socket: "npm:^9.3.1"
@@ -3045,27 +3045,27 @@ __metadata:
   dependenciesMeta:
     "@substrate/connect":
       optional: true
-  checksum: 10/7e90de9be86f866359dddbab7bb2b814f1bc705d7420e0e23aecbe19a42b283938e1113a3fe81b13c4f6b0963f27384a6f4318d3a761ce796cdfa428cd3a41d7
+  checksum: 10/f849a95577bde6f1f109de48ebb9035a0b301bf68c52ac4364b9ec288e0de61c53f382bad8b7080ca58df63e544485d0497ab544d7a0ff8c7269bbf8dbf66dc5
   languageName: node
   linkType: hard
 
-"@polkadot/typegen@npm:^16.4.6":
-  version: 16.4.6
-  resolution: "@polkadot/typegen@npm:16.4.6"
+"@polkadot/typegen@npm:^16.5.1":
+  version: 16.5.1
+  resolution: "@polkadot/typegen@npm:16.5.1"
   dependencies:
-    "@polkadot/api": "npm:16.4.6"
-    "@polkadot/api-augment": "npm:16.4.6"
-    "@polkadot/api-derive": "npm:16.4.6"
-    "@polkadot/rpc-augment": "npm:16.4.6"
-    "@polkadot/rpc-provider": "npm:16.4.6"
-    "@polkadot/types": "npm:16.4.6"
-    "@polkadot/types-augment": "npm:16.4.6"
-    "@polkadot/types-codec": "npm:16.4.6"
-    "@polkadot/types-create": "npm:16.4.6"
-    "@polkadot/types-support": "npm:16.4.6"
-    "@polkadot/util": "npm:^13.5.6"
-    "@polkadot/util-crypto": "npm:^13.5.6"
-    "@polkadot/x-ws": "npm:^13.5.6"
+    "@polkadot/api": "npm:16.5.1"
+    "@polkadot/api-augment": "npm:16.5.1"
+    "@polkadot/api-derive": "npm:16.5.1"
+    "@polkadot/rpc-augment": "npm:16.5.1"
+    "@polkadot/rpc-provider": "npm:16.5.1"
+    "@polkadot/types": "npm:16.5.1"
+    "@polkadot/types-augment": "npm:16.5.1"
+    "@polkadot/types-codec": "npm:16.5.1"
+    "@polkadot/types-create": "npm:16.5.1"
+    "@polkadot/types-support": "npm:16.5.1"
+    "@polkadot/util": "npm:^13.5.7"
+    "@polkadot/util-crypto": "npm:^13.5.7"
+    "@polkadot/x-ws": "npm:^13.5.7"
     comment-parser: "npm:^1.4.1"
     handlebars: "npm:^4.7.8"
     tslib: "npm:^2.8.1"
@@ -3076,116 +3076,116 @@ __metadata:
     polkadot-types-from-defs: scripts/polkadot-types-from-defs.mjs
     polkadot-types-internal-interfaces: scripts/polkadot-types-internal-interfaces.mjs
     polkadot-types-internal-metadata: scripts/polkadot-types-internal-metadata.mjs
-  checksum: 10/7b4252db900da80cc935a1d5c793ff2d9fee6a77d8a4192f3ded705f1f7a88e65aedbe12871aaeb0e0b64d3a2b204f1422610578aa7aa5a14b118f25dbfd1b1e
+  checksum: 10/304830ec4a41d3061aaaaf8529c39a9c57c9a78dde678d8cf68da53bff859e94607e055e8334474d6be64fc7219c99cddf3d76e0ba6ca098bb3b47750a579b09
   languageName: node
   linkType: hard
 
-"@polkadot/types-augment@npm:16.4.6":
-  version: 16.4.6
-  resolution: "@polkadot/types-augment@npm:16.4.6"
+"@polkadot/types-augment@npm:16.5.1":
+  version: 16.5.1
+  resolution: "@polkadot/types-augment@npm:16.5.1"
   dependencies:
-    "@polkadot/types": "npm:16.4.6"
-    "@polkadot/types-codec": "npm:16.4.6"
-    "@polkadot/util": "npm:^13.5.6"
+    "@polkadot/types": "npm:16.5.1"
+    "@polkadot/types-codec": "npm:16.5.1"
+    "@polkadot/util": "npm:^13.5.7"
     tslib: "npm:^2.8.1"
-  checksum: 10/c8c7b8065a0b11de05eaf62550ca87e3423455fd8c345ce4e547f99337ff1634508716ce397fb68d7c038b265ac82d07c7860fb69212f3df1c15e02dcc876844
+  checksum: 10/62078657c7370f9bfc534423592281cfffddb4ebb5ae1e4a2119745a41c156e6837266227f5d6bd9094536e9f931a6292bfaccd46d44cbc6ce2f70f7b7afe81a
   languageName: node
   linkType: hard
 
-"@polkadot/types-codec@npm:16.4.6":
-  version: 16.4.6
-  resolution: "@polkadot/types-codec@npm:16.4.6"
+"@polkadot/types-codec@npm:16.5.1":
+  version: 16.5.1
+  resolution: "@polkadot/types-codec@npm:16.5.1"
   dependencies:
-    "@polkadot/util": "npm:^13.5.6"
-    "@polkadot/x-bigint": "npm:^13.5.6"
+    "@polkadot/util": "npm:^13.5.7"
+    "@polkadot/x-bigint": "npm:^13.5.7"
     tslib: "npm:^2.8.1"
-  checksum: 10/73a728a5da522188a1aa8d9a241a9445d6dbdc116323ce5f0a7a83f8c355c84a6f12ce2a37c60d706b9e3f1cab63f39dcbfb8dc80ba8ffd8558b55ca004c9e8e
+  checksum: 10/2c4ca230a75e34fc44ef121d3b21cacdf2e744523d65b80895a3d90bb504827f99d25df9aee671d5d37b864c220866235afed703a6551dfc02a91133d29754c8
   languageName: node
   linkType: hard
 
-"@polkadot/types-create@npm:16.4.6":
-  version: 16.4.6
-  resolution: "@polkadot/types-create@npm:16.4.6"
+"@polkadot/types-create@npm:16.5.1":
+  version: 16.5.1
+  resolution: "@polkadot/types-create@npm:16.5.1"
   dependencies:
-    "@polkadot/types-codec": "npm:16.4.6"
-    "@polkadot/util": "npm:^13.5.6"
+    "@polkadot/types-codec": "npm:16.5.1"
+    "@polkadot/util": "npm:^13.5.7"
     tslib: "npm:^2.8.1"
-  checksum: 10/a47c6f7b9895f1864ccec134c710bd593e1662faf85172e1e606f6e8946a130879fd1e2b842d9de8a2ded87665fef9fe08decac19813402e71179c70040edc6f
+  checksum: 10/0af6c2737802979d9629bad53f23435f8c4351ba89f41bfc1026d23ff1e701c58f95b1119c88d7daf702ae0fd2b125e19cc2f6c1ef8a84f3ca58fe6460de7c30
   languageName: node
   linkType: hard
 
-"@polkadot/types-known@npm:16.4.6":
-  version: 16.4.6
-  resolution: "@polkadot/types-known@npm:16.4.6"
+"@polkadot/types-known@npm:16.5.1":
+  version: 16.5.1
+  resolution: "@polkadot/types-known@npm:16.5.1"
   dependencies:
-    "@polkadot/networks": "npm:^13.5.6"
-    "@polkadot/types": "npm:16.4.6"
-    "@polkadot/types-codec": "npm:16.4.6"
-    "@polkadot/types-create": "npm:16.4.6"
-    "@polkadot/util": "npm:^13.5.6"
+    "@polkadot/networks": "npm:^13.5.7"
+    "@polkadot/types": "npm:16.5.1"
+    "@polkadot/types-codec": "npm:16.5.1"
+    "@polkadot/types-create": "npm:16.5.1"
+    "@polkadot/util": "npm:^13.5.7"
     tslib: "npm:^2.8.1"
-  checksum: 10/f512322c76883a8c3fab4050fd986ad90a68152d912598db391313934680097eaa20e81055c6fb0a7a7bd7834b0943335859465dc19b843febec8ba30cb9cc3d
+  checksum: 10/7165bfc279b7fd1a3b6a55d6e83397a07eb48fbba9c160ecaaa2ef553b58cce3cd8b78494a63e1e37422e7f6686152682529e77387f2951319b66faf1b85d037
   languageName: node
   linkType: hard
 
-"@polkadot/types-support@npm:16.4.6":
-  version: 16.4.6
-  resolution: "@polkadot/types-support@npm:16.4.6"
+"@polkadot/types-support@npm:16.5.1":
+  version: 16.5.1
+  resolution: "@polkadot/types-support@npm:16.5.1"
   dependencies:
-    "@polkadot/util": "npm:^13.5.6"
+    "@polkadot/util": "npm:^13.5.7"
     tslib: "npm:^2.8.1"
-  checksum: 10/d6cc870ab18f2cad098e3677903004ce31fa135ad214ad287ff90d6546666235eafbe0ae619e5bd420ee6e9ca7cd60c6819aa55f30fbc25bd4a2f9e470f15a0e
+  checksum: 10/133ea1d2817f598ce2b30869e7e9d64000ee2a1cbe9233e890011e0f82c2f831815601aa3505d1b8e99db48cb0503b525e69808dcbb749a4207cf107f85e8068
   languageName: node
   linkType: hard
 
-"@polkadot/types@npm:16.4.6":
-  version: 16.4.6
-  resolution: "@polkadot/types@npm:16.4.6"
+"@polkadot/types@npm:16.5.1":
+  version: 16.5.1
+  resolution: "@polkadot/types@npm:16.5.1"
   dependencies:
-    "@polkadot/keyring": "npm:^13.5.6"
-    "@polkadot/types-augment": "npm:16.4.6"
-    "@polkadot/types-codec": "npm:16.4.6"
-    "@polkadot/types-create": "npm:16.4.6"
-    "@polkadot/util": "npm:^13.5.6"
-    "@polkadot/util-crypto": "npm:^13.5.6"
+    "@polkadot/keyring": "npm:^13.5.7"
+    "@polkadot/types-augment": "npm:16.5.1"
+    "@polkadot/types-codec": "npm:16.5.1"
+    "@polkadot/types-create": "npm:16.5.1"
+    "@polkadot/util": "npm:^13.5.7"
+    "@polkadot/util-crypto": "npm:^13.5.7"
     rxjs: "npm:^7.8.1"
     tslib: "npm:^2.8.1"
-  checksum: 10/1a02ff3733f665147cbfa6016a74a2392c5c2883fc13743627f49bfd886cacd3caee5966b287b35a1bde7f02198248650ea38cf28bb651cef15d9cc38388a96b
+  checksum: 10/017be57cf111c5e114b7cde4d2b6ee1564559e88b2056953b2bf38b5fafb997c0dd6eeb7ebba6a14f83f5a537eb702ce5df920149db78e3cf684f8411a0e6bed
   languageName: node
   linkType: hard
 
-"@polkadot/util-crypto@npm:13.5.6, @polkadot/util-crypto@npm:^13.5.6":
-  version: 13.5.6
-  resolution: "@polkadot/util-crypto@npm:13.5.6"
+"@polkadot/util-crypto@npm:13.5.7, @polkadot/util-crypto@npm:^13.5.7":
+  version: 13.5.7
+  resolution: "@polkadot/util-crypto@npm:13.5.7"
   dependencies:
     "@noble/curves": "npm:^1.3.0"
     "@noble/hashes": "npm:^1.3.3"
-    "@polkadot/networks": "npm:13.5.6"
-    "@polkadot/util": "npm:13.5.6"
+    "@polkadot/networks": "npm:13.5.7"
+    "@polkadot/util": "npm:13.5.7"
     "@polkadot/wasm-crypto": "npm:^7.5.1"
     "@polkadot/wasm-util": "npm:^7.5.1"
-    "@polkadot/x-bigint": "npm:13.5.6"
-    "@polkadot/x-randomvalues": "npm:13.5.6"
+    "@polkadot/x-bigint": "npm:13.5.7"
+    "@polkadot/x-randomvalues": "npm:13.5.7"
     "@scure/base": "npm:^1.1.7"
     tslib: "npm:^2.8.0"
   peerDependencies:
-    "@polkadot/util": 13.5.6
-  checksum: 10/42c888e459b40fbc84de0a810947f55412c22af26a5cf81dbebc5197f5485aaae7cc5cae7b4d2ca6a1fe09b2df831b9ad98e00cd858cce189ea3e587b2fb83cf
+    "@polkadot/util": 13.5.7
+  checksum: 10/5a924916b4ed613cca2f2576c2dab872544f975906cc536b9980ebdf9a48d3c4b5959f006c660020c658394559ab6fa33d94c193b22479a1953dde8c76576231
   languageName: node
   linkType: hard
 
-"@polkadot/util@npm:13.5.6, @polkadot/util@npm:^13.5.6":
-  version: 13.5.6
-  resolution: "@polkadot/util@npm:13.5.6"
+"@polkadot/util@npm:13.5.7, @polkadot/util@npm:^13.5.7":
+  version: 13.5.7
+  resolution: "@polkadot/util@npm:13.5.7"
   dependencies:
-    "@polkadot/x-bigint": "npm:13.5.6"
-    "@polkadot/x-global": "npm:13.5.6"
-    "@polkadot/x-textdecoder": "npm:13.5.6"
-    "@polkadot/x-textencoder": "npm:13.5.6"
+    "@polkadot/x-bigint": "npm:13.5.7"
+    "@polkadot/x-global": "npm:13.5.7"
+    "@polkadot/x-textdecoder": "npm:13.5.7"
+    "@polkadot/x-textencoder": "npm:13.5.7"
     "@types/bn.js": "npm:^5.1.6"
     bn.js: "npm:^5.2.1"
     tslib: "npm:^2.8.0"
-  checksum: 10/a99f767a62579b9ca082d671cb731fbfda56046058282f884534a9dfdeb97774ca017bbbf35ebd91e39873ac31ebabe75a545da2474f03ef80773e9158122562
+  checksum: 10/66a03ec05aaf8642809a46f6adf0c9b4b843b2f8fce6520dc4db9da607af96a25baf166e09595b26d3d419cf55f55494d51985d5a90f55bc66d061b1fbaf9e99
   languageName: node
   linkType: hard
 
@@ -3269,77 +3269,77 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/x-bigint@npm:13.5.6, @polkadot/x-bigint@npm:^13.5.6":
-  version: 13.5.6
-  resolution: "@polkadot/x-bigint@npm:13.5.6"
+"@polkadot/x-bigint@npm:13.5.7, @polkadot/x-bigint@npm:^13.5.7":
+  version: 13.5.7
+  resolution: "@polkadot/x-bigint@npm:13.5.7"
   dependencies:
-    "@polkadot/x-global": "npm:13.5.6"
+    "@polkadot/x-global": "npm:13.5.7"
     tslib: "npm:^2.8.0"
-  checksum: 10/a4aef1e1baf38c7ce2f41c3464fb1f59cf3b41de5cc466ebdc25ee99966ffaebfffb4897d5ea1bc0b5c526c3504d434908819080e6f03450bc100fd18c28ec04
+  checksum: 10/a890310186d457e234f03e05e5ade4a591d210002691c6c52f9eb75b3624d8e5c11c333817cdd8b3f627dc6eee685fa6a44d666c3d24ed5d5d545936b870e230
   languageName: node
   linkType: hard
 
-"@polkadot/x-fetch@npm:^13.5.6":
-  version: 13.5.6
-  resolution: "@polkadot/x-fetch@npm:13.5.6"
+"@polkadot/x-fetch@npm:^13.5.7":
+  version: 13.5.7
+  resolution: "@polkadot/x-fetch@npm:13.5.7"
   dependencies:
-    "@polkadot/x-global": "npm:13.5.6"
+    "@polkadot/x-global": "npm:13.5.7"
     node-fetch: "npm:^3.3.2"
     tslib: "npm:^2.8.0"
-  checksum: 10/64c6e7584dd5d2046fa36c91cf5e86379272577f923a0ecefe78191cd1760fc412f40f63965132a370f0acffce226afe65f363a09fc0dddad23a912eb17dab17
+  checksum: 10/8c3ba3ce3b229c7106d3e3c77daba8676d857d39889ecbd1646dbc36d6d528c4d77e951785067fbc4efb7a6e94fc7a1346e90f7fac332b1e35d17ea4b01e4a93
   languageName: node
   linkType: hard
 
-"@polkadot/x-global@npm:13.5.6, @polkadot/x-global@npm:^13.5.6":
-  version: 13.5.6
-  resolution: "@polkadot/x-global@npm:13.5.6"
+"@polkadot/x-global@npm:13.5.7, @polkadot/x-global@npm:^13.5.7":
+  version: 13.5.7
+  resolution: "@polkadot/x-global@npm:13.5.7"
   dependencies:
     tslib: "npm:^2.8.0"
-  checksum: 10/050cb02e1405a37c92b8ab9202b3a1187d6ba7f5193d93126420a283c7ba3796b4fa6ae349b3f25335c905af4355b97cc6c74c29f267b5a0de0cff6cea667c11
+  checksum: 10/756532b29565c0c72e6e911a8dc36b7256b55771119e9ee8fe8979a8cc0b09726b12d7708ea9459f72ae2843e0cdaca724d484b8faefcd43b3d24e5fa222ba6d
   languageName: node
   linkType: hard
 
-"@polkadot/x-randomvalues@npm:13.5.6":
-  version: 13.5.6
-  resolution: "@polkadot/x-randomvalues@npm:13.5.6"
+"@polkadot/x-randomvalues@npm:13.5.7":
+  version: 13.5.7
+  resolution: "@polkadot/x-randomvalues@npm:13.5.7"
   dependencies:
-    "@polkadot/x-global": "npm:13.5.6"
+    "@polkadot/x-global": "npm:13.5.7"
     tslib: "npm:^2.8.0"
   peerDependencies:
-    "@polkadot/util": 13.5.6
+    "@polkadot/util": 13.5.7
     "@polkadot/wasm-util": "*"
-  checksum: 10/47dbb4380b8e48fd0b9828d40a9c60bb21ac188dba5b1ebe9cef71f0c49af479f21b8025f3eb5cc3147ef452d4f18c416f59d28ff518f4caa2c3da6ac788a0c6
+  checksum: 10/49bd20e2140fa1905374e730726d9882ce4f651d3a10e7c705b1a7d6530190ea913b05165c6d19355e24284f872b2afd0a54042c3d33479e983016c30f1ccd11
   languageName: node
   linkType: hard
 
-"@polkadot/x-textdecoder@npm:13.5.6":
-  version: 13.5.6
-  resolution: "@polkadot/x-textdecoder@npm:13.5.6"
+"@polkadot/x-textdecoder@npm:13.5.7":
+  version: 13.5.7
+  resolution: "@polkadot/x-textdecoder@npm:13.5.7"
   dependencies:
-    "@polkadot/x-global": "npm:13.5.6"
+    "@polkadot/x-global": "npm:13.5.7"
     tslib: "npm:^2.8.0"
-  checksum: 10/7f04ba6d544acac05b6ea0b20b85ac31415c662b4d306b30cf5e7ba1bee387c36a5eee0abe889134048f3e6175528608b11c8540440343a8108440dfc4564156
+  checksum: 10/4a53a3cef1e978a9a86ab08850dd45f11971b56f6735b310f63900722cdb9cb605fadf2e9dc4bb15959e96778a47842257f363b02779bb65cc3156999ced82a3
   languageName: node
   linkType: hard
 
-"@polkadot/x-textencoder@npm:13.5.6":
-  version: 13.5.6
-  resolution: "@polkadot/x-textencoder@npm:13.5.6"
+"@polkadot/x-textencoder@npm:13.5.7":
+  version: 13.5.7
+  resolution: "@polkadot/x-textencoder@npm:13.5.7"
   dependencies:
-    "@polkadot/x-global": "npm:13.5.6"
+    "@polkadot/x-global": "npm:13.5.7"
     tslib: "npm:^2.8.0"
-  checksum: 10/0f8d433d2825bb9193c49262fd2ace2253cac76b87eb37e051a3db108445c92ed5832f8a02631a616a9ea2ea3f719576b179c38bdad8747002a8f54e7753761f
+  checksum: 10/b88e13db070c94fe20aed8c739d1740ecd6545921316efe0e4dbea6f0c489c849bbcf7ce6e1a81405885a90b359af812b78a5d06cfbdb555fb0ae9602b2357e9
   languageName: node
   linkType: hard
 
-"@polkadot/x-ws@npm:^13.5.6":
-  version: 13.5.6
-  resolution: "@polkadot/x-ws@npm:13.5.6"
+"@polkadot/x-ws@npm:^13.5.7":
+  version: 13.5.7
+  resolution: "@polkadot/x-ws@npm:13.5.7"
   dependencies:
-    "@polkadot/x-global": "npm:13.5.6"
+    "@polkadot/x-global": "npm:13.5.7"
     tslib: "npm:^2.8.0"
     ws: "npm:^8.18.0"
-  checksum: 10/7746aa886ae2799700e5b7c65a0e1d8c032dcc6da10c80a79bad994240fe626b760c00bae9f5f57dc784ff2329232c42abdfb444b4c15feb3b3a2a2390e9c4ea
+  checksum: 10/1c8da2d1dd0e08dd08a77badf4a89d8d4b7e6de45669feeb75bf718725c40d03ffabfb60a9ea35ca6d230f31f6874e62e30b343f4f3000d62e0ba5945a38c073
   languageName: node
   linkType: hard
 
@@ -11930,7 +11930,7 @@ __metadata:
     "@docusaurus/preset-classic": "npm:2.4.3"
     "@mdx-js/react": "npm:^1.6.22"
     "@polkadot/dev": "npm:^0.83.3"
-    "@polkadot/typegen": "npm:^16.4.6"
+    "@polkadot/typegen": "npm:^16.5.1"
     clsx: "npm:^2.1.1"
     comment-parser: "npm:^1.4.1"
     react: "npm:^18.2.0"


### PR DESCRIPTION
This PR aims to upgrade `@polkadot/*` packages and generates new docs for Kusama, Kusama Asset Hub, Polkadot and Polkadot Asset Hub with thier latest runtimes. The release is already done in https://github.com/polkadot-js/api. 

```
yarn upgrade-interactive
```

&&

```
yarn build
```

With this, all the extrinsics, storage, consts etc were automatically fetched from API.